### PR TITLE
add extern "C" to make the header work in C++

### DIFF
--- a/bld/causeway/inc/cwdll.h
+++ b/bld/causeway/inc/cwdll.h
@@ -1,6 +1,10 @@
 #pragma library (cwdll)
 
-#define _CWCAPI     __declspec(__cdecl)
+#ifdef __cplusplus
+ #define _CWCAPI     extern "C" __declspec(__cdecl)
+#else
+ #define _CWCAPI     __declspec(__cdecl)
+#endif
 
 /****************************************************************************
 ;Load a module by file name. If the module already exists in memory a new


### PR DESCRIPTION
Without extern "C" linker couldn't resolve functions in cwdll.lib
