### PR TITLE
Linux issues solving

### DIFF
--- a/bld/ui/unix/c/tixparse.c
+++ b/bld/ui/unix/c/tixparse.c
@@ -498,6 +498,12 @@ int ti_read_tix( const char *termname )
             wctomb( ti_char_map[i], i );
         }
     }
+
+    #if 0
+    /* do not play woth utf8 mode setting: all VT are already configured
+       as needed. With this code on there is a problem with line drawing
+       on the linux console (framebuffer mode) */
+
     if( strncmp( termname, "linux", 5 ) == 0 ) {
         /* force UTF-8 mode if the locale is set that way; *
          * we may be on a new VT on the Linux console      */
@@ -511,6 +517,8 @@ int ti_read_tix( const char *termname )
         else
             write( UIConHandle, "\033%@", 3 );
     }
+    #endif
+
     if( strncmp( termname, "xterm", 5 ) == 0 ) {
         /* special xterm keys available in recent xterms */
         TrieAdd( EV_CTRL_CURSOR_UP, "\033[1;5A" );

--- a/bld/ui/unix/c/uibios.c
+++ b/bld/ui/unix/c/uibios.c
@@ -73,7 +73,6 @@ char *GetTermType( void )
 int intern initbios( void )
 {
     PossibleDisplay             *curr;
-    int                         error;
 
     if( UIConFile == NULL ) {
         char *tty;
@@ -87,8 +86,11 @@ int intern initbios( void )
         UIConHandle = fileno( UIConFile );
         fcntl( UIConHandle, F_SETFD, 1 );
     }
-    setupterm( GetTermType(), UIConHandle, &error );
-    if( error != 1 ) return( FALSE );
+
+    setupterm( GetTermType(), UIConHandle, (int *)0);
+    /* will report an error message and exit if any
+       problem with a terminfo */
+
     // Check to make sure terminal is suitable
     if( cursor_address == NULL || hard_copy ) {
         del_curterm( cur_term );

--- a/bld/wipfc/configure
+++ b/bld/wipfc/configure
@@ -2307,8 +2307,12 @@ am__tar='${AMTAR} chof - "$$tardir"'; am__untar='${AMTAR} xf -'
 
 
 
-CPPFLAGS="-std=c++0x -D __STDC_LIMIT_MACROS -I$srcdir/cpp -I$srcdir/../watcom/h"
-CXXFLAGS="-pipe -g -Wall -march=native"
+# allow to use a plain gcc compiler (gcc-3.4.6)
+#CPPFLAGS="-std=c++0x -D __STDC_LIMIT_MACROS -I$srcdir/cpp -I$srcdir/../watcom/h"
+#CXXFLAGS="-pipe -g -Wall -march=native"
+
+CPPFLAGS="-D __STDC_LIMIT_MACROS -I$srcdir/cpp -I$srcdir/../watcom/h"
+CXXFLAGS="-pipe -g -Wall"
 
 ac_config_headers="$ac_config_headers config.h"
 

--- a/bld/wipfc/configure.ac
+++ b/bld/wipfc/configure.ac
@@ -1,8 +1,14 @@
 # Process this file with autoconf to produce a configure script.
 AC_INIT([wipfc], [2.0], [])
 AM_INIT_AUTOMAKE
-CPPFLAGS="-std=c++0x -D __STDC_LIMIT_MACROS -I$srcdir/cpp -I$srcdir/../watcom/h"
-CXXFLAGS="-pipe -g -Wall -march=native"
+
+# allow to use a plain gcc compiler (gcc-3.4.6)
+#CPPFLAGS="-std=c++0x -D __STDC_LIMIT_MACROS -I$srcdir/cpp -I$srcdir/../watcom/h"
+#CXXFLAGS="-pipe -g -Wall -march=native"
+
+CPPFLAGS="-D __STDC_LIMIT_MACROS -I$srcdir/cpp -I$srcdir/../watcom/h"
+CXXFLAGS="-pipe -g -Wall"
+
 AC_CONFIG_SRCDIR([cpp/main.cpp])
 AC_CONFIG_HEADERS([config.h])
 

--- a/bld/wipfc/cpp/document.cpp
+++ b/bld/wipfc/cpp/document.cpp
@@ -952,7 +952,7 @@ std::wstring* Document::prepNameitName( const std::wstring& key )
     return name;
 }
 /***************************************************************************/
-std::uint16_t Document::getGroupById( const std::wstring& i )
+STD1::uint16_t Document::getGroupById( const std::wstring& i )
 {
     ControlGroup* grp( controls->getGroupById( i ) );
     if( !grp ) {
@@ -962,4 +962,3 @@ std::uint16_t Document::getGroupById( const std::wstring& i )
     else
         return grp->index() + 1;
 }
-

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,10 @@
 #
 # Expects POSIX or OW tools.
 
+if [ -z "$OWROOT" ]; then
+    source ./setvars.sh
+fi
+
 OWBUILDER_BOOTX_OUTPUT=$OWROOT/bootx.log
 
 output_redirect()

--- a/setvars.sh
+++ b/setvars.sh
@@ -6,14 +6,15 @@
 #       modify it as necessary for your own use!!
 
 # Change this to point your Open Watcom source tree
-export OWROOT=/home/ow/ow
+# 	Note: '=' sign in path is not allowed (build will fail)
+export OWROOT=`pwd`
 
 # Subdirectory to be used for building OW build tools
 export OWOBJDIR=binbuild
 
 # Set this entry to identify your toolchain used by build process
 # supported values are WATCOM GCC CLANG
-export OWTOOLS=WATCOM
+export OWTOOLS=GCC
 
 # Documentation related variables
 

--- a/setvars.sh
+++ b/setvars.sh
@@ -6,7 +6,13 @@
 #       modify it as necessary for your own use!!
 
 # Change this to point your Open Watcom source tree
-# 	Note: '=' sign in path is not allowed (build will fail)
+#
+# 	Note: '=' sign in path is not allowed (build will fail).
+#	Try to keep a OWROOT path short and simple like
+#       /tmp/ow There is dosemu used to build some parts
+#	of the software. dosemu can hang if OWROOT is long
+#	or contain long names of the directories.
+
 export OWROOT=`pwd`
 
 # Subdirectory to be used for building OW build tools


### PR DESCRIPTION
Some corner problems: 
  * if terminfo base can not be found
  * if working on linux console with utf8 (not xterm)
  * if trying to build WATCOM with gcc 3.4.6 (or with other not c++0x compatible compiler)
  * allow to start build WATCOM by running build.sh w/o doing anything else (tuning)
