### PR TITLE
Support for Fortran in owcc wrapper.  Improvements to command-line handling in owcc and Fortran compilers.

### DIFF
--- a/bld/f77/wfc/c/sdcline.c
+++ b/bld/f77/wfc/c/sdcline.c
@@ -92,9 +92,13 @@ bool    MainCmdLine( char **fn, char **rest, char **opts, char *ptr ) {
             if( quoted ) {
                 if( *ptr == '\"' ) {
                     quoted = FALSE;
+                    if(scanning_file_name)
+                        *ptr = NULLCHAR;
                 }
             } else if( *ptr == '\"' ) {
                 quoted = TRUE;
+                if(scanning_file_name)
+                    *fn = ptr+1;
             } else if( ( *ptr == ' ' ) || ( *ptr == '\t' ) ) {
                 *ptr = NULLCHAR;
                 ++ptr;

--- a/bld/f77/wfc/h/optinfo.h
+++ b/bld/f77/wfc/h/optinfo.h
@@ -58,7 +58,9 @@ opt( "TYpe",       OPT_TYPE,         CMD,         NULL,         &BitOption, MS_O
 opt( "DIsk",       DISK_MASK,        CMD|NEG,     NULL,         &NegOption, MS_OPT_DISK ),
 opt( "INCList",    OPT_INCLIST,      CMD,         NULL,         &BitOption, MS_OPT_INCLIST ),
 opt( "ERrorfile",  OPT_ERRFILE,      CMD,         NULL,         &BitOption, MS_OPT_ERRFILE ),
+opt( "FR",         OPT_ERRFILE,      CMD,         NULL,         &BitOption, MS_OPT_ERRFILE ),
 opt( "INCPath",    OPT_INCPATH,      CMD|VAL,     &PathOption,  NULL,       MS_OPT_INCPATH ),
+opt( "I",          OPT_INCPATH,      CMD|VAL,     &PathOption,  NULL,       MS_OPT_INCPATH ),
 opt( "FO",         CGOPT_OBJ_NAME,   CMD|VAL|CG,  &FOOption,    NULL,       MS_CGOPT_OBJ_NAME ),
 //                      Diagnostic Options
 opt( "",           0,                CTG,         NULL,         NULL,       MS_CTG_DIAGNOSTIC ),
@@ -174,6 +176,7 @@ opt( "FORmat",     OPT_EXTEND_FORMAT,CMD,         NULL,         &BitOption, MS_O
 opt( "WILd",       OPT_WILD,         CMD,         NULL,         &BitOption, MS_OPT_WILD ),
 opt( "TErminal",   OPT_TERM,         CMD,         NULL,         &BitOption, MS_OPT_TERM ),
 opt( "Quiet",      OPT_QUIET,        CMD,         NULL,         &BitOption, MS_OPT_QUIET ),
+opt( "ZQ",         OPT_QUIET,        CMD,         NULL,         &BitOption, MS_OPT_QUIET ),
 opt( "RESources",  OPT_RESOURCES,    CMD,         NULL,         &BitOption, MS_OPT_RESOURCES ),
 opt( "CC",         OPT_UNIT_6_CC,    CMD,         NULL,         &BitOption, MS_OPT_UNIT_6_CC ),
 opt( "LFwithff",   OPT_LF_WITH_FF,   CMD,         NULL,         &BitOption, MS_OPT_LF_WITH_FF ),

--- a/bld/wcl/h/clcommon.h
+++ b/bld/wcl/h/clcommon.h
@@ -56,6 +56,7 @@ typedef enum tool_type {
     TYPE_ASM,
     TYPE_C,
     TYPE_CPP,
+    TYPE_FORT,
     TYPE_MAX
 } tool_type;
 


### PR DESCRIPTION
This commit (squash of 5) adds a few new Fortran-centric features, notably:

* Drastically better command-line handling in the Fortran compiler, the "wfl" driver, and the owcc driver by using spawnvp rather than erroneously using spawnlp
* Support for the Fortran compiler in the POSIX wrapper driver (owcc) when a .f or .for file is encountered
* Addition of compiler options to the Fortran compiler for compatibility with other Open Watcom tools (-zq, -fr, -i are now valid)
* Support for combinatorial optimization options in the Fortran compiler (like "-ohxl+" is now processed properly, just like our C compilers)
* Support for spaces in the objects and linked executable name when using wfl or owcc

With support for the Fortran compiler in the POSIX wrapper, we can start to look at providing proper support for complex math packages that expect a POSIX-like command line.  

The command line argument changes were necessary because the Fortran compiler was mis-parsing options due to its reconstruction of the command line prior to parsing.  Using spawnlp was causing the Fortran compilers to treat, for example, "-q -er" as a single option on Linux (by re-adding quotes when constructing the command line), causing all sorts of issues in the compiler.  Passing arguments one-by-oe from wfl and owcc properly constructs the argument list now when launching the child processes.

This pull request is rather large, but adding one thing required fixing another, which required fixing another...