### PR TITLE
For Windows 3.1, use GetProcAddress to call GetEnvironmentStrings(A) and FreeEnvironmentStringsA

### DIFF
--- a/bld/clib/startup/c/mainwnt.c
+++ b/bld/clib/startup/c/mainwnt.c
@@ -243,7 +243,12 @@ void __NTFini( void )
         _wcmd_ptr = NULL;
     }
     if( _RWD_Envptr != NULL ) {
-        FreeEnvironmentStrings( _RWD_Envptr );
+	BOOL (WINAPI *__fenvstr)(LPCH str);
+
+	/* Call FreeEnvironmentStringsA() if it exists.
+	 * Windows 3.1 Win32s v1.15 and earlier do not provide this function. */
+	__fenvstr = (void*)GetProcAddress(GetModuleHandle("KERNEL32.DLL"),"FreeEnvironmentStringsA");
+	if (__fenvstr) __fenvstr( _RWD_Envptr );
         _RWD_Envptr = NULL;
     }
 }


### PR DESCRIPTION
GetEnvironmentStringsA() returns NULL under Windows 3.1, to get the environment block you must call GetEnvironmentStrings(). GetEnvironmentStringsA/FreeEnvironmentStringsA entry points do not exist in Win32s v1.15 and earlier, using GetProcAddress allows us to run in that environment anyway.
