### PR TITLE
convert wgml.bat to CR-LF line-ending

### DIFF
--- a/bld/wgml/test/testlib/makefile
+++ b/bld/wgml/test/testlib/makefile
@@ -216,6 +216,7 @@ gencop : .procedure
         @%append $(dosemu_gendev_batch) set GMLINC=..\testsrc
         @%append $(dosemu_gendev_batch) w:\gml\dos\gendev.exe $(gendev_cmdl_params)
         @%append $(dosemu_gendev_batch) exitemu
+        @unix2dos $(dosemu_gendev_batch)
         $(GENDEVCMD)
 !else ifeq use_dosemu dosbox
         %create $(dosemu_gendev_batch)

--- a/docs/mif/onebook.mif
+++ b/docs/mif/onebook.mif
@@ -477,6 +477,7 @@ prepare_wgml_opts : .PROCEDURE
     @%append $(dosemu_wgml_batch) @set GMLINC=$(%GMLINC)
     @%append $(dosemu_wgml_batch) w:\gml\dos\wgml.exe $(wgml_cmdl_params)
     @%append $(dosemu_wgml_batch) exitemu
+    @unix2dos $(dosemu_wgml_batch)
 !else ifeq use_dosemu dosbox
 #-------------------------------------------------------
 # create DOSBOX batch file to run wgml utility


### PR DESCRIPTION
Some command.com's do not understand the unix's LF lines.