### PR TITLE
unix: a new buildrel.sh and modified clean.sh, bld/builder.ctl

### DIFF
--- a/bld/builder.ctl
+++ b/bld/builder.ctl
@@ -217,7 +217,7 @@ cdsay .
 # Source code samples
 [ INCLUDE <OWSRCDIR>/src/builder.ctl ]
 # IDE samples
-[ INCLUDE <OWSRCDIR>/idedemo/builder.ctl ]
+#[ INCLUDE <OWSRCDIR>/idedemo/builder.ctl ]
 # Build help viewer
 [ INCLUDE <OWSRCDIR>/hlpview/builder.ctl ]
 # Build help compilers

--- a/buildrel.sh
+++ b/buildrel.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Script to build the Open Watcom tools
+# using the host platform's native C/C++ compiler or OW tools.
+#
+# Expects POSIX or OW tools.
+
+if [ -z "$OWROOT" ]; then
+    source ./setvars.sh
+fi
+
+OWBUILDER_BOOTX_OUTPUT=$OWROOT/bootx.log
+
+output_redirect()
+{
+    $1 $2 $3 $4 $5 $6 >>$OWBUILDER_BOOTX_OUTPUT 2>&1
+}
+
+cd $OWSRCDIR
+builder rel
+RC=$?
+cd $OWROOT
+exit $RC

--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+if [ -z "$OWROOT" ]; then
+    source ./setvars.sh
+fi
 if [ ! -f $OWBINDIR/builder ]; then
     echo Cannot find builder - did you run boot.sh?
 else


### PR DESCRIPTION
    buildrel.sh - to simplify build a realise on unix
    bld/builder.ctl - commented out bld/idedemo/builder.ctl
      (os2.obj problem: can not build)
    clean.sh - clean even if OWROOT is not set (call
      setvars.sh to setup it)