### PR TITLE
Fixes for GUI toolkit to properly handle WM_DESTROY on Windows

### DIFF
--- a/bld/gui/win/c/guitool.c
+++ b/bld/gui/win/c/guitool.c
@@ -70,7 +70,9 @@ bool GUIXCloseToolBar( gui_window *wnd )
         }
         GUIMemFree( toolbar->bitmaps );
         GUIMemFree( toolbar );
-        GUIResizeBackground( wnd, true );
+        if(!(wnd->flags & DOING_DESTROY)) {
+            GUIResizeBackground( wnd, true );
+        }
         GUIEVENTWND( wnd, GUI_TOOLBAR_DESTROYED, NULL );
     }
     return( true );

--- a/bld/gui/win/c/guixutil.c
+++ b/bld/gui/win/c/guixutil.c
@@ -352,7 +352,7 @@ void GUIFreeWindowMemory( gui_window *wnd, bool from_parent, bool dialog )
     GUIFreeColours( wnd );
     GUIFreeBKBrush( wnd );
     GUIControlDeleteAll( wnd );
-    //GUICloseToolBar( wnd );
+    GUICloseToolBar( wnd );
     GUIFreeHint( wnd );
     _wpi_setwindowlongptr( wnd->hwnd, GUI_EXTRA_WORD * EXTRA_SIZE, 0 );
     if( wnd->root != NULLHANDLE ) {

--- a/bld/gui/win/c/guixwind.c
+++ b/bld/gui/win/c/guixwind.c
@@ -923,13 +923,6 @@ WPI_MRESULT CALLBACK GUIWindowProc( HWND hwnd, WPI_MSG msg, WPI_PARAM1 wparam,
             }
             return( (WPI_MRESULT)WPI_ERROR_ON_CREATE );
             break;
-        case WM_DESTROY :
-            wnd->flags |= DOING_DESTROY;
-            GUICloseToolBar( wnd );
-            //ret =  _wpi_defwindowproc( hwnd, msg, wparam, lparam );
-            //wnd->root       = NULL;
-            //wnd->root_frame = NULL;
-            return( 0L );
         }
     } else if( ( wnd->root != NULLHANDLE ) && ( hwnd == wnd->hwnd ) ) {
         /* message for container window */
@@ -1348,6 +1341,7 @@ WPI_MRESULT CALLBACK GUIWindowProc( HWND hwnd, WPI_MSG msg, WPI_PARAM1 wparam,
         if( wnd->flags & DOING_CLOSE ) {
             return( _wpi_defwindowproc( hwnd, msg, wparam, lparam ) );
         } else if( wnd->style & GUI_CLOSEABLE ) {
+            
             if( GUIEVENTWND( wnd, GUI_CLOSE, NULL ) ) {
                 wnd->flags |= DOING_CLOSE;
                 if( wnd->flags & IS_ROOT ) {
@@ -1368,12 +1362,12 @@ WPI_MRESULT CALLBACK GUIWindowProc( HWND hwnd, WPI_MSG msg, WPI_PARAM1 wparam,
         wnd->flags |= DOING_DESTROY;
         NumWindows--;
         GUIEVENTWND( wnd, GUI_DESTROY, NULL );
-        //ret = _wpi_defwindowproc( hwnd, msg, wparam, lparam );
         GUIDestroyAllChildren( wnd );
         if( wnd->flags & IS_ROOT ) {
             GUIDestroyAllPopupsWithNoParent();
         }
         GUIFreeWindowMemory( wnd, false, false );
+        
         if( NumWindows == 0 ) {
             _wpi_postquitmessage( 0 );
             Posted = true;


### PR DESCRIPTION
This pull request needs a bit of explanation.  On modern Windows systems (7 and higher at the very least), shutdown is regularly blocked by the Open Watcom IDE.  After some investigation, the cause was found to be that the IDE does not properly respond to WM_DESTROY messages.  It does respond to WM_CLOSE properly, but a shutdown event will trigger WM_DESTROY without a WM_CLOSE (apparently).

The GUI toolkit appeared to have double-accounted for WM_DESTROY messages.  If the window was the root window, it would destroy the window's toolbar and execute the default window procedure, failing to ever execute the actual WM_DESTROY code.  WM_CLOSE would cause this condition to be skipped for whatever reason, however.

The odd double-accounting seems to be caused by the need to deallocate a possible toolbar.  There are remnants of code elsewhere that have been commented where the toolbar was properly destroyed.  Reactivating them obviously led to crashes, the original reason the toolbar freeing code was moved.

Freeing the toolbar was crashing because it would trigger a resize event.  Normally this behavior is fine because, when the toolbar is destroyed, we need the background window (OW is adding a static background to its child windows) to resize to refill the space.  However, if we're destroying the parent window, requesting a resize causes a crash while enumerating children, which have already been freed.  Now the window flags are checked on toolbar destruction to see if we're currently in the process of destroying the parent.  If so, the resize step is skipped, and the crash due to enumerating nonexistent children is avoided.

So that's the long explanation.  The IDE now properly closes on Windows NT when issued a WM_DESTROY event.  
