### PR TITLE
Wmake meta-character fix on Windows

### DIFF
--- a/bld/wmake/c/mexec.c
+++ b/bld/wmake/c/mexec.c
@@ -1856,7 +1856,18 @@ STATIC BOOLEAN hasMetas( const char *cmd )
  */
 {
 #if defined( __DOS__ ) || defined( __NT__ )
-    return( strpbrk( cmd, SHELL_METAS ) != NULL );
+    const char *p;
+    BOOLEAN quoted;
+
+    quoted = FALSE;
+    for( p = cmd; *p != NULLCHAR; ++p ) {
+        if( *p == '"' ) {
+            quoted = !quoted;
+        } else if( !quoted && strchr( SHELL_METAS, *p ) != NULL ) {
+            return( TRUE );
+        }
+    }
+    return( FALSE );
 
 #elif defined( __OS2__ ) || defined( __UNIX__ )
     const char  *p;


### PR DESCRIPTION
Wmake had been using a somewhat naive method on Windows to determine if a path contained "meta characters."  If meta characters, which include "<>|&()" for Windows, are detected, it would force the make command to be executed via the shell.  However, the above would cause a failure if the command were one that is intercepted by wmake, i.e. _rm_, and the path contained parentheses.  For example:

```
clean: .SYMBOLIC
    rm -f "build (32)\output.o"
```

The above path is perfectly valid on Windows, but wmake would assume the parentheses imply a variable of some sort, causing execution to pass to the Windows command shell where _rm_ isn't a valid command.  The above command should be intercepted and handled by wmake.

I've changed the _hasMetas()_ routine to perform a relatively basic check for quotes around possible meta characters before deciding the command has any present.
