### PR TITLE
Implementation of POSIX timers

### DIFF
--- a/bld/clib/h/sys386.h
+++ b/bld/clib/h/sys386.h
@@ -298,6 +298,12 @@
 #define SYS_sched_setaffinity   241
 #define SYS_sched_getaffinity   242
 #define SYS_set_thread_area     243
+/* ... */
+#define SYS_timer_create        259
+#define SYS_timer_settime       260
+#define SYS_timer_gettime       261
+#define SYS_timer_getoverrun    262
+#define SYS_timer_delete        263
 
 /*
  * internal sub-numbers for SYS_socketcall

--- a/bld/clib/linux/c/timer.c
+++ b/bld/clib/linux/c/timer.c
@@ -1,0 +1,153 @@
+/****************************************************************************
+*
+*                            Open Watcom Project
+*
+*    Portions Copyright (c) 2015 Open Watcom Contributors.
+*    All Rights Reserved.
+*
+*  ========================================================================
+*
+*    This file contains Original Code and/or Modifications of Original
+*    Code as defined in and that are subject to the Sybase Open Watcom
+*    Public License version 1.0 (the 'License'). You may not use this file
+*    except in compliance with the License. BY USING THIS FILE YOU AGREE TO
+*    ALL TERMS AND CONDITIONS OF THE LICENSE. A copy of the License is
+*    provided with the Original Code and Modifications, and is also
+*    available at www.sybase.com/developer/opensource.
+*
+*    The Original Code and all software distributed under the License are
+*    distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+*    EXPRESS OR IMPLIED, AND SYBASE AND ALL CONTRIBUTORS HEREBY DISCLAIM
+*    ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF
+*    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR
+*    NON-INFRINGEMENT. Please see the License for the specific language
+*    governing rights and limitations under the License.
+*
+*  ========================================================================
+*
+* Description:  Linux/POSIX timer implementations
+*
+* Author: J. Armstrong
+*
+****************************************************************************/
+
+
+#include "variety.h"
+#include <string.h>
+#include <signal.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stddef.h>
+#include "linuxsys.h"
+
+/* Incomplete kernel sigevent type that provides "just enough"
+ * to properly create a timer
+ */
+typedef struct ksigevent {
+        union sigval sigev_value;
+        int sigev_signo;
+        int sigev_notify;
+    	int sigev_tid;
+};
+
+_WCRTLINK int timer_create( clockid_t __clk, struct sigevent *__sevp, timer_t *__tmr )
+{
+    u_long ures;
+    long res;
+    struct ksigevent ksev;
+    int id;
+
+    if( __tmr == NULL ) {
+        errno = EINVAL;
+        return -1;
+    }
+    
+    memset(&ksev, 0, sizeof(struct ksigevent));
+    if( __sevp != NULL ) {
+        ksev.sigev_value = __sevp->sigev_value;
+        ksev.sigev_signo = __sevp->sigev_signo;
+        ksev.sigev_notify = __sevp->sigev_notify;
+    } else {
+#ifdef SIGEV_SIGNAL        
+        ksev.sigev_notify = SIGEV_SIGNAL;
+#endif
+        ksev.sigev_signo = SIGALRM;
+    }
+
+    ures = sys_call3( SYS_timer_create, 
+                      (u_long)__clk, 
+                      (u_long)&ksev, 
+                      (u_long)&id );
+    
+    res = (long)ures;
+    
+    if( res < 0 ) {
+        errno = res;
+        return -1;
+    }
+    
+    *__tmr = (timer_t)(intptr_t)id;
+    
+    __syscall_return( int, ures );
+}
+
+
+_WCRTLINK int timer_delete( timer_t __tmr )
+{
+    long res;
+    u_long ures = sys_call1( SYS_timer_getoverrun, (u_long)__tmr );
+    
+    res = (long)ures;
+    
+    if( res < 0 ) {
+        errno = EINVAL;
+        return -1;
+    }
+    
+    __syscall_return( int, ures );
+}
+
+_WCRTLINK int timer_getoverrun( timer_t __tmr )
+{
+    long res;
+    u_long ures = sys_call1( SYS_timer_getoverrun, (u_long)__tmr );
+    
+    res = (long)ures;
+    
+    if( res < 0 ) {
+        errno = EINVAL;
+        return -1;
+    }
+    
+    __syscall_return( int, ures );
+}
+
+_WCRTLINK int timer_gettime( timer_t __tmr, struct itimerspec *__v )
+{
+    long res;
+    u_long ures = sys_call2( SYS_timer_gettime, (u_long)__tmr, (u_long)__v );
+    
+    res = (long)ures;
+    
+    if( res < 0 ) {
+        errno = -(res);
+        return -1;
+    }
+    
+    __syscall_return( int, ures );
+}
+
+_WCRTLINK int timer_settime( timer_t __tmr, int flags, struct itimerspec *__new, struct itimerspec *__old )
+{
+    long res;
+    u_long ures = sys_call4( SYS_timer_settime, (u_long)__tmr, (u_long)flags, (u_long)__new, (u_long)__old );
+    
+    res = (long)ures;
+    
+    if( res < 0 ) {
+        errno = -(res);
+        return -1;
+    }
+    
+    __syscall_return( int, ures );
+}

--- a/bld/clib/linux/objects.mif
+++ b/bld/clib/linux/objects.mif
@@ -91,6 +91,7 @@
 !inject sys_open.obj                                                                            l32 lpc lmp
 !inject sysmips.obj                                                                                     lmp
 !inject time.obj                                                                                l32 lpc lmp
+!inject timer.obj                                                                               l32 lpc lmp
 !inject times.obj                                                                               l32 lpc lmp
 !inject truncate.obj                                                                            l32 lpc lmp
 !inject umask.obj                                                                               l32 lpc lmp

--- a/bld/hdr/watcom/linux/arch/i386/siginfo.mh
+++ b/bld/hdr/watcom/linux/arch/i386/siginfo.mh
@@ -7,8 +7,8 @@
 :include clockt.sp
 
 union sigval {
-    int     sigval_int;
-    void    *sigval_ptr;
+    int     sival_int;
+    void    *sival_ptr;
 };
 
 /* Generic definition of siginfo struct borrowed from

--- a/bld/hdr/watcom/linux/arch/i386/sigposix.mh
+++ b/bld/hdr/watcom/linux/arch/i386/sigposix.mh
@@ -27,9 +27,15 @@ struct sigaction {
 struct sigevent {
     int          sigev_signo;
     union sigval sigev_value;
+    int          sigev_notify;
 };
 
 struct msigevent {
     long         sigev_signo;
     union sigval sigev_value;
+    int          sigev_notify;
 };
+
+#define SIGEV_SIGNAL    0
+#define SIGEV_NONE      1
+#define SIGEV_THREAD    2

--- a/bld/hdr/watcom/linux/arch/mips/siginfo.mh
+++ b/bld/hdr/watcom/linux/arch/mips/siginfo.mh
@@ -7,8 +7,8 @@
 :include clockt.sp
 
 union sigval {
-    int         sigval_int;
-    void        *sigval_ptr;
+    int         sival_int;
+    void        *sival_ptr;
 };
 
 /* Generic definition of siginfo struct borrowed from

--- a/bld/hdr/watcom/signal.mh
+++ b/bld/hdr/watcom/signal.mh
@@ -129,6 +129,7 @@ extern int sigaltstack(const stack_t *ss, stack_t *oss);
 struct sigevent {
     int          sigev_signo;
     union sigval sigev_value;
+    int          sigev_notify;
 };
 struct msigevent {
     long         sigev_signo;

--- a/bld/hdr/watcom/sys/types.mh
+++ b/bld/hdr/watcom/sys/types.mh
@@ -75,7 +75,7 @@ typedef short unsigned  msg_t;  /* Used for message passing         */
 typedef long            nid_t;  /* Used for network IDs             */
 #ifndef _TIMER_T_DEFINED_
 #define _TIMER_T_DEFINED_
- typedef int            timer_t;/* Used for timer IDs               */
+ typedef void *         timer_t;/* Used for timer IDs               */
 #endif
 #ifndef _CLOCKID_T_DEFINED_
 #define _CLOCKID_T_DEFINED_

--- a/bld/hdr/watcom/time.mh
+++ b/bld/hdr/watcom/time.mh
@@ -118,13 +118,13 @@ typedef int clockid_t;              /* clockid type */
 #ifndef __POSIX_TIMERS
 #define __POSIX_TIMERS
 struct timespec {
-    long tv_sec;
+    time_t tv_sec;
     long tv_nsec;
 };
 
 struct itimerspec {
-    struct timespec it_value;
     struct timespec it_interval;
+    struct timespec it_value;
     int             notify_type;            /* Uses native int size */
     int             timer_type;
     long            data;                   /* Used by gettimer only */
@@ -139,7 +139,13 @@ struct itimercb {
 #endif
 
 /*  Clock types */
-#define CLOCK_REALTIME          0
+#define CLOCK_REALTIME                  0
+:segment LINUX
+#define CLOCK_MONOTONIC                 1
+#define CLOCK_PROCESS_CPUTIME_ID        2
+#define CLOCK_THREAD_CPUTIME_ID         3
+#define CLOCK_MONOTONIC_RAW             4
+:endsegment
 
 /* Timer settime flags */
 #define TIMER_ABSTIME           0x0001
@@ -173,8 +179,9 @@ _WCRTLINK extern int qnx_clock( nid_t nid, clockid_t clock_id, struct timespec *
 
 struct sigevent;               /* for C++ */
 
-_WCRTLINK extern timer_t timer_create( clockid_t clock_id, struct sigevent *evp );
+_WCRTLINK extern int     timer_create( clockid_t clock_id, struct sigevent *evp, timer_t *tmr );
 _WCRTLINK extern int     timer_delete( timer_t timerid );
+_WCRTLINK extern int     timer_getoverrun( timer_t timerid );
 _WCRTLINK extern int     timer_gettime( timer_t timerid, struct itimerspec *value );
 _WCRTLINK extern int     timer_settime( timer_t timerid, int flags, struct itimerspec *value, struct itimerspec *ovalue );
 :segment QNX

--- a/docs/doc/lr/libfuns.gml
+++ b/docs/doc/lr/libfuns.gml
@@ -1550,7 +1550,12 @@
 .fnc timer_delete               timerdel.gml        QXO
 .fnc timer_gettime              timerget.gml        QXO
 .fnc timer_settime              timerset.gml        QXO
-.fnc times                      times.gml           QXO
+.fnc timer_create               tmrcreat.gml    DOS     W WIN32
+.fnc timer_delete               tmrdel.gml      DOS     W WIN32
+.fnc timer_gettime              tmrget.gml      DOS     W WIN32
+.fnc timer_settime              tmrset.gml      DOS     W WIN32
+.fnc timer_getoverrun           tmrover.gml     DOS     W WIN32
+.fnc times                      times.gml           QX0
 .fnc tmpfile                    tmpfile.gml     DOS QNX W WIN32
 .fnc tmpfile_s                  tmpfil_s.gml    DOS QNX W WIN32
 .fnc tmpnam_s                   tmpnam_s.gml    DOS QNX W WIN32

--- a/docs/doc/lr/liblist7.gml
+++ b/docs/doc/lr/liblist7.gml
@@ -1546,10 +1546,11 @@
 .sys tfork QNX32
 .sys tgamma MATH
 .sys time DOS16 DOS32 WIN16 WIN386 WIN32 QNX16 QNX32 OS216 OS216MT OS216DL OS232 LNX32 RDOS NET32
-.sys timer_create QNX16 QNX32
-.sys timer_delete QNX16 QNX32
-.sys timer_gettime QNX16 QNX32
-.sys timer_settime QNX16 QNX32
+.sys timer_create QNX16 QNX32 LNX32
+.sys timer_delete QNX16 QNX32 LNX32
+.sys timer_gettime QNX16 QNX32 LNX32
+.sys timer_settime QNX16 QNX32 LNX32
+.sys timer_getoverrun LNX32
 .sys times QNX16 QNX32 LNX32
 .sys timezone NET32
 .sys tmpfile DOS16 DOS32 WIN16 WIN386 WIN32 QNX16 QNX32 OS216 OS216MT OS216DL OS232 LNX32 RDOS NET32

--- a/docs/doc/lr/src/tmrcreat.gml
+++ b/docs/doc/lr/src/tmrcreat.gml
@@ -1,0 +1,53 @@
+.func timer_create
+.synop begin
+#include <time.h>
+int timer_create(clockid_t clockid, struct sigevent *evp, timer_t *timerid);
+
+struct sigevent {
+    int          sigev_signo;
+    union sigval sigev_value;
+    int          sigev_notify;
+};
+.synop end
+.desc begin
+The
+.id &funcb.
+function creates a new timer using the clock specified by
+.arg clockid
+as supported by the underlying operating system. The
+.arg evp
+argument can be NULL or may specify a handler for when an
+event of interest occurs.  This implementation currently
+only supports responding using SIGEV_SIGNAL implementations.
+The pointer
+.arg timerid
+will contain the unique, per-process timer id if the call
+is successful.
+.desc end
+.return begin
+If successful, the function will return zero, and the
+.arg timerid
+argument will contain the timer id.  If the call fails, the
+return value is -1, and
+.kw errno
+will be set appropriately.
+.return end
+.error begin
+.begterm 2
+.termhd1 Constant
+.termhd2 Meaning
+.term EINVAL
+The value of
+.arg timerid
+is NULL or an invalid
+.arg clockid
+is specified
+.term EAGAIN
+The system was unable to allocate resources for a new timer
+.endterm
+.error end
+.see begin
+.seelist timer_gettime timer_settime timer_delete timer_getoverrun
+.see end
+.class POSIX
+.system

--- a/docs/doc/lr/src/tmrdel.gml
+++ b/docs/doc/lr/src/tmrdel.gml
@@ -1,0 +1,33 @@
+.func timer_delete
+.synop begin
+#include <time.h>
+int timer_delete(timer_t timerid );
+.synop end
+.desc begin
+The
+.id &funcb.
+function disarms, if necessary, and deletes the timer
+.arg timerid
+immediately.
+.desc end
+.return begin
+If successful, the function will return zero. If the call fails, the
+return value is -1, and
+.kw errno
+will be set appropriately.
+.return end
+.error begin
+.begterm 1
+.termhd1 Constant
+.termhd2 Meaning
+.term EINVAL
+The value of
+.arg timerid
+is NULL or invalid
+.endterm
+.error end
+.see begin
+.seelist timer_create timer_settime timer_gettime timer_delete
+.see end
+.class POSIX
+.system

--- a/docs/doc/lr/src/tmrget.gml
+++ b/docs/doc/lr/src/tmrget.gml
@@ -1,0 +1,47 @@
+.func timer_gettime
+.synop begin
+#include <time.h>
+int timer_gettime(timer_t timerid,
+                  struct itimerspec *value );
+
+struct timespec {
+    time_t tv_sec;
+    long tv_nsec;
+};
+
+struct itimerspec {
+    struct timespec it_interval;
+    struct timespec it_value;
+    int             notify_type;
+    int             timer_type;
+    long            data;
+    
+.synop end
+.desc begin
+The
+.id &funcb.
+function retrieves time remaining in the timer
+.arg timerid
+until expiration.
+.desc end
+.return begin
+If successful, the function will return zero. If the call fails, the
+return value is -1, and
+.kw errno
+will be set appropriately.
+.return end
+.error begin
+.begterm 1
+.termhd1 Constant
+.termhd2 Meaning
+.term EINVAL
+The value of
+.arg timerid
+is NULL or invalid
+.endterm
+.error end
+.see begin
+.seelist timer_create timer_settime timer_delete timer_getoverrun
+.see end
+.class POSIX
+.system

--- a/docs/doc/lr/src/tmrover.gml
+++ b/docs/doc/lr/src/tmrover.gml
@@ -1,0 +1,35 @@
+.func timer_getoverrun
+.synop begin
+#include <time.h>
+int timer_getoverrun( timer_t timerid );
+.synop end
+.desc begin
+The
+.id &funcb.
+function returns the number of intervals for the given
+.arg timerid
+since expiration.
+.desc end
+.return begin
+If successful, the function will return the number of
+elapsed intervals since the latest timer expiration. If the 
+call fails, the
+return value is -1, and
+.kw errno
+will be set appropriately.
+.return end
+.error begin
+.begterm 1
+.termhd1 Constant
+.termhd2 Meaning
+.term EINVAL
+The value of
+.arg timerid
+is NULL or invalid
+.endterm
+.error end
+.see begin
+.seelist timer_create timer_settime timer_delete timer_overrun
+.see end
+.class POSIX
+.system

--- a/docs/doc/lr/src/tmrset.gml
+++ b/docs/doc/lr/src/tmrset.gml
@@ -1,0 +1,75 @@
+.func timer_settime
+.synop begin
+#include <time.h>
+int timer_settime(timer_t timerid, int flags, 
+                  struct itimerspec *new_value,
+                  struct itimerspec *old_value );
+
+struct timespec {
+    time_t tv_sec;
+    long tv_nsec;
+};
+
+struct itimerspec {
+    struct timespec it_interval;
+    struct timespec it_value;
+    int             notify_type;
+    int             timer_type;
+    long            data;
+    
+.synop end
+.desc begin
+The
+.id &funcb.
+function arms or resets the timer
+.arg timerid
+using the interval and value specified in 
+.arg new_value
+pointer.  The previous interval and value is returned in the
+.arg oldvalue
+pointer.  
+.np
+The structure pointed to by the "it_value" member of
+.arg new_value
+specifies the time in the future when the timer will expire,
+and effectively arms the timer.  If the it_value member of 
+.arg new_value
+specifies a time of zero, the timer is disarmed.  The structure
+pointed to by the "it_interval" member of
+.arg new_value
+specifies the interval after the initial timer expiration when
+the timer would repeat expiration.  If the it_interval member's
+components are set to zero, the timer will expire at the time
+specified by the "it_value" member of
+.arg new_value
+and the timer will not automatically rearm.
+.np
+The "it_value" member of
+.arg new_value
+is regarded, by default, as a time relative to the system clock
+at the time of the function call.  If flags incorporates the
+TIMER_ABSTIME constant, the time in "it_value" is regarded as 
+an absolute system time as opposed to a time relative to 
+calling this function.  
+.desc end
+.return begin
+If successful, the function will return zero. If the call fails, the
+return value is -1, and
+.kw errno
+will be set appropriately.
+.return end
+.error begin
+.begterm 1
+.termhd1 Constant
+.termhd2 Meaning
+.term EINVAL
+The value of
+.arg timerid
+is NULL or invalid
+.endterm
+.error end
+.see begin
+.seelist timer_create timer_gettime timer_delete timer_getoverrun
+.see end
+.class POSIX
+.system


### PR DESCRIPTION
Although present in our headers, we didn't have an implementation of the POSIX timers.  This pull request implements (with docs) the following:

* timer_create
* timer_delete
* timer_settime
* timer_gettime
* timer_getoverrun

All functions appear to be working on a Linux kernel that supports timers.