### PR TITLE
clean up dosemu setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ before_install:
  - sudo apt-get -qq update
 # install DOSEMU
  - sudo apt-get install -y dosemu
-# setup DOSEMU to work with OW build
- - sudo sysctl -w vm.mmap_min_addr=0
- - echo " \$_layout = \"us\"" > ~/.dosemurc
 
 before_script:
 # initialize OW build environment variables

--- a/bld/wgml/test/test.sh
+++ b/bld/wgml/test/test.sh
@@ -30,7 +30,7 @@ else
    echo "set GMLLIB=w:\gml\syslib;w:\doc\whelp;w:\doc\hlp;.\testlib" >> wgml.bat
    echo "w:\gml\dos\wgml.exe $fn ( file wgml.opt out $fb.ops %1 %2 %3 %4 %5 %6 %7 %8 %9 >$fb.old" >> wgml.bat
    echo "exitemu" >> wgml.bat
-   dosemu -dumb wgml.bat
+   dosemu -dumb -quiet wgml.bat
 fi
    $OWROOT/bld/wgml/$WGML_DIR/wgml.exe $fn "(" file wgml.opt out $fb.nps $1 $2 $3 $4 $5 $6 $7 $8 $9 >$fb.ntr
    $OWROOT/bld/wgml/$WGML_DIR/wgml.exe $fn -r "(" file wgml.opt out $fb.nps $1 $2 $3 $4 $5 $6 $7 $8 $9 >$fb.new

--- a/build/mif/wgmlcmd.mif
+++ b/build/mif/wgmlcmd.mif
@@ -50,8 +50,8 @@ use_dosemu = dosbox
 # only DOSBOX use upper cased file name
 wgml_ucase=1
 !else
-WGMLCMD = dosemu -dumb $(dosemu_wgml_batch)
-GENDEVCMD = dosemu -dumb $(dosemu_gendev_batch)
+WGMLCMD = dosemu -dumb -quiet $(dosemu_wgml_batch)
+GENDEVCMD = dosemu -dumb -quiet $(dosemu_gendev_batch)
 use_dosemu = dosemu
 !endif
 


### PR DESCRIPTION
dosemu issues the useless warnings and waits for ENTER to
be pressed. Instead of messing around its configs, we can
fortunately just use the "-quiet" option to suppress all
stupid things.