### PR TITLE
build.sh: use bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@
 # Expects POSIX or OW tools.
 
 if [ -z "$OWROOT" ]; then
-    source ./setvars.sh
+    . ./setvars.sh
 fi
 
 OWBUILDER_BOOTX_OUTPUT=$OWROOT/bootx.log


### PR DESCRIPTION
Many distributions (ubuntu, debian) use dash instead of bash.
dash gives the following error:
./build.sh: 9: ./build.sh: source: not found
./build.sh: 20: cd: can't cd to /wmake