### PR TITLE
Update bld/wv/c/dbgset.c

### DIFF
--- a/bld/wv/c/dbgset.c
+++ b/bld/wv/c/dbgset.c
@@ -709,7 +709,7 @@ static void ToggleWindowSwitches( window_toggle *toggle, int len,
                 }
             }
         }
-        if( i == len || settings == NULL ) {
+        if( settings == NULL || i == len ) {
             if( wt >= MWT_LAST || !OneToggle( wt ) ) {
                 Error( ERR_LOC, LIT( ERR_BAD_SUBCOMMAND ), GetCmdName( CMD_SET ) );
             }


### PR DESCRIPTION
Regarding to the function ToggleWindowSwitches (line #692):
In case of third input argument "settings" equal to NULL, local variable "i" in testing of ( i == len || settings == NULL ) will be undefined in the line #712.
