### PR TITLE
Update dlgexpr.c

### DIFF
--- a/bld/wv/c/dlgexpr.c
+++ b/bld/wv/c/dlgexpr.c
@@ -31,6 +31,7 @@
 
 
 #include <string.h>
+#include <ctype.h>
 #include "dbgdefn.h"
 #include "dbgwind.h"
 #include "dbgtoggl.h"
@@ -197,7 +198,8 @@ bool    DlgModName( char *title, mod_handle *mod )
 
 bool DlgString( char *title, char *buff )
 {
-    return( DlgGetItemWithRtn( "", EXPR_LEN, title, buff, DlgScanString, DlgNew));
+    buff[isprint(buff[0]) ? 1 : 0] = '\0';
+    return( DlgGetItemWithRtn( buff, EXPR_LEN, title, buff, DlgScanString, DlgNew));
 }
 
 bool DlgMadTypeExpr( char *title, item_mach *value, mad_type_handle th )


### PR DESCRIPTION
Regarding Debugger issue.
Modifying memory by double-clicking on a symbol representation of any value in the Memory window (in the right column of symbols) is not working or crashes debugger with a memory access violation in the line 78 of "bld\aui\c\dlgnew.c"
 dlgnew->buff[0] = '\0'; 
because 'buf' in this case points to read only memory of the empty string "" from first argument of DlgGetItemWithRtn( "", ...
