### PR TITLE
Added LC_MIN and LC_MAX to locale.h

### DIFF
--- a/bld/hdr/watcom/locale.mh
+++ b/bld/hdr/watcom/locale.mh
@@ -68,6 +68,9 @@ using std::localeconv;
 #define LC_MESSAGES     5
 #define LC_ALL          6
 
+#define LC_MIN  LC_CTYPE
+#define LC_MAX  LC_ALL
+
 :segment CNAME
 namespace std {
 


### PR DESCRIPTION
Microsoft's locale.h defines two convenience constants, LC_MIN and LC_MAX for locale categories.  These constants are especially useful for simply checking if a locale category is valid.  Although OpenWatcom's categories are defined differently, it doesn't provide these two values.  

Microsoft mentions them here: http://msdn.microsoft.com/en-us/library/vstudio/ftyz68a0%28v=vs.120%29.aspx

While not necessarily standard, it certainly doesn't hurt anything including them (it helps to allow Python to build, for example).
