### PR TITLE
OWGUIBUILD build variable

### DIFF
--- a/bld/builder.ctl
+++ b/bld/builder.ctl
@@ -76,7 +76,9 @@ cdsay .
 [ INCLUDE <OWSRCDIR>/whpcvt/builder.ctl ]
 [ INCLUDE <OWSRCDIR>/win386/wbind/builder.ctl ]
 #[ INCLUDE <OWSRCDIR>/w32loadr/builder.ctl ]
+[ IFDEF <OWGUIBUILD> 1 ]
 [ INCLUDE <OWSRCDIR>/browser/dlgprs/builder.ctl ]
+[ ENDIF ]
 # Build help compilers and tools
 [ INCLUDE <OWSRCDIR>/hcdos/builder.ctl ]
 [ INCLUDE <OWSRCDIR>/hcwin/builder.ctl ]
@@ -84,8 +86,10 @@ cdsay .
 [ INCLUDE <OWSRCDIR>/bmp2eps/builder.ctl ]
 # Build ide2make tool for idedemo
 [ INCLUDE <OWSRCDIR>/wclass/builder.ctl ]
+[ IFDEF <OWGUIBUILD> 1 ]
 [ INCLUDE <OWSRCDIR>/ide/lib/builder.ctl ]
 [ INCLUDE <OWSRCDIR>/ide/ide2make/builder.ctl ]
+[ ENDIF ]
 # Miscellaneous libraries/utilities required during installers build
 [ INCLUDE <OWSRCDIR>/setupgui/ziplib/builder.ctl ]
 [ INCLUDE <OWSRCDIR>/setupgui/zlib/builder.ctl ]
@@ -199,11 +203,15 @@ cdsay .
 [ INCLUDE <OWSRCDIR>/wclass/builder.ctl ]
 # Other GUI tools
 [ INCLUDE <OWSRCDIR>/wprof/builder.ctl ]
+[ IFDEF <OWGUIBUILD> 1 ]
 [ INCLUDE <OWSRCDIR>/browser/builder.ctl ]
+[ ENDIF ]
 # The IDE tools
 [ INCLUDE <OWSRCDIR>/editdll/builder.ctl ]
+[ IFDEF <OWGUIBUILD> 1 ]
 [ INCLUDE <OWSRCDIR>/idebatch/builder.ctl ]
 [ INCLUDE <OWSRCDIR>/ide/builder.ctl ]
+[ ENDIF ]
 # The miscelaneous tools
 [ INCLUDE <OWSRCDIR>/cmdedit/builder.ctl ]
 [ INCLUDE <OWSRCDIR>/cvpack/builder.ctl ]
@@ -216,7 +224,9 @@ cdsay .
 # Source code samples
 [ INCLUDE <OWSRCDIR>/src/builder.ctl ]
 # IDE samples
+[ IFDEF <OWGUIBUILD> 1 ]
 [ INCLUDE <OWSRCDIR>/idedemo/builder.ctl ]
+[ ENDIF ]
 # Build help viewer
 [ INCLUDE <OWSRCDIR>/hlpview/builder.ctl ]
 # Build help compilers
@@ -231,7 +241,9 @@ cdsay .
 [ INCLUDE <OWSRCDIR>/setupgui/builder.ctl ]
 
 # only test build for now
+[ IFDEF <OWGUIBUILD> 1 ]
 [ INCLUDE <OWSRCDIR>/wgml/builder.ctl ]
+[ ENDIF ]
 # Build documentation
 [ IFDEF <OWDOCBUILD> 1 ]
 [ INCLUDE <OWDOCSDIR>/builder.ctl ]

--- a/setvars.sh
+++ b/setvars.sh
@@ -30,6 +30,9 @@ fi
 # Set this variable to 0 to suppress documentation build
 export OWDOCBUILD=0
 
+# Set this variable to 0 to suppress the GUI, IDE, and browser
+export OWGUIBUILD=1
+
 # Change this to the PATH required by GhostScript for PDF creation on used host OS (optional)
 # export OWGHOSTSCRIPTPATH=$PATH
 


### PR DESCRIPTION
Add condition code to enable/disable compiling GUI/IDE/Browser
components and browse headers. Default on in the sample setvars.sh in
consideration of others who are used to compiling these components.
Disabling it saves some compile time and removes the need to bring in
DOSBox or DOSemu. The remainder of the compiler (non-GUI command line
tools) still compile.

(how's this?)
