### PR TITLE
Fixed return value of setpwent/endpwent in headers

### DIFF
--- a/bld/hdr/watcom/pwd.mh
+++ b/bld/hdr/watcom/pwd.mh
@@ -38,8 +38,8 @@ struct passwd {
 _WCRTLINK extern struct passwd *getpwnam( const char *__name );
 _WCRTLINK extern struct passwd *getpwuid( uid_t __uid );
 _WCRTLINK extern struct passwd *getpwent( void );
-_WCRTLINK extern int           setpwent( void );
-_WCRTLINK extern int           endpwent( void );
+_WCRTLINK extern void          setpwent( void );
+_WCRTLINK extern void          endpwent( void );
 
 :include cplusepi.sp
 


### PR DESCRIPTION
POSIX and Linux has the return values for setpwent/endpwent as void.  The headers needed to be updated.