### PR TITLE
OS X build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dh
 *.dip
 *.dll
+*.dSYM
 *.elf
 *.err
 *.exe

--- a/bld/plusplus/c/utility.c
+++ b/bld/plusplus/c/utility.c
@@ -50,14 +50,14 @@ char *stpcpy_after(             // COPY STRING, UPDATE SOURCE POINTER
     return( tgt );
 }
 
-
+#ifndef __APPLE__
 char *stpcpy(                   // CONCATENATE STRING AS STRING
     char *string,               // - target location
     const char *src_string )    // - source string
 {
     return( stpcpy_after( string, &src_string ) - 1 );
 }
-
+#endif
 
 char *stvcpy_after(             // COPY VECTOR, UPDATE SOURCE POINTER
     char *tgt,                  // - target

--- a/bld/plusplus/h/utility.h
+++ b/bld/plusplus/h/utility.h
@@ -174,10 +174,12 @@ char *sti64cpy(                 // CONCATENATE I64 NUMBER
     char *tgt,                  // - target location
     signed_64 value )           // - value to be concatenated
 ;
+#ifndef __APPLE__
 char *stpcpy(                   // CONCATENATE STRING AS STRING
     char *string,               // - target location
     const char *src_string )    // - source string
 ;
+#endif
 char *stpcpy_after(             // COPY STRING, UPDATE SOURCE POINTER
     char *tgt,                  // - target
     char const **src )          // - addr( source )

--- a/bld/wipfc/cpp/document.cpp
+++ b/bld/wipfc/cpp/document.cpp
@@ -542,7 +542,7 @@ void Document::makeBitmaps()
         std::vector< std::string > paths;
         std::string cwd;    //empty string for current directory
         paths.push_back( cwd );
-#ifdef __UNIX__
+#if defined( __UNIX__ ) || defined( __APPLE__ )
         std::string separators( ":;" );
         char slash( '/' );
 #else
@@ -566,7 +566,7 @@ void Document::makeBitmaps()
                     if( !fullname.empty() )
                         fullname += slash;
                     fullname += fname;
-#ifndef __UNIX__
+#if !defined( __UNIX__ ) && !defined( __APPLE__ )
                     if( fullname.size() > PATH_MAX ) {
                         throw FatalError( ERR_PATH_MAX );
                     }
@@ -815,7 +815,7 @@ Lexer::Token Document::processCommand( Lexer* lexer, Tag* parent )
         std::vector< std::wstring > paths;
         std::wstring cwd;   //empty string for current directory
         paths.push_back( cwd );
-#ifdef __UNIX__
+#if defined( __UNIX__ ) || defined( __APPLE__ )
         std::string separators( ":;" );
         char slash( '/' );
 #else
@@ -839,7 +839,7 @@ Lexer::Token Document::processCommand( Lexer* lexer, Tag* parent )
             if( !fname->empty() )
                 *fname += slash;
             *fname += lexer->text();
-#ifndef __UNIX__
+#if !defined( __UNIX__ ) && !defined( __APPLE__ )
             if( fname->size() > PATH_MAX ) {
                 throw FatalError( ERR_PATH_MAX );
             }

--- a/bld/wipfc/cpp/ipffile.cpp
+++ b/bld/wipfc/cpp/ipffile.cpp
@@ -31,7 +31,7 @@
 #include "errors.hpp"
 #include "util.hpp"
 #include <cstdlib>
-#ifndef __UNIX__
+#if !defined( __UNIX__ ) && !defined( __APPLE__ )
     #include <mbctype.h>
 #endif
 
@@ -48,7 +48,7 @@ IpfFile::IpfFile( const std::wstring*  fname ) : IpfData(), fileName ( fname ),
 //Returns EOB if end-of-file reached
 std::wint_t IpfFile::get()
 {
-#ifdef __UNIX__
+#if defined( __UNIX__ ) || defined( __APPLE__ )
     std::wint_t ch( 0 );
     if( ungotten ) {
         ch = ungottenChar;
@@ -87,7 +87,7 @@ void IpfFile::unget( wchar_t ch )
         decLine();
 }
 /*****************************************************************************/
-#ifndef __UNIX__
+#if !defined( __UNIX__ ) && !defined( __APPLE__ )
 std::wint_t IpfFile::readMBChar()
 {
     wchar_t ch = 0;

--- a/bld/wipfc/cpp/ipffile.hpp
+++ b/bld/wipfc/cpp/ipffile.hpp
@@ -66,7 +66,7 @@ private:
     std::FILE* stream;
     wchar_t ungottenChar;
     bool ungotten;
-#ifndef __UNIX__
+#if !defined( __UNIX__ ) && !defined( __APPLE__ )
     std::wint_t readMBChar();
 #endif
 };

--- a/bld/wipfc/cpp/main.cpp
+++ b/bld/wipfc/cpp/main.cpp
@@ -112,7 +112,7 @@ static void processCommandLine(int argc, char **argv, Compiler& c)
     int outIndex( 0 );
     bool info( false );
     for( int count = 1; count < argc; ++count ) {
-#ifdef __UNIX__
+#if defined( __UNIX__ ) || defined( __APPLE__ )
         if( argv[count][0] == '-' ) {
 #else
         if( argv[count][0] == '-' || argv[count][0] == '/' ) {

--- a/bld/wipfc/cpp/nls.cpp
+++ b/bld/wipfc/cpp/nls.cpp
@@ -33,7 +33,7 @@
 #endif
 #include <cstdlib>
 #include <cstring>
-#ifdef __UNIX__
+#if defined( __UNIX__ ) || defined( __APPLE__ )
     #include <clocale>
 #else
     #include <mbctype.h>
@@ -56,12 +56,12 @@ Nls::Nls( const char *loc ) : bytes( 0 ), useDBCS( false )
 /*****************************************************************************/
 void Nls::setCodePage( int cp )
 {
-#ifndef __UNIX__
+#if !defined( __UNIX__ ) && !defined( __APPLE__ )
     _setmbcp( cp ); //doesn't do much of anything in OW
 #endif
     std::string path( Environment.value( "WIPFC" ) );
     if( path.length() )
-#ifndef __UNIX__
+#if !defined( __UNIX__ ) && !defined( __APPLE__ )
         path += '\\';
 #else
         path += '/';
@@ -109,7 +109,7 @@ void Nls::setLocalization( const char *loc)
 {
     std::string path( Environment.value( "WIPFC" ) );
     if( path.length() )
-#ifndef __UNIX__
+#if !defined( __UNIX__ ) && !defined( __APPLE__ )
         path += '\\';
 #else
         path += '/';
@@ -121,7 +121,7 @@ void Nls::setLocalization( const char *loc)
         throw FatalError( ERR_LANG );
     readNLS( nls );
     std::fclose( nls );
-#ifdef __UNIX__
+#if defined( __UNIX__ ) || defined( __APPLE__ )
     std::setlocale( LC_ALL, loc );  //this doesn't really do anything in OW either
 #endif
     setCodePage( country.codePage );

--- a/bld/wipfc/cpp/util.cpp
+++ b/bld/wipfc/cpp/util.cpp
@@ -35,7 +35,7 @@
 #include <cstring>
 #include <memory>
 #include <string>
-#ifdef __UNIX__
+#if defined( __UNIX__ ) || defined( __APPLE__ )
     #include <unistd.h>
 #else
     #include <direct.h>
@@ -122,7 +122,7 @@ std::string canonicalPath( char* arg )
     std::auto_ptr< char > cwd( ::getcwd( 0, 0 ) );
     std::string fullpath( cwd.get() );
     std::string inFile( arg );
-#ifdef __UNIX__
+#if defined( __UNIX__ ) || defined( __APPLE__ )
     const char* srchstr = "../";
     char sep = '/';
 #else
@@ -138,7 +138,7 @@ std::string canonicalPath( char* arg )
                 inFile.erase( idx1, 3 );
             }
             else if( !fullpath.empty() ) {
-#ifdef __UNIX__
+#if defined( __UNIX__ ) || defined( __APPLE__ )
                 idx2 = 0;
 #else
                 idx2 = fullpath.find( ':' );    //don't kill drive
@@ -156,7 +156,7 @@ std::string canonicalPath( char* arg )
     }
     else
         fullpath = inFile;
-#ifndef __UNIX__
+#if !defined( __UNIX__ ) && !defined( __APPLE__ )
     if( fullpath.size() > PATH_MAX )
         throw FatalError( ERR_PATH_MAX );
 #endif

--- a/bld/wmake/c/mglob.c
+++ b/bld/wmake/c/mglob.c
@@ -99,7 +99,23 @@ const char FAR *BuiltIns = {
 
 #elif defined( __OSX__ ) || defined( __APPLE__ )
     "__OSX__=\n"
+    "__BSD__=\n"
     "__UNIX__=\n"
+    #if defined( _M_X64 ) || defined( __x86_64__ ) || defined( __amd64__ ) || defined( __amd64 )
+        "__BSDX64__=\n"
+        "__OSXX64__=\n"
+    #elif defined( _M_IX86 ) || defined( __i386 ) || defined( __i386__ )
+        "__BSDX386__=\n"
+        "__OSXX386__=\n"
+    #elif defined( __PPC__ ) || defined( __ppc__ ) || defined( __powerpc__ )
+        "__BSDPPC__=\n"
+        "__OSXPPC__=\n"
+    #elif defined( _M_ARM ) || defined( __ARM__ ) || defined( __arm__ )
+        "__BSDARM__=\n"
+        "__OSXARM__=\n"
+    #else
+        #error Unknown CPU architecture
+    #endif
 
 #elif defined( __LINUX__ ) || defined( __linux__ )
     "__LINUX__=\n"

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ OWBUILDER_BOOTX_OUTPUT=$OWROOT/bootx.log
 
 output_redirect()
 {
-    $1 $2 $3 $4 $5 $6 >>$OWBUILDER_BOOTX_OUTPUT 2>&1
+    "$@" >>$OWBUILDER_BOOTX_OUTPUT 2>&1
 }
 
 rm -f $OWBUILDER_BOOTX_OUTPUT
@@ -35,6 +35,10 @@ else
         FreeBSD)
             output_redirect make -f ../posmake clean
             output_redirect make -f ../posmake TARGETDEF=-D__BSD__
+            ;;
+        Darwin)
+            output_redirect make -f ../posmake clean
+            output_redirect make -f ../posmake TARGETDEF='-D__BSD__ -D__OSX__'
             ;;
         Haiku)
             output_redirect make -f ../posmake clean

--- a/build/mif/local.mif
+++ b/build/mif/local.mif
@@ -247,10 +247,16 @@ incl_file_opts = -include
 # common settings
 ############################
 common_cppflags_bsd = -D__BSD__ -D__UNIX__ -D__FLAT__
+!ifdef __OSX__
+common_cppflags_osx = -D__OSX__
+!else
+common_cppflags_osx =
+!endif
 
 common_cppflags_386   = -D_M_IX86 -D__386__ -D__BSD_386__
 common_cppflags_x64   = -D_M_X64 -D__BSD_X64__
 common_cppflags_ppc   = -D__PPC__
+common_cppflags_arm   = -D__ARM__
 
 # common release/debug flags
 common_flags_rel = -O -g
@@ -317,14 +323,17 @@ bld_cl_sys =
 
 bld_incs = $(bld_extra_incs) -I"$(watcom_dir)/h"
 
-bld_cppflags = $(common_cppflags_bsd) $(common_cppflags_$(bld_cpu))
+bld_cppflags = $(common_cppflags_bsd) $(common_cppflags_osx) $(common_cppflags_$(bld_cpu))
 
 bld_cflags   = $(common_cflags) $(common_flags) -o $@
 
 bld_cxxflags = -std=c++98
 
 # options for linking
-!ifdef __CLANG__
+!ifdef __OSX__
+bld_ldflags_cxx = -lc++
+bld_ldflags_dll_cxx = -lc++
+!else ifdef __CLANG__
 bld_ldflags_cxx = -lstdc++
 bld_ldflags_dll_cxx = -lstdc++
 !else
@@ -332,7 +341,7 @@ bld_ldflags_cxx = -lsupc++ -lstdc++
 bld_ldflags_dll_cxx = -lsupc++ -lstdc++
 !endif
 
-bld_ldflags1 = $(common_ldflags) -Wl,-Map,$^&.map
+bld_ldflags1 = $(common_ldflags) -Wl,-map,$^&.map
 
 bld_ldflags  = $(bld_extra_ldflags) $(bld_ldflags_$(proj_type))
 
@@ -357,6 +366,7 @@ cl  = gcc -pipe
 
 cppflags_bsd   = $(common_cppflags_bsd)
 cppflags_osi   = $(common_cppflags_bsd)
+cppflags_osx   = $(common_cppflags_osx)
 cppflags_386   = $(common_cppflags_386)
 cppflags_ppc   = $(common_cppflags_ppc)
 cppflags_x64   = $(common_cppflags_x64)
@@ -368,7 +378,7 @@ cflags_dll  = $(bld_cc_sys) $(common_cflags) $(common_flags) $(common_cflags_lib
 cflags_wind = $(cflags_gen)
 
 # options for linking
-ldflags1 = $(common_ldflags) -Wl,-Map,$^&.map
+ldflags1 = $(common_ldflags) -Wl,-map,$^&.map
 
 ldflags_gen  = $(cl_libs_gen) $(extra_ldflags) $(bld_ldflags_$(proj_type))
 ldflags_dll  = $(cl_libs_dll) $(extra_ldflags_dll) $(bld_ldflags_dll_$(proj_type))


### PR DESCRIPTION
This patch set improves the build support for OS X hosts. It fixes various issues I encountered when trying to run `./build.sh` on OS X. It might not be completely correct yet:

```
bwrc -q -I.. -I"$WATCOM/bld/hdr/dos" -I"$WATCOM/bld/w32api/nt" -bt=nt -r ../restest.rc -fo=restest.res
```

seems to fail (abort) with a stack overflow, but the large majority of the build actually proceeds and succeeds.