### PR TITLE
Fix for wsplice to avoid warnings on some compilers (MSVC for example)

### DIFF
--- a/bld/builder/c/wsplice.c
+++ b/bld/builder/c/wsplice.c
@@ -281,7 +281,7 @@ int main(               // MAIN-LINE
             }
 
             i = 0;
-            while( i < len ) {
+            while( i < (int)len ) {
                 while( st[i] == ' ' )
                     i++;
                 if( st[i] == 0 )


### PR DESCRIPTION
This change simply corrects a type comparison issue in wsplice that some compilers may issue warnings about, most notably MSVC2012.
