### PR TITLE
Fixes for getdelim regarding memory allocation

### DIFF
--- a/bld/clib/posix/c/getline.c
+++ b/bld/clib/posix/c/getline.c
@@ -73,9 +73,12 @@ _WCRTLINK ssize_t getdelim( char **s, size_t *n, int delim, FILE *fp )
 
     /* Now with a line length, check if we need a reallocation */
     if( linelength > *n ) {
-        *s = realloc( *s, linelength * sizeof( char ) );
-        if( *s == '\0' ) {
+        if(*n > 0 && *s != NULL)
+            free(*s);
+        *s = malloc( linelength );
+        if( *s == NULL ) {
             errno = ENOMEM;
+            *n = 0;
             return( -1 );
         }
         *n = linelength;


### PR DESCRIPTION
Using `realloc` in `getdelim` is not strictly necessary since we don't care about the previous line/segment's contents when a resizing is needed.  I've been running into some odd realloc() failures on Linux that I haven't tracked down yet.  That said, this commit provides a more reliable and, possibly, efficient way to handle the line allocation.  Additionally, it does correct a minor bug in the code that probably wasn't strictly causing issues.