### PR TITLE
Reduce win32s stack buffer, error out if unable to query stack memory range.

### DIFF
--- a/bld/clib/startup/c/stklmwnt.c
+++ b/bld/clib/startup/c/stklmwnt.c
@@ -49,7 +49,8 @@ void __init_stack_limits( unsigned *stacklow, unsigned *stacktop )
     if( WIN32_IS_NT ) {
         low += 4096 * 3;
     } else if( WIN32_IS_WIN32S ) {
-        low += 4096 * (16 + 2);
+	/* Windows 3.1 appears to only offer 64KB of stack. Assume a buffer zone of 16KB and tread carefully. */
+        low += 4096 * 4;
     } else {
         // Win 95
         low += 4096 * (16 + 3);

--- a/bld/clib/startup/c/stklmwnt.c
+++ b/bld/clib/startup/c/stklmwnt.c
@@ -30,6 +30,7 @@
 
 
 #include "variety.h"
+#include "exitwmsg.h"
 #include "osver.h"
 #include <stdlib.h>
 #include <windows.h>
@@ -41,7 +42,8 @@ void __init_stack_limits( unsigned *stacklow, unsigned *stacktop )
     int                         dummy;
     MEMORY_BASIC_INFORMATION    mbi;
 
-    VirtualQuery( &dummy, &mbi, sizeof( mbi ) );
+    if (VirtualQuery( &dummy, &mbi, sizeof( mbi ) ) == 0)
+        __fatal_runtime_error( "cannot determine stack information", 127 );
 
     top = ((unsigned)mbi.BaseAddress) + mbi.RegionSize;
     low = (unsigned)mbi.AllocationBase;


### PR DESCRIPTION
Windows 3.1 only allocates 64KB of stack for the program, this change reduces the buffer down to 16KB. If VirtualQuery fails, error out instead of letting uninitialized data on the stack determine stack limits. Win32 binaries with stack checking enabled now run properly in Windows 3.1.