### PR TITLE
Dependency fix for building CHM help files

### DIFF
--- a/docs/mif/onebook.mif
+++ b/docs/mif/onebook.mif
@@ -245,7 +245,7 @@ $(hbook).ib $(hbook).h : $(book_objs) $(proj_objs)
 
 .EXTENSIONS: .chm 
 
-$(hbook).chm : $(hbook).htm
+$(hbook).chm : $(hbook).htm $(hbook).h
     @if not exist $(hbook) mkdir $(hbook)
 !ifdef book_bmroot
     cp -f $(book_bmroot)/*.bmp $(hbook)/ > $(nulldevice)


### PR DESCRIPTION
There was a minor dependency missing in docs/mif/onebook.mif for constructing CHM documentation.  These files rely on the corresponding header to be built.  Normally, if all goes well, an earlier step results in their being present, but interrupting the build can cause them to be missing, making the build unrecoverable.  Just needed to add it to the appropriate make target line.

This bug was present regardless of the help compiler used.
