### PR TITLE
Added missing declaration of MSICloseHandle to msi.h

### DIFF
--- a/bld/w32api/include/msi.mh
+++ b/bld/w32api/include/msi.mh
@@ -325,6 +325,9 @@ typedef enum tagMSICODE {
 
 :include cpluspro.sp
 
+  UINT WINAPI            MsiCloseHandle( MSIHANDLE );
+  UINT WINAPI            MsiCloseAllHandles( );
+
   INSTALLUILEVEL WINAPI  MsiSetInternalUI( INSTALLUILEVEL, HWND * );
   INSTALLUI_HANDLERA WINAPI   MsiSetExternalUIA( INSTALLUI_HANDLERA, DWORD, LPVOID );
   INSTALLUI_HANDLERA WINAPI   MsiSetExternalUIW( INSTALLUI_HANDLERW, DWORD, LPVOID );


### PR DESCRIPTION
Minor bug fix adding two functions that were mistakenly left out of the Win32 MSI API headers.
