### PR TITLE
This adds native support in WLINK for generating DOS extended programs t...

### DIFF
--- a/bld/wl/lnk/specs.sp
+++ b/bld/wl/lnk/specs.sp
@@ -758,6 +758,32 @@ system begin pmodew
     format os2 le
 :endsegment
 end
+system begin pmodewi
+:segment Pspecs
+    CC  wcc386 -bt=dos
+    CPP wpp386 -bt=dos
+    AS  wasm
+:elsesegment Pwlsystem
+    option osname='PMODE/WI'
+    libpath %WATCOM%/lib386
+    libpath %WATCOM%/lib386/dos
+    op stub=pmodewi.exe
+    format os2 le
+:endsegment
+end
+system begin wdosx
+:segment Pspecs
+    CC  wcc386 -bt=dos
+    CPP wpp386 -bt=dos
+    AS  wasm
+:elsesegment Pwlsystem
+    option osname='WDOSX'
+    libpath %WATCOM%/lib386
+    libpath %WATCOM%/lib386/dos
+    op stub=wdosxle.exe
+    format os2 le
+:endsegment
+end
 system begin zrdx
 :segment Pspecs
     CC  wcc386 -bt=dos


### PR DESCRIPTION
This adds native support in WLINK for generating DOS extended programs that use [PMODE/WI](http://www.sid6581.net/pmodew/) and [WDOSX](http://tippach.business.t-online.de/wdosx/).

PMODE/WI is the tiny version of the PMODE/W DOS extender, that thanks to removing some capabilities, further reduces its overhead to about 8 KB.

WDOSX for Wuschel's DOS eXtender, is another DOS extender supporting various development environments, in particular Watcom/OpenWatcom.

This is done by updating WLINK.LNK that is generated throught bld/wl/lnk/specs.sp.
