### PR TITLE
Promoted all material in namespace tr1 to namespace std.

### DIFF
--- a/bld/hdr/watcom/_hash.mh
+++ b/bld/hdr/watcom/_hash.mh
@@ -16,10 +16,7 @@
 :include cpponly.sp
 
 namespace std {
-  namespace tr1 {
-    
 
-  } // namespace tr1
 } // namespace std
 
 #endif

--- a/bld/hdr/watcom/deque.mh
+++ b/bld/hdr/watcom/deque.mh
@@ -4,15 +4,15 @@
 :keep CPP_HDR
 :include crwatcnt.sp
 //
-// Description: This header is part of the C++ standard library. It defines
-//              a double ended queue template that provides random access
-//              to its elements yet amortized O(1) time push/pop operations
-//              on *both* ends.
-//              References to objects are *not* invalidated with an insert
-//              operation.
-//              Extention: extra template parameter PageSize allow
-//              number of objects per block of allocations to be adjusted
-//              must be power of 2 because of assumptions in math in operations
+// Description: This header is part of the C++ standard library. It defines a double ended queue
+//              template that provides random access to its elements yet amortized O(1) time
+//              push/pop operations on *both* ends.
+//
+//              References to objects are *not* invalidated with an insert operation.
+//
+//              Extension: extra template parameter PageSize allow number of objects per block
+//              of allocations to be adjusted must be power of 2 because of assumptions in math
+//              in operations
 ///////////////////////////////////////////////////////////////////////////
 #ifndef _DEQUE_INCLUDED
 #define _DEQUE_INCLUDED
@@ -203,7 +203,7 @@ namespace std {
     template< class InputIt >
     void insert( iterator pos, InputIt first, InputIt last )
     {
-        helper_insert( pos, first, last, tr1::is_integral<InputIt>::type() );
+        helper_insert( pos, first, last, is_integral<InputIt>::type() );
     }
     iterator erase( iterator position );
     iterator erase( iterator first, iterator last );
@@ -267,7 +267,7 @@ namespace std {
     // overloaded helpers get called by insert(many) depending on iterator type
     // int type
     template< class InputIt1, class InputIt2 >
-    void insert_helper( iterator pos, InputIt1 first, InputIt2 last, tr1::true_type )
+    void insert_helper( iterator pos, InputIt1 first, InputIt2 last, true_type )
     {
         insert( pos, static_cast<size_type>(first), static_cast<value_type>(last) );
     }
@@ -275,7 +275,7 @@ namespace std {
     // to do: specialise for iterator of type input it (make temp copy of elements
     // in order to count them)
     template< class It1, class It2 >
-    void insert_helper( iterator pos, It1 first, It2 last, tr1::false_type )
+    void insert_helper( iterator pos, It1 first, It2 last, false_type )
     {/*
         // if at begin
         

--- a/bld/hdr/watcom/list.mh
+++ b/bld/hdr/watcom/list.mh
@@ -126,7 +126,7 @@ namespace std {
         {
             sentinel = link_allocator.allocate( 1 );
             sentinel->next = sentinel->previous = sentinel;
-            helper_assign( first, last, tr1::is_integral<InputIterator>::type( ) );
+            helper_assign( first, last, is_integral<InputIterator>::type( ) );
         }
     
         list( const list & );
@@ -138,7 +138,7 @@ namespace std {
         void assign( InputIterator first, InputIterator last )
         {
             clear( );
-            helper_assign( first, last, tr1::is_integral<InputIterator>::type( ) );
+            helper_assign( first, last, is_integral<InputIterator>::type( ) );
         }
 
         allocator_type get_allocator( ) const;
@@ -167,7 +167,7 @@ namespace std {
         template< class InputIterator >
         void insert( iterator it, InputIterator first, InputIterator last )
         {
-            helper_insert( it, first, last, tr1::is_integral<InputIterator>::type( ) );
+            helper_insert( it, first, last, is_integral<InputIterator>::type( ) );
         }
     
         iterator erase( iterator it );
@@ -216,7 +216,7 @@ namespace std {
         // helper_assign( InputIterator, InputIterator, true_type )
         // ********************************************************
         template< class InputIterator >
-        void helper_assign( InputIterator first, InputIterator last, tr1::true_type )
+        void helper_assign( InputIterator first, InputIterator last, true_type )
         {
             for( size_type i = 0; i < static_cast< size_type >( first ); i++ ) {
                 push_back( static_cast< value_type >( last ) );
@@ -226,7 +226,7 @@ namespace std {
         // helper_insert( iterator, InputIterator, InputIterator, true_type )
         // ******************************************************************
         template< class InputIterator >
-        void helper_insert( iterator it, InputIterator first, InputIterator last, tr1::true_type )
+        void helper_insert( iterator it, InputIterator first, InputIterator last, true_type )
         { 
             for( size_type n = static_cast< size_type >( first ); n > 0; n-- ) {
                 push( static_cast< node * >( it.current ),
@@ -237,7 +237,7 @@ namespace std {
         // helper_assign( InputIterator, InputIterator, false_type )
         // *********************************************************
         template< class InputIterator >
-        void helper_assign( InputIterator first, InputIterator last, tr1::false_type )
+        void helper_assign( InputIterator first, InputIterator last, false_type )
         {
             for( ; first != last; ++first ) push_back( *first );
         }
@@ -245,7 +245,7 @@ namespace std {
         // helper_insert( iterator, InputIterator, InputIterator, false_type )
         // *******************************************************************
         template< class InputIterator >
-        void helper_insert( iterator it, InputIterator first, InputIterator last, tr1::false_type )
+        void helper_insert( iterator it, InputIterator first, InputIterator last, false_type )
         {
             for( ; first != last; ++first, ++it ) it = insert( it, *first );
         }

--- a/bld/hdr/watcom/random.mh
+++ b/bld/hdr/watcom/random.mh
@@ -4,8 +4,7 @@
 :keep CPP_HDR
 :include crwatcnt.sp
 //
-// Description: This header is part of the C++ standard library extentions
-//              TR1 as currently defined in n1836
+// Description: This header is part of the C++ standard library.
 ///////////////////////////////////////////////////////////////////////////
 #ifndef _RANDOM_INCLUDED
 #define _RANDOM_INCLUDED
@@ -192,8 +191,6 @@ namespace _ow {
 
 namespace std {
 
-  namespace tr1 {
-
     template< class UIntType, UIntType a, UIntType c, UIntType m >
     class linear_congruential{
     public:
@@ -232,10 +229,10 @@ namespace std {
 
     // to do - specialise for 2^n - x where x is small and x is 0
 
-    typedef std::tr1::linear_congruential< std::tr1::uint32_t, 16807, 0, (1<<31)-1 > minstd_rand0;
-    typedef std::tr1::linear_congruential< std::tr1::uint32_t, 48271, 0, (1<<31)-1 > minstd_rand;
+    typedef std::linear_congruential< std::uint32_t, 16807, 0, (1<<31)-1 > minstd_rand0;
+    typedef std::linear_congruential< std::uint32_t, 48271, 0, (1<<31)-1 > minstd_rand;
 
-// ===========================================================================
+    // ===========================================================================
 
     template< class UIntType, int w, int n, int m, int r, UIntType a,
               int u, int s, UIntType b, int t, UIntType c, int l >
@@ -282,13 +279,13 @@ namespace std {
             //      uniform pseudorandom number generator"
             // Makoto Matsumoto and Takuji Nishimura 1998
 
-            // I wondered whether calculating blocks at a time is bad on
-            // modern processor because of unnecessary comparisons and jumps
-            // Little difference on p4 northwood and seems rather tetchy to
-            // differences in way coded/optimisation settings that change order
-            // of instruction/regs used
-            // Would be interested to see how it fairs on other processors (amd?)
-            // see bench/owstl
+            // I wondered whether calculating blocks at a time is bad on modern processor
+            // because of unnecessary comparisons and jumps Little difference on p4 northwood
+            // and seems rather tetchy to differences in way coded/optimisation settings that
+            // change order of instruction/regs used
+            //
+            // Would be interested to see how it fairs on other processors (amd?) see
+            // bench/owstl
 
             UIntType y;
             int z, i_1;
@@ -336,28 +333,25 @@ namespace std {
                               31,0x9908b0df,11,7,0x9d2c5680,
                               15,0xefc60000,18>  mt19937;
 
-  } // namespace tr1
-
 } // namespace std
 
 namespace _watcom {
 
     // to do - would like to add WELL generator
 
-    /* also see "tables of lenear congruential generators of different sizes
-       and good lattice structure" Pierre L'Ecuyer.
-       I guess we could create some statistical tests, try out a few and
-       provide some potetially useful ones here ? */
+    /* also see "tables of lenear congruential generators of different sizes and good lattice
+       structure" Pierre L'Ecuyer. I guess we could create some statistical tests, try out a few
+       and provide some potetially useful ones here ? */
 
-    typedef std::tr1::linear_congruential< std::tr1::uint32_t, 1588635695, 0, (1<<32)-5 > lcg325a;
-    typedef std::tr1::linear_congruential< std::tr1::uint64_t, 2862933555777941757, 0, (1<<64) > lcg64a;
-    typedef std::tr1::linear_congruential< std::tr1::uint32_t, 2891336453, 1, (1<<32) > lcg32;
-    typedef std::tr1::linear_congruential< std::tr1::uint32_t, 37769685, 1, (1<<31) > lcg31;
+    typedef std::linear_congruential< std::uint32_t, 1588635695, 0, (1<<32)-5 > lcg325a;
+    typedef std::linear_congruential< std::uint64_t, 2862933555777941757, 0, (1<<64) > lcg64a;
+    typedef std::linear_congruential< std::uint32_t, 2891336453, 1, (1<<32) > lcg32;
+    typedef std::linear_congruential< std::uint32_t, 37769685, 1, (1<<31) > lcg31;
     // to do
 
     // useful MT typedefs see Matsumoto & Nishimura 1998
     // w, n, m, r, a, u, s, b, t, c, l
-    typedef std::tr1::mersenne_twister< std::tr1::uint32_t, 32, 351, 175, 19,
+    typedef std::mersenne_twister< std::uint32_t, 32, 351, 175, 19,
         0xE4BD75F5, 11, 7, 0x655E5280, 15, 0xFFD58000, 17 > mt11213a;
     // to do
 

--- a/bld/hdr/watcom/slist.mh
+++ b/bld/hdr/watcom/slist.mh
@@ -108,14 +108,14 @@ public:
     slist( size_type, T const &, A const & = A() );
     template< class InputIt > slist( InputIt f, InputIt l )//, A const & = A() )
         : mSize( 0 ), first( 0 )
-        { helper_assign( f, l, std::tr1::is_integral< InputIt >::type() ); }
+        { helper_assign( f, l, std::is_integral< InputIt >::type() ); }
     slist( slist<T,A> const & );
     //slist( slist&& );
     ~slist(){ clear(); }
     slist<T,A>& operator=( slist<T,A> const & );
     //slist<T,A>& operator=( slist<T,A> && );
     template < class InputIt > void assign( InputIt f, InputIt l )
-        { helper_assign( f, l, std::tr1::is_integral< InputIt >::type() ); }
+        { helper_assign( f, l, std::is_integral< InputIt >::type() ); }
     void assign( size_type, T const & );
     allocator_type get_allocator() const { allocator_type a(nmem); return( a ); }
 
@@ -152,12 +152,12 @@ public:
     void insert( const_iterator, size_type, T const & );
     template< class InputIt >
         void insert( const_iterator it, InputIt f, InputIt l )
-        { helper_insert( it, f, l, std::tr1::is_integral< InputIt >::type() ); }
+        { helper_insert( it, f, l, std::is_integral< InputIt >::type() ); }
     iterator insert_after( const_iterator, T const & ); //special for SLL
     void insert_after( const_iterator, size_type, T const & );
     template< class InputIt >
         void insert_after( const_iterator it, InputIt f, InputIt l )
-        { helper_insert_after( it, f, l, std::tr1::is_integral< InputIt >::type() ); }
+        { helper_insert_after( it, f, l, std::is_integral< InputIt >::type() ); }
 
     iterator erase( const_iterator );
     iterator erase( const_iterator, const_iterator );
@@ -496,13 +496,13 @@ private:
      * exception safety: strong (although standard says multi inserts don't have to be)
      */
     template< class InputIt >
-    void helper_assign( InputIt f, InputIt l, std::tr1::true_type )
+    void helper_assign( InputIt f, InputIt l, std::true_type )
     {
         //std::cout<<"true_type\n";
         assign( static_cast<size_type>(f), static_cast<T const>(l) );
     }
     template< class InputIt >
-    void helper_assign( InputIt f, InputIt l, std::tr1::false_type )
+    void helper_assign( InputIt f, InputIt l, std::false_type )
     {
         //std::cout<<"false_type\n";
         size_type c;
@@ -514,13 +514,13 @@ private:
         mSize = c;
     }
     template< class InputIt >
-    void helper_insert( const_iterator it, InputIt f, InputIt l, std::tr1::true_type )
+    void helper_insert( const_iterator it, InputIt f, InputIt l, std::true_type )
     {
         //std::cout<<"insert true\n";
         insert( it, static_cast<size_type>(f), static_cast<T const>(l) );
     }
     template< class InputIt >
-    void helper_insert( const_iterator cit, InputIt f, InputIt l, std::tr1::false_type )
+    void helper_insert( const_iterator cit, InputIt f, InputIt l, std::false_type )
     {
         //std::cout<<"insert false\n";
         size_type c;
@@ -538,13 +538,13 @@ private:
         mSize += c;
     }
     template< class InputIt >
-    void helper_insert_after( const_iterator it, InputIt f, InputIt l, std::tr1::true_type )
+    void helper_insert_after( const_iterator it, InputIt f, InputIt l, std::true_type )
     {
         //std::cout<<"insert after true\n";
         insert_after( it, static_cast<size_type>(f), static_cast<T const>(l) );
     }
     template< class InputIt >
-    void helper_insert_after( const_iterator cit, InputIt f, InputIt l, std::tr1::false_type )
+    void helper_insert_after( const_iterator cit, InputIt f, InputIt l, std::false_type )
     {
         //std::cout<<"insert after false\n";
         size_type c;

--- a/bld/hdr/watcom/type_tra.mh
+++ b/bld/hdr/watcom/type_tra.mh
@@ -4,8 +4,7 @@
 :keep CPP_HDR
 :include crwatcnt.sp
 //
-// Description: This header is part of the C++ standard library extentions
-//              TR1 as currently defined in n1836
+// Description: This header is part of the C++ standard library.
 ///////////////////////////////////////////////////////////////////////////
 #ifndef _TYPE_TRAITS_INCLUDED
 #define _TYPE_TRAITS_INCLUDED
@@ -15,283 +14,299 @@
 :include cpponly.sp
 
 namespace std {
-namespace tr1 {
 
-template< class T, T v >
-struct integral_constant{
-    static const T value = v;
-    typedef T value_type;
-    typedef integral_constant< T, v > type;
-};
-typedef integral_constant< bool, true >  true_type;
-typedef integral_constant< bool, false > false_type;
+    template< class T, T v >
+    struct integral_constant{
+        static const T value = v;
+        typedef T value_type;
+        typedef integral_constant< T, v > type;
+    };
+    typedef integral_constant< bool, true >  true_type;
+    typedef integral_constant< bool, false > false_type;
+
 
 #define __MAKE_TYPE_TRAIT_DEFAULT( name, base ) \
-    template < class T > struct name : public base {};
+    template < class T > struct name : public base { };
+
 #define __MAKE_TYPE_TRAIT( name, type, base ) \
-    template <> struct name< type > : public base {};
+    template <> struct name< type > : public base { };
+
 #define __MAKE_TYPE_TRAIT_MOD( name, modifer, base ) \
-    template < class T > struct name< T modifer > : public base {};
-#define __MAKE_TYPE_TRAITS_CV( name, type, base ) \
-    __MAKE_TYPE_TRAIT( name, type, base ) \
-    __MAKE_TYPE_TRAIT( name, type const, base ) \
-    __MAKE_TYPE_TRAIT( name, type volatile, base ) \
+    template < class T > struct name< T modifer > : public base { };
+
+#define __MAKE_TYPE_TRAITS_CV( name, type, base )       \
+    __MAKE_TYPE_TRAIT( name, type, base )               \
+    __MAKE_TYPE_TRAIT( name, type const, base )         \
+    __MAKE_TYPE_TRAIT( name, type volatile, base )      \
     __MAKE_TYPE_TRAIT( name, type const volatile, base )
-#define __MAKE_TYPE_TRAITS_MOD_CV( name, mod, base ) \
-    __MAKE_TYPE_TRAIT_MOD( name, mod, base ) \
-    __MAKE_TYPE_TRAIT_MOD( name, mod const, base ) \
-    __MAKE_TYPE_TRAIT_MOD( name, mod volatile, base ) \
+
+#define __MAKE_TYPE_TRAITS_MOD_CV( name, mod, base )    \
+    __MAKE_TYPE_TRAIT_MOD( name, mod, base )            \
+    __MAKE_TYPE_TRAIT_MOD( name, mod const, base )      \
+    __MAKE_TYPE_TRAIT_MOD( name, mod volatile, base )   \
     __MAKE_TYPE_TRAIT_MOD( name, mod const volatile, base )
-#define __MAKE_TYPE_TRAITS_CV_SUS( name, type, base ) \
-    __MAKE_TYPE_TRAITS_CV( name, unsigned type, base ) \
+
+#define __MAKE_TYPE_TRAITS_CV_SUS( name, type, base )   \
+    __MAKE_TYPE_TRAITS_CV( name, unsigned type, base )  \
     __MAKE_TYPE_TRAITS_CV( name, signed type, base )
 
-// ==================================================================
-// 4.5.1 primary type categories
-/* ------------------------------------------------------------------
- * is_void
- */
-__MAKE_TYPE_TRAIT_DEFAULT( is_void, false_type )
-__MAKE_TYPE_TRAITS_CV( is_void, void, true_type )
 
-/* ------------------------------------------------------------------
- * is_integral
- */
-__MAKE_TYPE_TRAIT_DEFAULT( is_integral, false_type )
-__MAKE_TYPE_TRAITS_CV_SUS( is_integral, int, true_type )
-__MAKE_TYPE_TRAITS_CV_SUS( is_integral, short, true_type )
-__MAKE_TYPE_TRAITS_CV_SUS( is_integral, long, true_type )
-__MAKE_TYPE_TRAITS_CV_SUS( is_integral, long long, true_type )
-__MAKE_TYPE_TRAITS_CV( is_integral, bool, true_type )
-__MAKE_TYPE_TRAITS_CV( is_integral, signed char, true_type )
-__MAKE_TYPE_TRAITS_CV( is_integral, unsigned char, true_type )
-__MAKE_TYPE_TRAITS_CV( is_integral, char, true_type )
-__MAKE_TYPE_TRAITS_CV( is_integral, wchar_t, true_type )
+    // ==================================================================
+    // 4.5.1 primary type categories
+    /* ------------------------------------------------------------------
+     * is_void
+     */
+    __MAKE_TYPE_TRAIT_DEFAULT( is_void, false_type )
+    __MAKE_TYPE_TRAITS_CV( is_void, void, true_type )
+
+    /* ------------------------------------------------------------------
+     * is_integral
+     */
+    __MAKE_TYPE_TRAIT_DEFAULT( is_integral, false_type )
+    __MAKE_TYPE_TRAITS_CV_SUS( is_integral, int, true_type )
+    __MAKE_TYPE_TRAITS_CV_SUS( is_integral, short, true_type )
+    __MAKE_TYPE_TRAITS_CV_SUS( is_integral, long, true_type )
+    __MAKE_TYPE_TRAITS_CV_SUS( is_integral, long long, true_type )
+    __MAKE_TYPE_TRAITS_CV( is_integral, bool, true_type )
+    __MAKE_TYPE_TRAITS_CV( is_integral, signed char, true_type )
+    __MAKE_TYPE_TRAITS_CV( is_integral, unsigned char, true_type )
+    __MAKE_TYPE_TRAITS_CV( is_integral, char, true_type )
+    __MAKE_TYPE_TRAITS_CV( is_integral, wchar_t, true_type )
 
 
-/* ------------------------------------------------------------------
- * is_floating_point
- */
-__MAKE_TYPE_TRAIT_DEFAULT( is_floating_point, false_type )
-__MAKE_TYPE_TRAITS_CV( is_floating_point, float, true_type )
-__MAKE_TYPE_TRAITS_CV( is_floating_point, double, true_type )
-__MAKE_TYPE_TRAITS_CV( is_floating_point, long double, true_type )
+    /* ------------------------------------------------------------------
+     * is_floating_point
+     */
+    __MAKE_TYPE_TRAIT_DEFAULT( is_floating_point, false_type )
+    __MAKE_TYPE_TRAITS_CV( is_floating_point, float, true_type )
+    __MAKE_TYPE_TRAITS_CV( is_floating_point, double, true_type )
+    __MAKE_TYPE_TRAITS_CV( is_floating_point, long double, true_type )
 
-/* ------------------------------------------------------------------
- * is_pointer
- */
-__MAKE_TYPE_TRAIT_DEFAULT( is_pointer, false_type )
-__MAKE_TYPE_TRAITS_MOD_CV( is_pointer, *, true_type )
+    /* ------------------------------------------------------------------
+     * is_pointer
+     */
+    __MAKE_TYPE_TRAIT_DEFAULT( is_pointer, false_type )
+    __MAKE_TYPE_TRAITS_MOD_CV( is_pointer, *, true_type )
 
-/* ------------------------------------------------------------------
- * is_reference
- */
-__MAKE_TYPE_TRAIT_DEFAULT( is_reference, false_type )
-__MAKE_TYPE_TRAITS_MOD_CV( is_reference, &, true_type )
+    /* ------------------------------------------------------------------
+     * is_reference
+     */
+    __MAKE_TYPE_TRAIT_DEFAULT( is_reference, false_type )
+    __MAKE_TYPE_TRAITS_MOD_CV( is_reference, &, true_type )
 
-/*
- * err will these need compiler support?
-template <class T>
-struct is_member_object_pointer;
-template <class T>
-struct is_member_function_pointer;
-template <class T>
-struct is_enum;
-template <class T>
-struct is_union;
-template <class T>
-struct is_class;
-template <class T>
-struct is_function;
-*/
+    /*
+     * Will these need compiler support?
 
-// ==================================================================
-// 4.5.2 composite type traits
-/* ------------------------------------------------------------------
- * is_arithmetic
- */
-template < class T >
-struct is_arithmetic : public integral_constant< bool, 
-                                is_integral< T >::value ||
-                                is_floating_point< T >::value >
-{ };
+     template <class T>
+     struct is_member_object_pointer;
+     template <class T>
+     struct is_member_function_pointer;
+     template <class T>
+     struct is_enum;
+     template <class T>
+     struct is_union;
+     template <class T>
+     struct is_class;
+     template <class T>
+     struct is_function;
+    */
 
-/* ------------------------------------------------------------------
- * is_fundamental
- */
-template < class T >
-struct is_fundamental : public integral_constant< bool, 
-                                is_integral< T >::value ||
-                                is_floating_point< T >::value ||
-                                is_void< T >::value >
-{ };
-/*
-template <class T>
-struct is_object;
-template <class T>
-struct is_scalar;
-template <class T>
-struct is_compound;
-template <class T>
-struct is_member_pointer;
-*/
+    // ==================================================================
+    // 4.5.2 composite type traits
+    /* ------------------------------------------------------------------
+     * is_arithmetic
+     */
+    template < class T >
+    struct is_arithmetic : public integral_constant< bool, 
+                                                     is_integral< T >::value ||
+                                                     is_floating_point< T >::value > { };
 
-// ==================================================================
-// 4.5.3 type properties
-/* ------------------------------------------------------------------
- * is_const
- */
-__MAKE_TYPE_TRAIT_DEFAULT( is_const, false_type )
-__MAKE_TYPE_TRAIT_MOD( is_const, const, true_type )
+    /* ------------------------------------------------------------------
+     * is_fundamental
+     */
+    template < class T >
+    struct is_fundamental : public integral_constant< bool, 
+                                                      is_integral< T >::value ||
+                                                      is_floating_point< T >::value ||
+                                                      is_void< T >::value > { };
+    /*
+      template <class T>
+      struct is_object;
+      template <class T>
+      struct is_scalar;
+      template <class T>
+      struct is_compound;
+      template <class T>
+      struct is_member_pointer;
+    */
 
-/* ------------------------------------------------------------------
- * is_volatile
- */
-__MAKE_TYPE_TRAIT_DEFAULT( is_volatile, false_type )
-__MAKE_TYPE_TRAIT_MOD( is_volatile, volatile, true_type )
+    // ==================================================================
+    // 4.5.3 type properties
+    /* ------------------------------------------------------------------
+     * is_const
+     */
+    __MAKE_TYPE_TRAIT_DEFAULT( is_const, false_type )
+    __MAKE_TYPE_TRAIT_MOD( is_const, const, true_type )
 
-/*
-template <class T> struct is_pod;
-template <class T> struct is_empty;
-template <class T> struct is_polymorphic;
-template <class T> struct is_abstract;
-template <class T> struct has_trivial_constructor;
-template <class T> struct has_trivial_copy;
-template <class T> struct has_trivial_assign;
-template <class T> struct has_trivial_destructor;
-template <class T> struct has_nothrow_constructor;
-template <class T> struct has_nothrow_copy;
-template <class T> struct has_nothrow_assign;
-template <class T> struct has_virtual_destructor;
-template <class T> struct is_signed;
-template <class T> struct is_unsigned;
-template <class T> struct alignment_of;
-template <class T> struct rank;
-template <class T, unsigned I = 0> struct extent;
-*/
+    /* ------------------------------------------------------------------
+     * is_volatile
+     */
+    __MAKE_TYPE_TRAIT_DEFAULT( is_volatile, false_type )
+    __MAKE_TYPE_TRAIT_MOD( is_volatile, volatile, true_type )
 
-// ==================================================================
-// 4.6 type relations
-/* ------------------------------------------------------------------
- * is_same
- */
-template < class T, class U > struct is_same : public false_type {};
-template < class T > struct is_same< T, T > : public true_type {};
-/*
-template <class Base, class Derived> struct is_base_of;
-template <class From, class To> struct is_convertible;
-*/
+    /*
+      template <class T> struct is_pod;
+      template <class T> struct is_empty;
+      template <class T> struct is_polymorphic;
+      template <class T> struct is_abstract;
+      template <class T> struct has_trivial_constructor;
+      template <class T> struct has_trivial_copy;
+      template <class T> struct has_trivial_assign;
+      template <class T> struct has_trivial_destructor;
+      template <class T> struct has_nothrow_constructor;
+      template <class T> struct has_nothrow_copy;
+      template <class T> struct has_nothrow_assign;
+      template <class T> struct has_virtual_destructor;
+      template <class T> struct is_signed;
+      template <class T> struct is_unsigned;
+      template <class T> struct alignment_of;
+      template <class T> struct rank;
+      template <class T, unsigned I = 0> struct extent;
+    */
 
-// ==================================================================
-// 4.7.1 const-volatile modifications
-/* ------------------------------------------------------------------
- * remove_const
- */
-template< typename T >
-struct remove_const{ typedef T type; };
+    // ==================================================================
+    // 4.6 type relations
+    /* ------------------------------------------------------------------
+     * is_same
+     */
+    template < class T, class U > struct is_same : public false_type {};
+    template < class T > struct is_same< T, T > : public true_type {};
+    /*
+      template <class Base, class Derived> struct is_base_of;
+      template <class From, class To> struct is_convertible;
+    */
 
-template< typename T >
-struct remove_const< T const >{ typedef T type; };
+    // ==================================================================
+    // 4.7.1 const-volatile modifications
+    /* ------------------------------------------------------------------
+     * remove_const
+     */
+    template< typename T >
+    struct remove_const { typedef T type; };
 
-/* ------------------------------------------------------------------
- * remove_volatile
- */
-template< typename T >
-struct remove_volatile{ typedef T type; };
+    template< typename T >
+    struct remove_const< T const > { typedef T type; };
 
-template< typename T >
-struct remove_volatile< T volatile >{ typedef T type; };
+    /* ------------------------------------------------------------------
+     * remove_volatile
+     */
+    template< typename T >
+    struct remove_volatile { typedef T type; };
 
-/* ------------------------------------------------------------------
- * remove_cv
- */
-template< typename T >
-struct remove_cv{ 
-    typedef remove_volatile< remove_const< T >::type >::type type; 
-};
+    template< typename T >
+    struct remove_volatile< T volatile > { typedef T type; };
 
-/* ------------------------------------------------------------------
- * add_const
- */
-template< typename T >
-struct add_const{ typedef T const type; };
+    /* ------------------------------------------------------------------
+     * remove_cv
+     */
+    template< typename T >
+    struct remove_cv {  
+        typedef remove_volatile< remove_const< T >::type >::type type; 
+    };
 
-/* ------------------------------------------------------------------
- * add_volatile
- */
-template< typename T >
-struct add_volatile{ typedef T volatile type; };
+    /* ------------------------------------------------------------------
+     * add_const
+     */
+    template< typename T >
+    struct add_const { typedef T const type; };
 
-/* ------------------------------------------------------------------
- * add_cv
- */
-template< typename T >
-struct add_cv{ typedef T const volatile type; };
+    /* ------------------------------------------------------------------
+     * add_volatile
+     */
+    template< typename T >
+    struct add_volatile { typedef T volatile type; };
 
-// ==================================================================
-// 4.7.2 reference modifications
-/* ------------------------------------------------------------------
- * remove_reference
- */
-template< typename T >
-struct remove_reference{ typedef T type; };
-template< typename T >
-struct remove_reference< T& > { typedef T type; };
-template< typename T >
-struct remove_reference< T& const > { typedef T type; };
-template< typename T >
-struct remove_reference< T& volatile > { typedef T type; };
-template< typename T >
-struct remove_reference< T& const volatile > { typedef T type; };
+    /* ------------------------------------------------------------------
+     * add_cv
+     */
+    template< typename T >
+    struct add_cv { typedef T const volatile type; };
 
-/* ------------------------------------------------------------------
- * add_reference
- */
-template< typename T >
-struct add_reference{ typedef T& type; };
-template< typename T >
-struct add_reference< T& > { typedef T& type; };
-template< typename T >
-struct add_reference< T& const > { typedef T& const type; };
-template< typename T >
-struct add_reference< T& volatile > { typedef T& volatile type; };
-template< typename T >
-struct add_reference< T& const volatile > { typedef T& const volatile type; };
+    // ==================================================================
+    // 4.7.2 reference modifications
+    /* ------------------------------------------------------------------
+     * remove_reference
+     */
+    template< typename T >
+    struct remove_reference { typedef T type; };
 
-// ==================================================================
-// 4.7.3 array modifications
-/*
-template <class T> struct remove_extent;
-template <class T> struct remove_all_extents;
-*/
+    template< typename T >
+    struct remove_reference< T& > { typedef T type; };
 
-// ==================================================================
-// 4.7.4 pointer modifications
-/* ------------------------------------------------------------------
- * remove_pointer
- */
-template< typename T >
-struct remove_pointer{ typedef T type; };
-template< typename T >
-struct remove_pointer< T* > { typedef T type; };
-template< typename T >
-struct remove_pointer< T* const > { typedef T type; };
-template< typename T >
-struct remove_pointer< T* volatile > { typedef T type; };
-template< typename T >
-struct remove_pointer< T* const volatile > { typedef T type; };
+    template< typename T >
+    struct remove_reference< T& const > { typedef T type; };
 
-/*
-template <class T> struct add_pointer;
-*/
+    template< typename T >
+    struct remove_reference< T& volatile > { typedef T type; };
 
-// ==================================================================
-// 4.8 other transformations
-/*
-template <std::size_t Len, std::size_t Align> struct aligned_storage;
-*/
+    template< typename T >
+    struct remove_reference< T& const volatile > { typedef T type; };
 
-} // namespace tr1
+    /* ------------------------------------------------------------------
+     * add_reference
+     */
+    template< typename T >
+    struct add_reference { typedef T& type; };
+
+    template< typename T >
+    struct add_reference< T& > { typedef T& type; };
+
+    template< typename T >
+    struct add_reference< T& const > { typedef T& const type; };
+
+    template< typename T >
+    struct add_reference< T& volatile > { typedef T& volatile type; };
+
+    template< typename T >
+    struct add_reference< T& const volatile > { typedef T& const volatile type; };
+
+    // ==================================================================
+    // 4.7.3 array modifications
+    /*
+      template <class T> struct remove_extent;
+      template <class T> struct remove_all_extents;
+    */
+
+    // ==================================================================
+    // 4.7.4 pointer modifications
+    /* ------------------------------------------------------------------
+     * remove_pointer
+     */
+    template< typename T >
+    struct remove_pointer { typedef T type; };
+
+    template< typename T >
+    struct remove_pointer< T* > { typedef T type; };
+
+    template< typename T >
+    struct remove_pointer< T* const > { typedef T type; };
+
+    template< typename T >
+    struct remove_pointer< T* volatile > { typedef T type; };
+
+    template< typename T >
+    struct remove_pointer< T* const volatile > { typedef T type; };
+
+    /*
+      template <class T> struct add_pointer;
+    */
+
+    // ==================================================================
+    // 4.8 other transformations
+    /*
+      template <std::size_t Len, std::size_t Align> struct aligned_storage;
+    */
+
 } // namespace std
 
 #endif

--- a/bld/hdr/watcom/unordere.mh
+++ b/bld/hdr/watcom/unordere.mh
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// FILE: unordere (Definition of std::tr1::unordered_set and unordered_map)
+// FILE: unordere (Definition of std::unordered_set and std::unordered_map)
 //
 :keep CPP_HDR
 :include crwatcnt.sp
@@ -20,10 +20,7 @@
 #endif
 
 namespace std {
-  namespace tr1 {
-    
 
-  } // namespace tr1
 } // namespace std
 
 #endif

--- a/bld/hdr/watcom/vector.mh
+++ b/bld/hdr/watcom/vector.mh
@@ -108,19 +108,19 @@ public:
     {
         buffer = alloc( 1, buf_length );
         vec_length = 0;
-        helper_assign( first, last, tr1::is_integral<InputIterator>::type() );
+        helper_assign( first, last, is_integral<InputIterator>::type() );
     }
 
     template< class InputIterator >
     void assign( InputIterator first, InputIterator last )
     {
-        helper_assign( first, last, tr1::is_integral<InputIterator>::type() );
+        helper_assign( first, last, is_integral<InputIterator>::type() );
     }
 
     template< class Integral >
     void helper_assign( Integral count,
                         Integral value,
-                        tr1::true_type )
+                        true_type )
     {
         vector temp;
         for( Integral i = 0; i < count; ++i )
@@ -131,7 +131,7 @@ public:
     template< class InputIterator >
     void helper_assign( InputIterator first,
                         InputIterator last,
-                        tr1::false_type )
+                        false_type )
     {
         vector temp;
         while( first != last ) {
@@ -147,14 +147,14 @@ public:
         helper_insert( position,
                        first,
                        last,
-                       tr1::is_integral<InputIterator>::type( ) );
+                       is_integral<InputIterator>::type( ) );
     }
     
     template< class Integral >
     void helper_insert( iterator position,
                         Integral count,
                         Integral value,
-                        tr1::true_type )
+                        true_type )
     {
         insert( position,
                 static_cast<size_type>( count ),
@@ -165,7 +165,7 @@ public:
     void helper_insert( iterator position,
                         InputIterator first,
                         InputIterator last,
-                        tr1::false_type )
+                        false_type )
     {
         while( first != last ) {
             insert( position, *first );

--- a/bld/plustest/regress/owstl/typetr01.cpp
+++ b/bld/plustest/regress/owstl/typetr01.cpp
@@ -32,7 +32,7 @@
 #include <type_traits>
 #include "sanity.cpp"
 
-using namespace std::tr1;
+using namespace std;
 
 /* ------------------------------------------------------------------
  * this function doesn't really do anything 


### PR DESCRIPTION
The namespace `tr1` was really a kind of temporary namespace to hold material developed after the 1998 standard for possible inclusion in a later standard. Now that C++ 2011 is a reality most of the `tr1` material is actually standard. Current users will expect and prefer to find that material in namespace `std` rather than `std::tr1`.

Technically moving material out of `std::tr1` is an incompatible change. However, the number of people making use of that namespace in the Open Watcom community is probably microscopic.
