### PR TITLE
fix build

### DIFF
--- a/bld/rc/rc/c/pprcenv.c
+++ b/bld/rc/rc/c/pprcenv.c
@@ -16,8 +16,7 @@
 #include "clibext.h"
 #include "rccore.h"
 
-
-char *PP_GetEnv( const char *name )
+const char *PP_GetEnv( const char *name )
 {
     return( RcGetEnv( name ) );
 }


### PR DESCRIPTION
Looks like commit [0b010815544ea6ca26c2c3de428a09cf0c521f38](https://github.com/open-watcom/open-watcom-v2/commit/0b010815544ea6ca26c2c3de428a09cf0c521f38) broke bootstrap build with following error:
````
cc pprcenv.obj
..\c\pprcenv.c(21): Error! E1062: Inconsistent return type for function 'PP_GetE
nv'
..\c\pprcenv.c(21): Note! N2003: source conversion type is 'char *'
..\c\pprcenv.c(21): Note! N2004: target conversion type is 'char const *'
..\c\pprcenv.c(21): Note! N2002: 'PP_GetEnv' defined in: c:\ow\ow\bld\cpp\h\prep
roc.h(148)
Error(E42): Last command making (pprcenv.obj) returned a bad status
Error(E02): Make execution terminated
<wmake -h -f ../binmake bootstrap=1> => non-zero return: 2
Build failed
````