### PR TITLE
Fixed typo in Windows zipup batch files

### DIFF
--- a/zipup-rel.cmd
+++ b/zipup-rel.cmd
@@ -7,7 +7,7 @@ set LABEL=open_watcom_%1
 set PREFIX=open_watcom_%1
 set P4OPT=-f
 set ARCHIVES=\archives
-cdd %ARCHIVES%
+cd %ARCHIVES%
 del /q %PREFIX%-src.zip >& NUL
 
 rem ##########################################################################

--- a/zipup.bat
+++ b/zipup.bat
@@ -7,7 +7,7 @@ set LABEL=open_watcom_devel_%1
 set PREFIX=open_watcom_devel_%1
 set P4OPT=-f
 set ARCHIVES=\archives
-cdd %ARCHIVES%
+cd %ARCHIVES%
 del /q %PREFIX%-src.zip >& NUL
 
 rem ##########################################################################


### PR DESCRIPTION
Batch files for zipping the release contained a minor typo, leading to #121 .
