### PR TITLE
Fixes for the unix version of _bgetcmd

### DIFF
--- a/bld/clib/environ/c/gtcmdunx.c
+++ b/bld/clib/environ/c/gtcmdunx.c
@@ -48,12 +48,12 @@ _WCRTLINK int (_bgetcmd)( char *buffer, int len )
     int     i;
     char    *word;
     char    *p     = NULL;
-    char    **argv = &_argv[0];
+    char    **argv = &_argv[1];
     char    *space;
 
     --len; // reserve space for NULL byte
 
-    if( buffer && (len > 0) ) {
+    if( buffer && (len >= 0) ) {
         p  = buffer;
         *p = '\0';
     }

--- a/bld/clib/environ/c/gtcmdunx.c
+++ b/bld/clib/environ/c/gtcmdunx.c
@@ -2,7 +2,9 @@
 *
 *                            Open Watcom Project
 *
-*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+*    Portions Copyright (c) 1983-2002 Sybase, Inc. 
+*    Portions Copyright (c) 2014 Open Watcom contributors. 
+*    All Rights Reserved.
 *
 *  ========================================================================
 *
@@ -46,7 +48,8 @@ _WCRTLINK int (_bgetcmd)( char *buffer, int len )
     int     i;
     char    *word;
     char    *p     = NULL;
-    char    **argv = &_argv[1];
+    char    **argv = &_argv[0];
+    char    *space;
 
     --len; // reserve space for NULL byte
 
@@ -54,13 +57,27 @@ _WCRTLINK int (_bgetcmd)( char *buffer, int len )
         p  = buffer;
         *p = '\0';
     }
-
+    
     /* create approximation of original command line */
     for( word = *argv++, i = 0, total = 0; word; word = *argv++ ) {
         i      = strlen( word );
         total += i;
+        
+        /* Check for spaces.  If found, this argument should
+         * be quoted.  This solution is a bit hacky and might
+         * possibly be fooled under very odd circumstances.
+         */
+        space = strchr(word, ' ');
+        if(space != NULL)
+            total +=2;
 
         if( p ) {
+        
+            if(space != NULL && len > 0) {
+                *p++ = '"';
+                --len;
+            }
+        
             if( i >= len ) {
                 strncpy( p, word, len );
                 p[len] = '\0';
@@ -71,11 +88,16 @@ _WCRTLINK int (_bgetcmd)( char *buffer, int len )
                 p   += i;
                 len -= i;
             }
+            
+            if(space != NULL && len > 0) {
+                *p++ = '"';
+                --len;
+            }
         }
 
         /* account for at least one space separating arguments */
         if( *argv ) {
-            if( p ) {
+            if( p != NULL && len > 0 ) {
                 *p++ = ' ';
                 --len;
             }


### PR DESCRIPTION
The `_bgetcmd` function was failing under extremely common circumstances under Linux.  Specifically, it would never capture the actual executable name (it was starting with the first argument).  Additionally, it now properly quotes arguments with spaces when reconstructing the command line.