### PR TITLE
Fix clock() on Linux to properly scale the values returned by times()

### DIFF
--- a/bld/clib/time/c/clock.c
+++ b/bld/clib/time/c/clock.c
@@ -36,7 +36,6 @@
 #elif defined( __LINUX__ )
 #include <sys/times.h>
 #include <errno.h>
-#include <unistd.h>
 #endif
 #include "rtinit.h"
 #include "timedata.h"


### PR DESCRIPTION
While attempting to run some benchmarks on Linux, I noticed that Open Watcom was, on average, producing code that was 10x faster than GCC, which is highly suspect.  After some testing, I concluded that the `clock()` function was returning values that were scaled improperly.  This pull request more carefully processes the `clock_t` values returned by `times()` for a correct result.  The code is similar to that used  in (but not copied from) other runtime libraries.

To see the problem for yourself, try running the following program that does some "busy work:"

``` C
#include <stdio.h>
#include <time.h>
#include <sys/times.h>
#include <string.h>
#include <stdlib.h>
#include <ctype.h>

#define HZ      CLOCKS_PER_SEC
#define SPDP    double

SPDP dtime()
{
 SPDP q;
 clock_t tnow;

 struct tms  buf;

 times(&buf);

 tnow = clock();
 return (SPDP)tnow / (SPDP)HZ;
}

int main(int argc, char *argv[])
{
double start, now;
int waiting;
char *s;

    if(argc > 1)
        waiting = atoi(argv[1]);
    else
        waiting = 10;

    start = dtime();
    now = start;
    while(now - start < (double)waiting) {
        s = (char *)malloc(128*sizeof(char));
        snprintf(s, 128, "Text!");
        strchr(s, '!');
        free(s);

        now = dtime();
    }

    return 0;
}
```

The timing function `dtime()` above is taken from a Whetstone implementation, so excuse the syntax.  With current Open Watcom releases, the above program should take 100 seconds to run (without arguments), although it should take 10 seconds. After this patch, things seem to actually work properly.
