### PR TITLE
Fix crash in wlinkd.dll when running wlink on OS/2

### DIFF
--- a/bld/wl/c/ideentry.c
+++ b/bld/wl/c/ideentry.c
@@ -56,7 +56,7 @@ static IDECBHdl         IdeHdl;
 static IDEInitInfo      InitInfo;
 static IDECallBacks     *IdeCB;
 
-#if defined( __OS2__ )
+#if 0 && defined( __OS2__ )
 //extern int InitMsg( void );
 //extern int FiniMsg( void );
 
@@ -226,7 +226,7 @@ IDEBool IDEAPI IDEInitDLL( IDECBHdl hdl, IDECallBacks *cb, IDEDllHdl *info )
     IdeHdl = hdl;
     IdeCB = cb;
     InitSubSystems();
-#if defined( __OS2__ )
+#if 0 && defined( __OS2__ )
     RunOnce = FALSE;
 #endif
     return FALSE;
@@ -243,14 +243,14 @@ IDEBool IDEAPI IDERunYourSelf( IDEDllHdl hdl, const char * opts, IDEBool *fatale
 /**********************************************************************************/
 {
     hdl = hdl;
-#if defined( __OS2__ )
+#if 0 && defined( __OS2__ )
     if( RunOnce ) {
         InitMsg();
     }
     RunOnce = TRUE;
 #endif
     LinkMainLine( (char *) opts );
-#if defined( __OS2__ )
+#if 0 && defined( __OS2__ )
     FiniMsg();
 #endif
     *fatalerr = (LinkState & LINK_ERROR) != 0;


### PR DESCRIPTION
There were some strange '#ifdef __OS2__' parts in wl/c/ideentry.c, which caused wlink to crash.
I've disabled them for now (the IDE crashes anyway on startup).
I've successfully compiled 16 and 32 bit OS/2 test programs and 16 bit DOS program on a OS/2 host with this change.