### PR TITLE
Fixed references to PAGE_SIZE macro in help compilers/viewers

### DIFF
--- a/bld/hcdos/c/dmp.c
+++ b/bld/hcdos/c/dmp.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include "index.h"
 
-char    Buffer[ PAGE_SIZE ];
+char    Buffer[ HPAGE_SIZE ];
 
 
 void PrintHeader( HelpHeader *header )
@@ -164,7 +164,7 @@ void main( int argc, char *argv[] )
     read( fp, Buffer, header.datapagecnt * sizeof( uint_16 ) );
     PrintItemIndex( &header );
     for( i = 0; i < header.indexpagecnt + header.datapagecnt; i++ ) {
-        read( fp, Buffer, PAGE_SIZE );
+        read( fp, Buffer, HPAGE_SIZE );
         PrintPage();
     }
 }

--- a/bld/hcdos/c/index.c
+++ b/bld/hcdos/c/index.c
@@ -58,7 +58,7 @@ static unsigned markDataPages( void )
     while( curnode != NULL ) {
         topicCnt++;
         nodesize = sizeof( PageIndexEntry ) + strlen( curnode->name ) + 1;
-        if( nodesize + size > PAGE_SIZE ) {
+        if( nodesize + size > HPAGE_SIZE ) {
             page++;
             size = sizeof( HelpPageHeader );
         }
@@ -118,7 +118,7 @@ unsigned long CalcIndexSize( char **str, bool gen_str )
 
     dataPageCnt = markDataPages();
     indexPageCnt = calcIndexPages( dataPageCnt );
-    ret = ( dataPageCnt + indexPageCnt ) * PAGE_SIZE
+    ret = ( dataPageCnt + indexPageCnt ) * HPAGE_SIZE
             + dataPageCnt * sizeof( uint_16 );
     if( gen_str ) {
         ret += sizeof( HelpHeader ) + calcStringBlockSize( str );
@@ -167,8 +167,8 @@ static int writeOneDataPage( int fout, unsigned pagenum )
     unsigned            len;
     a_helpnode          *curnode;
 
-    page = malloc( PAGE_SIZE );
-    memset( page, 0, PAGE_SIZE );
+    page = malloc( HPAGE_SIZE );
+    memset( page, 0, HPAGE_SIZE );
     pagehdr = (HelpPageHeader *)page;
     index = (PageIndexEntry *)( page + sizeof( HelpPageHeader ) );
     pagehdr->type = PAGE_DATA;
@@ -187,7 +187,7 @@ static int writeOneDataPage( int fout, unsigned pagenum )
         curnode = curnode->next;
         index++;
     }
-    write( fout, page, PAGE_SIZE );
+    write( fout, page, HPAGE_SIZE );
     free( page );
     return( 0 );
 }
@@ -267,8 +267,8 @@ static void generateIndexLevel( void **pages, unsigned curbase,
         base = prevbase;
     }
     for( i = curbase; i < curbase + cur_level; i++ ) {
-        pages[i] = malloc( PAGE_SIZE );
-        memset( pages[i], 0, PAGE_SIZE );
+        pages[i] = malloc( HPAGE_SIZE );
+        memset( pages[i], 0, HPAGE_SIZE );
     }
     /***********************************
      * for each B tree page in a level *
@@ -315,7 +315,7 @@ static int writeIndexPages( int fout )
          prevbase = curbase;
      }
      for( i = 0; i < indexPageCnt; i++ ) {
-         write( fout, pages[i], PAGE_SIZE );
+         write( fout, pages[i], HPAGE_SIZE );
          if( pages[i] != NULL ) free( pages[i] );
      }
      free( pages );

--- a/bld/hcwin/cpp/pagecomp.cpp
+++ b/bld/hcwin/cpp/pagecomp.cpp
@@ -34,12 +34,8 @@
 #include "compress.h"
 #include "hcmem.h"
 
-#ifdef PAGE_SIZE
-#undef PAGE_SIZE
-#endif
-
 #define BLOCK_SIZE      128
-#define PAGE_SIZE       1024
+#define HPAGE_SIZE      1024
 
 struct BlockFile : public File
 {
@@ -91,7 +87,7 @@ int main( int argc, char *argv[] )
         if( amount_read == 0 )
             break;
         amount_written += compactor.compress( block, amount_read );
-        if( amount_written > PAGE_SIZE ) {
+        if( amount_written > HPAGE_SIZE ) {
             pagebreaks[i++] = num_pages;
             compactor.flush();
             amount_written = compactor.compress( block, amount_read );
@@ -111,7 +107,7 @@ int main( int argc, char *argv[] )
     for( int j=0; j < num_pages; j++ ) {
         if( j == pagebreaks[i] ) {
             compactor.flush();
-            while( amount_written < PAGE_SIZE ) {
+            while( amount_written < HPAGE_SIZE ) {
                 output.write( (uint_8)0 );
                 amount_written++;
             }

--- a/bld/hlpview/c/search.c
+++ b/bld/hlpview/c/search.c
@@ -43,7 +43,7 @@
 #define DEFAULTTOPIC "TABLE OF CONTENTS"
 
 int                     curFile = -1;
-char                    curPage[PAGE_SIZE];
+char                    curPage[HPAGE_SIZE];
 HelpPageHeader          *pageHeader;
 char                    *stringBlock;
 void                    *pageIndex;
@@ -59,10 +59,10 @@ static void loadPage( HelpHdl hdl, unsigned long pagenum )
     } else {
         tmp = sizeof( HelpHeader );
     }
-    offset = tmp + hdl->header.str_size + pagenum * PAGE_SIZE
+    offset = tmp + hdl->header.str_size + pagenum * HPAGE_SIZE
            + hdl->header.datapagecnt * sizeof( uint_16 );
     HelpSeek( hdl->fp, offset, HELP_SEEK_SET );
-    HelpRead( hdl->fp, curPage, PAGE_SIZE );
+    HelpRead( hdl->fp, curPage, HPAGE_SIZE );
     curFile = hdl->fp;
     pageHeader = (HelpPageHeader *)curPage;
     pageIndex = curPage + sizeof( HelpPageHeader );

--- a/bld/hlpview/cpp/pagecomp.cpp
+++ b/bld/hlpview/cpp/pagecomp.cpp
@@ -34,12 +34,8 @@
 #include "compress.h"
 #include "hcmem.h"
 
-#ifdef PAGE_SIZE
-#undef PAGE_SIZE
-#endif
-
 #define BLOCK_SIZE      128
-#define PAGE_SIZE       1024
+#define HPAGE_SIZE      1024
 
 struct BlockFile : public File
 {
@@ -92,7 +88,7 @@ int main( int argc, char *argv[] )
         amount_read = input.get_block( block );
         if( amount_read == 0 ) break;
         amount_written += compactor.compress( block, amount_read );
-        if( amount_written > PAGE_SIZE ){
+        if( amount_written > HPAGE_SIZE ){
             pagebreaks[i++] = num_pages;
             compactor.flush();
             amount_written = compactor.compress( block, amount_read );
@@ -112,7 +108,7 @@ int main( int argc, char *argv[] )
     for( int j=0; j < num_pages; j++ ){
         if( j == pagebreaks[i] ){
             compactor.flush();
-            while( amount_written < PAGE_SIZE ){
+            while( amount_written < HPAGE_SIZE ){
                 output.write( (uint_8)0 );
                 amount_written++;
             }

--- a/bld/hlpview/h/index.h
+++ b/bld/hlpview/h/index.h
@@ -68,9 +68,9 @@
  */
 
 
-#define PAGE_SIZE                       1024
+#define HPAGE_SIZE                      1024
 #define INDEX_ENTRIES_PER_PAGE          \
-        ( ( PAGE_SIZE - sizeof( HelpPageHeader ) ) / sizeof( HelpIndexEntry ) )
+        ( ( HPAGE_SIZE - sizeof( HelpPageHeader ) ) / sizeof( HelpIndexEntry ) )
 
 #define HELP_SIG_1              0x1359ddcc
 #define HELP_SIG_2              0x95843561


### PR DESCRIPTION
This commit should eliminate using the possibly problematic term `PAGE_SIZE` within some of the help compilers and viewers.  It appears that these changes are building fine.