### PR TITLE
Add _spawnxxx Macros for MSVC Compatability

### DIFF
--- a/bld/hdr/watcom/process.mh
+++ b/bld/hdr/watcom/process.mh
@@ -83,6 +83,8 @@ _WCRTDATA extern int __p_overlay;
 #define _P_OVERLAY   P_OVERLAY
 #define _P_NOWAITO   P_NOWAITO
 
+#define	_OLD_P_OVERLAY	_P_OVERLAY
+
 /*
  *  Prototypes for non-POSIX functions
  */


### PR DESCRIPTION
MSVC has deprecated the POSIX-ish calls spawnxxx in favor of ISO standard _spawnxxx calls.  While I don't think we should remove the original calls, I think some macros to provide the equivalent calls for OpenWatcom might be in order.

I'm not sure if this commit is sufficient for everyone.  However, it does fix the issue in a simple manner.
