### PR TITLE
vi on unix: show (turn on) an edit window border

### DIFF
--- a/bld/vi/c/globals.c
+++ b/bld/vi/c/globals.c
@@ -147,7 +147,7 @@ window_info statusw_info = { 0, WHITE, BLACK, { WHITE, BLACK, 0 },
     { BRIGHT_WHITE, BLACK, 0 }, 69, 24, 79, 24 };
 window_info repcntw_info = { 1, WHITE, BLACK, { WHITE, BLACK, 0 },
     { BRIGHT_WHITE, BLACK, 0 }, 28, 20, 43, 32 };
-window_info editw_info = { 0, WHITE, BLACK, { WHITE, BLACK, 0 },
+window_info editw_info = { 1, WHITE, BLACK, { WHITE, BLACK, 0 },
     { BRIGHT_WHITE, BLACK, 0 }, 0, 0, 79, 24 };
 window_info extraw_info = { 1, WHITE, BLACK, { WHITE, BLACK, 0 },
     { BRIGHT_WHITE, BLACK, 0 }, 26, 2, 51, 18 };

--- a/bld/vi/dat/ed.cfg
+++ b/bld/vi/dat/ed.cfg
@@ -43,7 +43,11 @@ set currentstatuscolumn = 64
 set endoflinechar = 0
 set exitattr = 7
 set fileendstring = ""
+if %(OS) == unix 
+set gadgetstring = 	
+else
 set gadgetstring = =¿ÀÙ³Ä´Ã°Û
+endif
 set grepdefault = *.(c|h)
 set hardtab = 8
 set inactivewindowcolor = 0


### PR DESCRIPTION
    vi from the watcom 1.9 has this. I don't found
    why it disappears in the current version.