### PR TITLE
std::streamsize type introduced.

### DIFF
--- a/bld/cpplib/iostream/cpp/flfconsf.cpp
+++ b/bld/cpplib/iostream/cpp/flfconsf.cpp
@@ -37,7 +37,7 @@
 
 namespace std {
 
-  filebuf::filebuf( filedesc fd, char *buf, int len ) : __file_handle( EOF ) {
+  filebuf::filebuf( filedesc fd, char *buf, streamsize len ) : __file_handle( EOF ) {
     attach( fd );
     setbuf( buf, len );
   }

--- a/bld/cpplib/iostream/cpp/flfname.txt
+++ b/bld/cpplib/iostream/cpp/flfname.txt
@@ -22,7 +22,7 @@ Semantics: Create a filebuf object that is connected to an open file.
 
 Filename: flfconsf.cpp
 Declaration:
-    std::filebuf::filebuf( filedesc fd, char *buf, int len ) : __file_handle( EOF ) 
+    std::filebuf::filebuf( filedesc fd, char *buf, streamsize len ) : __file_handle( EOF ) 
 Semantics: Create a filebuf object that is connected to an open file and
 	   that uses the buffer specified by buf and len.
 
@@ -75,7 +75,7 @@ Semantics: Handle allocating a buffer, if required.
 
 Filename: flfsetbf.cpp 
 Declaration:
-    streambuf *std::filebuf::setbuf( char *buf, int len ) 
+    streambuf *std::filebuf::setbuf( char *buf, streamsize len ) 
 Semantics: Set up the filebuf using the specified buffer.
 
 

--- a/bld/cpplib/iostream/cpp/flfsetbf.cpp
+++ b/bld/cpplib/iostream/cpp/flfsetbf.cpp
@@ -48,7 +48,7 @@ namespace std {
   // If the buffer is too small (<= DEFAULT_PUTBACK_SIZE), then it
   // cannot be used.
 
-  streambuf *filebuf::setbuf( char *buf, int len ) {
+  streambuf *filebuf::setbuf( char *buf, streamsize len ) {
 
     __lock_it( __b_lock );
     if( (fd() != EOF) && (base() != NULL) ) {

--- a/bld/cpplib/iostream/cpp/fsbconsf.cpp
+++ b/bld/cpplib/iostream/cpp/fsbconsf.cpp
@@ -44,7 +44,7 @@ namespace std {
   // non-default constructors since there are multiply-inherited derived
   // classes that will only call the default constructors anyway.
 
-  fstreambase::fstreambase( filedesc fd, char *buf, int len ) {
+  fstreambase::fstreambase( filedesc fd, char *buf, streamsize len ) {
 
     ios::init( &__flbuf );
     if( __flbuf.attach( fd ) == NULL ) {

--- a/bld/cpplib/iostream/cpp/fsbsetbf.cpp
+++ b/bld/cpplib/iostream/cpp/fsbsetbf.cpp
@@ -40,7 +40,7 @@ namespace std {
   // Attempt filebuf::setbuf() If something goes wrong, then set
   // "ios::failbit".
 
-  void fstreambase::setbuf( char *buf, int len ) {
+  void fstreambase::setbuf( char *buf, streamsize len ) {
 
     filebuf *fb;
 

--- a/bld/cpplib/iostream/cpp/fstconsf.cpp
+++ b/bld/cpplib/iostream/cpp/fstconsf.cpp
@@ -37,7 +37,7 @@
 
 namespace std {
 
-  fstream::fstream( filedesc fd, char *buf, int len )
+  fstream::fstream( filedesc fd, char *buf, streamsize len )
     : fstreambase( fd, buf, len ) {
   }
 

--- a/bld/cpplib/iostream/cpp/fstname.txt
+++ b/bld/cpplib/iostream/cpp/fstname.txt
@@ -24,7 +24,7 @@ Semantics: Construct an fstreambase that is initialized and attached to the
 
 Filename: fsbconsf.cpp
 Declaration: 
-    std::fstreambase::fstreambase( filedesc fd, char *buf, int len )
+    std::fstreambase::fstreambase( filedesc fd, char *buf, streamsize len )
 Semantics: Construct an fstreambase that is initialized and attached to the
 	   specified file, using the specified buf.
 
@@ -55,7 +55,7 @@ Semantics: Open the named file.
 
 Filename: fsbsetbf.cpp
 Declaration: 
-    void std::fstreambase::setbuf( char *buf, int len )
+    void std::fstreambase::setbuf( char *buf, streamsize len )
 Semantics: Attempt filebuf::setbuf()
 
 
@@ -87,7 +87,7 @@ Semantics: Construct an ifstream that is initialized and attached to the
 
 Filename: ifsconsf.cpp
 Declaration: 
-    std::ifstream::ifstream( filedesc fd, char *buf, int len )
+    std::ifstream::ifstream( filedesc fd, char *buf, streamsize len )
             : fstreambase( fd, buf, len )
 Semantics: Construct an ifstream that is initialized and attached to the
 	   specified file, using the specified buf.
@@ -126,7 +126,7 @@ Semantics: Construct an ofstream that is initialized and attached to the
 
 Filename: ofsconsf.cpp
 Declaration: 
-    std::ofstream::ofstream( filedesc fd, char *buf, int len )
+    std::ofstream::ofstream( filedesc fd, char *buf, streamsize len )
             : fstreambase( fd, buf, len )
 Semantics: Construct an ofstream that is initialized and attached to the
 	   specified file, using the specified buf.
@@ -165,7 +165,7 @@ Semantics: Construct an fstream that is initialized and attached to the
 
 Filename: fstconsf.cpp
 Declaration: 
-    std::fstream::fstream( filedesc fd, char *buf, int len )
+    std::fstream::fstream( filedesc fd, char *buf, streamsize len )
            : fstreambase( fd, buf, len )
 Semantics: Construct an fstream that is initialized and attached to the
 	   specified file, using the specified buf.

--- a/bld/cpplib/iostream/cpp/ifsconsf.cpp
+++ b/bld/cpplib/iostream/cpp/ifsconsf.cpp
@@ -37,7 +37,7 @@
 
 namespace std {
 
-  ifstream::ifstream( filedesc fd, char *buf, int len )
+  ifstream::ifstream( filedesc fd, char *buf, streamsize len )
     : fstreambase( fd, buf, len ) {
   }
 

--- a/bld/cpplib/iostream/cpp/isscochz.cpp
+++ b/bld/cpplib/iostream/cpp/isscochz.cpp
@@ -40,7 +40,7 @@ namespace std {
   // Construct an istrstream that reads from the characters starting at
   // str for length size.
 
-  istrstream::istrstream( char *str, int size )
+  istrstream::istrstream( char *str, streamsize size )
     : strstreambase( str, size, NULL ) {
   }
 

--- a/bld/cpplib/iostream/cpp/isscoscz.cpp
+++ b/bld/cpplib/iostream/cpp/isscoscz.cpp
@@ -40,7 +40,7 @@ namespace std {
   // Construct an istrstream that reads from the characters starting at
   // str for length size.
 
-  istrstream::istrstream( signed char *str, int size )
+  istrstream::istrstream( signed char *str, streamsize size )
     : strstreambase( (char *)str, size, NULL ) {
   }
 

--- a/bld/cpplib/iostream/cpp/isscoucz.cpp
+++ b/bld/cpplib/iostream/cpp/isscoucz.cpp
@@ -40,7 +40,7 @@ namespace std {
   // Construct an istrstream that reads from the characters starting at
   // str for length size.
 
-  istrstream::istrstream( unsigned char *str, int size )
+  istrstream::istrstream( unsigned char *str, streamsize size )
     : strstreambase( (char *)str, size, NULL ) {
   }
 

--- a/bld/cpplib/iostream/cpp/istdread.cpp
+++ b/bld/cpplib/iostream/cpp/istdread.cpp
@@ -41,10 +41,10 @@ namespace std {
 
   // Implementation of read.
 
-  istream &istream::do_read( char *buf, int len ) {
+  istream &istream::do_read( char *buf, streamsize len ) {
 
     __lock_it( __i_lock );
-    int offset = rdbuf()->sgetn( buf, len );
+    streamsize offset = rdbuf()->sgetn( buf, len );
     if( offset < len ) {
 #if 0
         setstate( ios::failbit );

--- a/bld/cpplib/iostream/cpp/istgalin.cpp
+++ b/bld/cpplib/iostream/cpp/istgalin.cpp
@@ -44,8 +44,8 @@
 // added).
 //
 // Used by:
-//    get( char *buf, int len, char delim )
-//    getline( char *buf, int len, char delim )
+//    get( char *buf, streamsize len, char delim )
+//    getline( char *buf, streamsize len, char delim )
 //
 // NOTE: Borland sets eofbit only. A full buffer just stops reading. If
 //       something has been read, set eofbit anyway.
@@ -64,12 +64,12 @@
 
 ios::iostate __getaline( std::istream &istrm,
                          char *buf,
-                         int len,
+                         std::streamsize len,
                          char delim,
                          int is_get,
-                         int &chars_read ) {
+                         std::streamsize &chars_read ) {
     int           c;
-    int           offset;
+    std::streamsize    offset;
     ios::iostate  state = 0;
     streambuf    *sb;
 

--- a/bld/cpplib/iostream/cpp/istgbase.cpp
+++ b/bld/cpplib/iostream/cpp/istgbase.cpp
@@ -40,7 +40,7 @@
 #include "lock.h"
 #include "isthdr.h"
 
-std::ios::iostate __getbase( std::streambuf *sb, int &base, int &offset ) {
+std::ios::iostate __getbase( std::streambuf *sb, int &base, std::streamsize &offset ) {
 
     int ch;
 

--- a/bld/cpplib/iostream/cpp/istgetul.cpp
+++ b/bld/cpplib/iostream/cpp/istgetul.cpp
@@ -47,12 +47,12 @@ std::ios::iostate __getunsignedlong( std::streambuf *sb,
                                      std::ios::fmtflags format )
 {
 
-    unsigned long  number;
+    unsigned long       number;
     std::ios::iostate   state;
-    char           sign;
-    int            base;
-    int            offset;
-    int            ch;
+    char                sign;
+    int                 base;
+    std::streamsize     offset;
+    int                 ch;
 
     state = std::ios::goodbit;
     offset = 0;

--- a/bld/cpplib/iostream/cpp/istgline.cpp
+++ b/bld/cpplib/iostream/cpp/istgline.cpp
@@ -40,7 +40,7 @@
 
 namespace std {
 
-  istream &istream::getline( char *buf, int len, char delim ) {
+  istream &istream::getline( char *buf, streamsize len, char delim ) {
     ios::iostate state;
 
     __lock_it( __i_lock );

--- a/bld/cpplib/iostream/cpp/istgnm64.cpp
+++ b/bld/cpplib/iostream/cpp/istgnm64.cpp
@@ -65,7 +65,7 @@ static unsigned __int64 const overFlowMasks[] = {
 std::ios::iostate __getnumberint64( std::streambuf *sb,
                                     unsigned __int64 &number,
                                     int base,
-                                    int &offset ) {
+                                    std::streamsize &offset ) {
 
     unsigned __int64  result;
     unsigned __int64  overflow;

--- a/bld/cpplib/iostream/cpp/istgnum.cpp
+++ b/bld/cpplib/iostream/cpp/istgnum.cpp
@@ -65,7 +65,7 @@ static unsigned long const overFlowMasks[] = {
 std::ios::iostate __getnumber( std::streambuf *sb,
                                unsigned long &number,
                                int base,
-                               int &offset ) {
+                               std::streamsize &offset ) {
 
     unsigned long  result;
     unsigned long  overflow;

--- a/bld/cpplib/iostream/cpp/istgpch.cpp
+++ b/bld/cpplib/iostream/cpp/istgpch.cpp
@@ -40,7 +40,7 @@
 
 namespace std {
 
-  istream &istream::get( char *buf, int len, char delim ) {
+  istream &istream::get( char *buf, streamsize len, char delim ) {
     ios::iostate state;
 
     __lock_it( __i_lock );

--- a/bld/cpplib/iostream/cpp/istgstf.cpp
+++ b/bld/cpplib/iostream/cpp/istgstf.cpp
@@ -46,7 +46,7 @@ namespace std {
   istream &istream::get( streambuf &tgt_sb, char delim ) {
     streambuf *src_sb;
     int        c;
-    int        offset;
+    streamsize offset;
 
     __lock_it( __i_lock );
     if( !ipfx( 1 ) ) {

--- a/bld/cpplib/iostream/cpp/istgtu64.cpp
+++ b/bld/cpplib/iostream/cpp/istgtu64.cpp
@@ -49,10 +49,10 @@ std::ios::iostate __getunsignedint64( std::streambuf *sb,
 
     unsigned __int64  number;
     std::ios::iostate state;
-    char           sign;
-    int            base;
-    int            offset;
-    int            ch;
+    char              sign;
+    int               base;
+    std::streamsize   offset;
+    int               ch;
 
     state = std::ios::goodbit;
     offset = 0;

--- a/bld/cpplib/iostream/cpp/istignor.cpp
+++ b/bld/cpplib/iostream/cpp/istignor.cpp
@@ -45,7 +45,7 @@ namespace std {
   // not count ignored characters and will continue ignoring until the
   // delimiter is found.
 
-  istream &istream::ignore( int n, int delim ) {
+  istream &istream::ignore( streamsize n, int delim ) {
 
     int c;
 

--- a/bld/cpplib/iostream/cpp/istname.txt
+++ b/bld/cpplib/iostream/cpp/istname.txt
@@ -43,6 +43,11 @@ Semantics: *this is an istream that has been initialized, and may or may not
            have a streambuf associated with it.
            Associate the streambuf found in "istrm" with the stream.
 
+Filename: istdread.cpp
+Declaration: 
+    std::istream &std::istream::do_read( char *buf, streamsize len )
+Semantics: Read up to "len" characters from the stream and store them in
+	   buffer "buf".
 
 Filename: istipfx.cpp
 Declaration: 
@@ -91,6 +96,12 @@ Declaration:
             unsigned long maxval, signed long minval, ios::fmtflags format )
 
 
+Filename: istgtu64.cpp
+Declaration:
+    ios::iostate __getunsignedint64( streambuf *sb, unsigned int64 &value, 
+            unsigned int64 maxval, signed int64 minval, ios::fmtflags format )
+
+
 Filename: istgsign.cpp
 Declaration: 
     ios::iostate __getsign( streambuf *sb, char &sign, int &base )
@@ -99,17 +110,25 @@ Semantics: Examine the input for a + or - sign character.
 
 Filename: istgbase.cpp
 Declaration: 
-    ios::iostate __getbase( streambuf *sb, int &base, int &offset )
+    ios::iostate __getbase( streambuf *sb, int &base, streamsize &offset )
+
+
+Filename: istgnm64.cpp
+Declaration: 
+    ios::iostate ____getnumberint64( streambuf *sb, unsigned __int64 &number,
+    int base, streamsize &offset )
+Semantics: Extract digits from the stream.
+           Stop when a non-digit is found, leaving the non-digit in the stream.
+           As digits are read, convert to an "unsigned int64".
 
 
 Filename: istgnum.cpp
 Declaration: 
     ios::iostate __getnumber( streambuf *sb, unsigned long &number,
-    int base, int &offset ) 
+    int base, streamsize &offset ) 
 Semantics: Extract digits from the stream.
            Stop when a non-digit is found, leaving the non-digit in the stream.
            As digits are read, convert to an "unsigned long".
-
 
 Filename: istexslo.cpp
 Declaration: 
@@ -158,8 +177,8 @@ Semantics: Extract a single character and store it in "ch".
 
 Filename: istgalin.cpp
 Declaration: 
-    ios::iostate __getaline( std::istream &istrm, char *buf, int len,
-    char delim, int is_get, int &chars_read ) 
+    ios::iostate __getaline( std::istream &istrm, char *buf, streamsize len,
+    char delim, int is_get, streamsize &chars_read ) 
 Semantics: Read characters into buffer "buf".
            At most "len - 1" characters are read, and a 0 is added at the end.
            If "delim" is encountered, it is left in the stream and the read is
@@ -168,17 +187,17 @@ Semantics: Read characters into buffer "buf".
 
 Filename: istgpch.cpp
 Declaration: 
-    std::istream &std::istream::get( char *buf, int len, char delim )
+    std::istream &std::istream::get( char *buf, streamsize len, char delim )
 
 
 Filename: istgline.cpp
 Declaration: 
-    std::istream &std::istream::getline( char *buf, int len, char delim )
+    std::istream &std::istream::getline( char *buf, streamsize len, char delim )
 
 
 Filename: istread.cpp
 Declaration: 
-    std::istream &std::istream::read( char *buf, int len )
+    std::istream &std::istream::read( char *buf, streamsize len )
 Semantics: Read up to "len" characters from the stream and store them in
 	   buffer "buf".
 
@@ -192,7 +211,7 @@ Semantics: Extract characters from our streambuf and store them into the
 
 Filename: istignor.cpp
 Declaration: 
-    std::istream &std::istream::ignore( int n, int delim )
+    std::istream &std::istream::ignore( streamsize n, int delim )
 Semantics: Ignore "n" characters, or until the specified delimiter is found,
            whichever comes first. If "delim" is EOF, don't look for a delimiter.
            As an extension, specifying a negative "n" value will not count

--- a/bld/cpplib/iostream/cpp/istread.cpp
+++ b/bld/cpplib/iostream/cpp/istread.cpp
@@ -42,7 +42,7 @@ namespace std {
   // Read up to "len" characters from the stream and store them in
   // buffer "buf".
 
-  istream &istream::read( char *buf, int len ) {
+  istream &istream::read( char *buf, streamsize len ) {
     __lock_it( __i_lock );
     if( ipfx1() ) {
         if( rdbuf()->in_avail() > len ) {

--- a/bld/cpplib/iostream/cpp/ofsconsf.cpp
+++ b/bld/cpplib/iostream/cpp/ofsconsf.cpp
@@ -37,7 +37,7 @@
 
 namespace std {
 
-  ofstream::ofstream( filedesc fd, char *buf, int len )
+  ofstream::ofstream( filedesc fd, char *buf, streamsize len )
     : fstreambase( fd, buf, len ) {
   }
 

--- a/bld/cpplib/iostream/cpp/ssbconsz.cpp
+++ b/bld/cpplib/iostream/cpp/ssbconsz.cpp
@@ -37,7 +37,7 @@
 
 namespace std {
 
-  strstreambase::strstreambase( char *str, int size, char *pstart )
+  strstreambase::strstreambase( char *str, streamsize size, char *pstart )
     : __strstrmbuf( str, size, pstart ) {
 
     ios::init( (streambuf *) &__strstrmbuf );

--- a/bld/cpplib/iostream/cpp/ssfdoall.cpp
+++ b/bld/cpplib/iostream/cpp/ssfdoall.cpp
@@ -46,11 +46,11 @@ namespace std {
 
   int strstreambuf::doallocate() {
 
-    char   *oldbuf;
-    int     oldbufsize;
-    char   *newbuf;
-    int     newbufsize;
-    size_t  base_offset, ptr_offset, end_offset;
+    char      *oldbuf;
+    streamsize oldbufsize;
+    char      *newbuf;
+    streamsize newbufsize;
+    size_t     base_offset, ptr_offset, end_offset;
 
     __lock_it( __b_lock );
     if( !__dynamic || __frozen ) {

--- a/bld/cpplib/iostream/cpp/ssfempsz.cpp
+++ b/bld/cpplib/iostream/cpp/ssfempsz.cpp
@@ -40,7 +40,7 @@ namespace std {
   // Create an empty strstreambuf that will use dynamic allocation of
   // the specified size.
 
-  strstreambuf::strstreambuf( int size ) {
+  strstreambuf::strstreambuf( streamsize size ) {
     __strstreambuf( NULL, 0, NULL );
     __allocation_size = size;
   }

--- a/bld/cpplib/iostream/cpp/ssfsetbf.cpp
+++ b/bld/cpplib/iostream/cpp/ssfsetbf.cpp
@@ -39,7 +39,7 @@ namespace std {
 
   // Just remember the size to allocate next time.
 
-  streambuf *strstreambuf::setbuf( char *, int size ) {
+  streambuf *strstreambuf::setbuf( char *, streamsize size ) {
     __lock_it( __b_lock );
     if( size > 0 ) {
         __allocation_size = size;

--- a/bld/cpplib/iostream/cpp/ssfstbuf.cpp
+++ b/bld/cpplib/iostream/cpp/ssfstbuf.cpp
@@ -53,7 +53,7 @@ namespace std {
   // Otherwise, it partitions the ptr/size area into a get area (from
   // ptr to pstart-1), and a put area (from pstart to ptr+size-1).
 
-  void strstreambuf::__strstreambuf( char *ptr, int size, char *pstart ) {
+  void strstreambuf::__strstreambuf( char *ptr, streamsize size, char *pstart ) {
     char *get;
     char *eget;
     char *put;

--- a/bld/cpplib/iostream/cpp/sstname.txt
+++ b/bld/cpplib/iostream/cpp/sstname.txt
@@ -3,7 +3,7 @@
 
 Filename: ssfempsz.cpp
 Declaration:
-    std::strstreambuf::strstreambuf( int size )
+    std::strstreambuf::strstreambuf( streamsize size )
 Semantics: Create an empty strstreambuf that will use dynamic allocation
            of the specified size.
 
@@ -17,7 +17,7 @@ Semantics: Create an empty strstreambuf that will use dynamic allocation
 
 Filename: ssfstbuf.cpp
 Declaration:
-    void std::strstreambuf::__strstreambuf( char *ptr, int size, char *pstart )
+    void std::strstreambuf::__strstreambuf( char *ptr, streamsize size, char *pstart )
 Semantics: Initialize a streambuf.
 
 
@@ -48,7 +48,7 @@ Semantics: The streambuf has decided that it needs more characters for input.
 
 Filename: ssfsetbf.cpp
 Declaration:
-    streambuf *std::strstreambuf::setbuf( char *, int size )
+    streambuf *std::strstreambuf::setbuf( char *, streamsize size )
 Semantics: Just remember the size to allocate next time.
 
 
@@ -94,7 +94,7 @@ Semantics: Construct a default strstreambase.
 
 Filename: ssbconsz.cpp
 Declaration:
-std::strstreambase::strstreambase( char *str, int size, char *pstart )
+std::strstreambase::strstreambase( char *str, streamsize size, char *pstart )
              : __strstrmbuf( str, size, pstart ) 
 
 
@@ -132,7 +132,7 @@ Semantics: Construct an istrstream that will read from the NULLCHAR-delimited
 
 Filename: isscochz.cpp
 Declaration:
-    std::istrstream::istrstream( char *str, int size )
+    std::istrstream::istrstream( char *str, streamsize size )
               : strstreambase( str, size, NULL )
 Semantics: Construct an istrstream that reads from the characters starting at
            str for length size.
@@ -140,7 +140,7 @@ Semantics: Construct an istrstream that reads from the characters starting at
 
 Filename: isscoscz.cpp
 Declaration:
-    std::istrstream::istrstream( signed char *str, int size )
+    std::istrstream::istrstream( signed char *str, streamsize size )
               : strstreambase( (char *)str, size, NULL )
 Semantics: Construct an istrstream that reads from the characters starting at
            str for length size.
@@ -148,7 +148,7 @@ Semantics: Construct an istrstream that reads from the characters starting at
 
 Filename: isscoucz.cpp
 Declaration:
-    std::istrstream::istrstream( unsigned char *str, int size )
+    std::istrstream::istrstream( unsigned char *str, streamsize size )
               : strstreambase( (char *)str, size, NULL )
 Semantics: Construct an istrstream that reads from the characters starting at
 	   str for length size.

--- a/bld/cpplib/iostream/cpp/stfconb.cpp
+++ b/bld/cpplib/iostream/cpp/stfconb.cpp
@@ -42,7 +42,7 @@ namespace std {
   // Construct an empty streambuf using the given buf. If buffer is NULL
   // or len is 0, then the streambuf is unbuffered.
 
-  streambuf::streambuf( char *buf, int len ) {
+  streambuf::streambuf( char *buf, streamsize len ) {
 
 #ifdef __SW_BM
     __b_lock = __get_next_streambuf_lock();

--- a/bld/cpplib/iostream/cpp/stfdsgtn.cpp
+++ b/bld/cpplib/iostream/cpp/stfdsgtn.cpp
@@ -44,10 +44,10 @@ namespace std {
   // Return the "len" characters starting at get_ptr. If there aren't
   // enough characters, return as many as possible. Advance the get_ptr.
 
-  int streambuf::do_sgetn( char *buf, int len ) {
+  streamsize streambuf::do_sgetn( char *buf, streamsize len ) {
 
-    int available;
-    int returned;
+    streamsize available;
+    streamsize returned;
 
     returned = 0;
     __lock_it( __b_lock );

--- a/bld/cpplib/iostream/cpp/stfdspun.cpp
+++ b/bld/cpplib/iostream/cpp/stfdspun.cpp
@@ -45,10 +45,10 @@ namespace std {
   // Return 0 if not possible. Return the number of characters
   // successfully put.
 
-  int streambuf::do_sputn( char const *buf, int len ) {
+  streamsize streambuf::do_sputn( char const *buf, streamsize len ) {
 
-    int waiting;
-    int written;
+    streamsize waiting;
+    streamsize written;
 
     written = 0;
     __lock_it( __b_lock );

--- a/bld/cpplib/iostream/cpp/stfname.txt
+++ b/bld/cpplib/iostream/cpp/stfname.txt
@@ -9,11 +9,16 @@ Filename: stfdbp.cpp
 Declaration:
     void std::streambuf::dbp()
 
-Filename: stfconde.cpp
+Filename: stfconb.cpp
 Declaration:
-    std::streambuf::streambuf( char *buf, int len )
+    std::streambuf::streambuf( char *buf, streamsize len )
 Semantics: Construct an empty streambuf using the given buf.
            If buffer is NULL or len is 0, then the streambuf is unbuffered.
+
+Filename: stfconde.cpp
+Declaration:
+    std::streambuf::streambuf()
+Semantics: Construct an empty streambuf.
 
 Filename: stfdestr.cpp
 Declaration:
@@ -36,7 +41,7 @@ Semantics: Do the allocation required if allocate() thinks it's needed.
 
 Filename: stfdsgtn.cpp
 Declaration:
-    int std::streambuf::do_sgetn( char *buf, int len )
+    streamsize std::streambuf::do_sgetn( char *buf, streamsize len )
 Semantics: Return the "len" characters starting at get_ptr.
            If there aren't enough characters, return as many as possible.
            Advance the get_ptr.
@@ -44,7 +49,7 @@ Semantics: Return the "len" characters starting at get_ptr.
 
 Filename: stfdspun.cpp
 Declaration:
-    int std::streambuf::do_sputn( char const *buf, int len )
+    streamsize std::streambuf::do_sputn( char const *buf, streamsize len )
 Semantics: Write the "len" characters starting at "buf" into the put area.
            Return 0 if not possible.
            Return the number of characters successfully put.
@@ -60,7 +65,7 @@ Semantics: Default virtual function to handle failure of sputbackc.
 
 Filename: stfsbuf.cpp
 Declaration:
-    std::streambuf *std::streambuf::setbuf( char *buf, int len )
+    std::streambuf *std::streambuf::setbuf( char *buf, streamsize len )
 Semantics: Set up a new reserve area using the specified buffer and length.
            If a reserve area is already present, then ignore the offered
 	   buffer. If buffer is NULL or len is 0, then the streambuf is

--- a/bld/cpplib/iostream/cpp/stfsbuf.cpp
+++ b/bld/cpplib/iostream/cpp/stfsbuf.cpp
@@ -44,7 +44,7 @@ namespace std {
   // a reserve area is already present, then ignore the offered buffer.
   // If buffer is NULL or len is 0, then the streambuf is unbuffered.
 
-  streambuf *streambuf::setbuf( char *buf, int len ) {
+  streambuf *streambuf::setbuf( char *buf, streamsize len ) {
 
     __lock_it( __b_lock );
     if( base() != NULL ) {

--- a/bld/cpplib/iostream/h/isthdr.h
+++ b/bld/cpplib/iostream/h/isthdr.h
@@ -33,10 +33,10 @@
 #define _ISTHDR_H_INCLUDED
 
 #define ERR_CHAR    '\0'
-extern std::ios::iostate __getaline( std::istream &, char *, int, char, int, int & );
+extern std::ios::iostate __getaline( std::istream &, char *, std::streamsize, char, int, std::streamsize & );
 extern std::ios::iostate __getsign( std::streambuf *, char & );
-extern std::ios::iostate __getbase( std::streambuf *, int &, int & );
-extern std::ios::iostate __getnumber( std::streambuf *, unsigned long &, int, int & );
+extern std::ios::iostate __getbase( std::streambuf *, int &, std::streamsize & );
+extern std::ios::iostate __getnumber( std::streambuf *, unsigned long &, int, std::streamsize & );
 extern std::ios::iostate __getunsignedlong( std::streambuf *,
                                             unsigned long &,
                                             unsigned long,

--- a/bld/hdr/watcom/fstream.mh
+++ b/bld/hdr/watcom/fstream.mh
@@ -63,7 +63,7 @@ namespace std {
 
     filebuf();
     filebuf( filedesc __fd );
-    filebuf( filedesc __fd, char *__buf, int __len );
+    filebuf( filedesc __fd, char *__buf, streamsize __len );
    ~filebuf();
 
     int       is_open() const;
@@ -77,7 +77,7 @@ namespace std {
     virtual int        pbackfail( int __c );
     virtual int        overflow( int = EOF );
     virtual int        underflow();
-    virtual streambuf *setbuf( char *__buf, int __len );
+    virtual streambuf *setbuf( char *__buf, streamsize __len );
     virtual streampos  seekoff( streamoff     __offset,
                                 ios::seekdir  __direction,
                                 ios::openmode __ignored );
@@ -113,7 +113,7 @@ namespace std {
                     int            __prot = filebuf::openprot );
     void      close();
     filebuf  *rdbuf() const;
-    void      setbuf( char *__buf, int __len );
+    void      setbuf( char *__buf, streamsize __len );
 
   protected:
     fstreambase();
@@ -121,7 +121,7 @@ namespace std {
                  ios::openmode  __mode,
                  int            __prot = filebuf::openprot );
     fstreambase( filedesc __fd );
-    fstreambase( filedesc __fd, char *__buf, int __len );
+    fstreambase( filedesc __fd, char *__buf, streamsize __len );
     ~fstreambase();
 
   private:
@@ -155,7 +155,7 @@ namespace std {
               ios::openmode  __mode = ios::in,
               int            __prot = filebuf::openprot );
     ifstream( filedesc __fd );
-    ifstream( filedesc __fd, char *__buf, int __len );
+    ifstream( filedesc __fd, char *__buf, streamsize __len );
     ~ifstream();
 
     void open( char const    *__name,
@@ -178,7 +178,7 @@ namespace std {
               ios::openmode  __mode = ios::out,
               int            __prot = filebuf::openprot );
     ofstream( filedesc __fd );
-    ofstream( filedesc __fd, char *__buf, int __len );
+    ofstream( filedesc __fd, char *__buf, streamsize __len );
     ~ofstream();
 
     void open( char const    *__name,
@@ -201,7 +201,7 @@ namespace std {
              ios::openmode  __mode = ios::in|ios::out,
              int            __prot = filebuf::openprot );
     fstream( filedesc __fd );
-    fstream( filedesc __fd, char *__buf, int __len );
+    fstream( filedesc __fd, char *__buf, streamsize __len );
     ~fstream();
 
     void open( char const    *__name,

--- a/bld/hdr/watcom/ios.mh
+++ b/bld/hdr/watcom/ios.mh
@@ -58,6 +58,9 @@ namespace std {
   // Offset from current position in the stream:
   typedef long streamoff;
 
+  // Sizes and character counts in streams.
+  typedef int streamsize;
+
   // These are referred to in class ios, but are defined later, or elsewhere:
   class _WPRTLINK istream;
   class _WPRTLINK ostream;
@@ -162,10 +165,10 @@ namespace std {
     fmtflags   flags() const;
     char       fill( char __fillchar );
     char       fill() const;
-    int        precision( int __precision );
-    int        precision() const;
-    int        width( int __width );
-    int        width() const;
+    streamsize precision( streamsize __precision );
+    streamsize precision() const;
+    streamsize width( streamsize __width );
+    streamsize width() const;
     long      &iword( int __index );
     void     *&pword( int __index );
 
@@ -188,8 +191,8 @@ namespace std {
     long       __format_flags;
     int        __error_state;
     int        __enabled_exceptions;
-    int        __float_precision;
-    int        __field_width;
+    streamsize __float_precision;
+    streamsize __field_width;
     void      *__xalloc_list;
     char       __fill_character;
 
@@ -281,25 +284,25 @@ namespace std {
     return( __fill_character );
   }
 
-  inline int ios::precision( int __precision ) {
+  inline streamsize ios::precision( streamsize __precision ) {
     __lock_it( __i_lock );
-    int __old_precision = __float_precision;
+    streamsize __old_precision = __float_precision;
     __float_precision   = __precision;
     return( __old_precision );
   }
 
-  inline int ios::precision() const {
+  inline streamsize ios::precision() const {
     return( __float_precision );
   }
 
-  inline int ios::width( int __width ) {
+  inline streamsize ios::width( streamsize __width ) {
     __lock_it( __i_lock );
-    int __old_width = __field_width;
+    streamsize __old_width = __field_width;
     __field_width   = __width;
     return( __old_width );
   }
 
-  inline int ios::width() const {
+  inline streamsize ios::width() const {
     return( __field_width );
   }
 

--- a/bld/hdr/watcom/istream.mh
+++ b/bld/hdr/watcom/istream.mh
@@ -85,25 +85,25 @@ namespace std {
     int        ipfx( int __noskipws = 0 );
     void       isfx();
     int        get();
-    istream   &get(          char *__buf, int __len, char __delim = '\n' );
-    istream   &get(   signed char *__buf, int __len, char __delim = '\n' );
-    istream   &get( unsigned char *__buf, int __len, char __delim = '\n' );
+    istream   &get(          char *__buf, streamsize __len, char __delim = '\n' );
+    istream   &get(   signed char *__buf, streamsize __len, char __delim = '\n' );
+    istream   &get( unsigned char *__buf, streamsize __len, char __delim = '\n' );
     istream   &get(          char &__c );
     istream   &get(   signed char &__c );
     istream   &get( unsigned char &__c );
     istream   &get( streambuf &__sb, char __delim = '\n' );
-    istream   &getline(          char *__buf, int __len, char __delim = '\n' );
-    istream   &getline(   signed char *__buf, int __len, char __delim = '\n' );
-    istream   &getline( unsigned char *__buf, int __len, char __delim = '\n' );
-    istream   &ignore( int __num = 1, int __delim = EOF );
-    istream   &read(          char *__buf, int __len );
-    istream   &read(   signed char *__buf, int __len );
-    istream   &read( unsigned char *__buf, int __len );
+    istream   &getline(          char *__buf, streamsize __len, char __delim = '\n' );
+    istream   &getline(   signed char *__buf, streamsize __len, char __delim = '\n' );
+    istream   &getline( unsigned char *__buf, streamsize __len, char __delim = '\n' );
+    istream   &ignore( streamsize __num = 1, int __delim = EOF );
+    istream   &read(          char *__buf, streamsize __len );
+    istream   &read(   signed char *__buf, streamsize __len );
+    istream   &read( unsigned char *__buf, streamsize __len );
     istream   &seekg( streampos __position );
     istream   &seekg( streamoff __offset, ios::seekdir __direction );
     istream   &putback( char __c );
     streampos  tellg();
-    int        gcount() const;
+    streamsize gcount() const;
     int        peek();
     int        sync();
 
@@ -112,13 +112,13 @@ namespace std {
     void     eatwhite();
     istream &do_get( char &__c );
     istream &do_rshift( char &__c );
-    istream &do_read( char *__buf, int __len );
+    istream &do_read( char *__buf, streamsize __len );
     int      ipfx0( void );
     int      ipfx1( void );
     int      do_ipfx( int __noskipws );
 
   private:
-    int __last_read_length;
+    streamsize __last_read_length;
   };
 :include poppack.sp
 
@@ -153,12 +153,12 @@ namespace std {
     return( *this >> (char &) __c );
   }
 
-  inline istream &istream::get( signed char *__buf, int __len, char __delim ) {
+  inline istream &istream::get( signed char *__buf, streamsize __len, char __delim ) {
     return( get( (char *)__buf, __len, __delim ) );
   }
 
   inline istream &istream::get( unsigned char *__buf,
-                                int __len,
+                                streamsize __len,
                                 char __delim ) {
     return( get( (char *)__buf, __len, __delim ) );
   }
@@ -189,19 +189,19 @@ namespace std {
   }
 
   inline istream &istream::getline( signed char *__buf,
-                                    int __len,
+                                    streamsize __len,
                                     char __delim ) {
     return( getline( (char *)__buf, __len, __delim ) );
   }
 
   inline istream &istream::getline( unsigned char *__buf,
-                                    int __len,
+                                    streamsize __len,
                                     char __delim ) {
     return( getline( (char *)__buf, __len, __delim ) );
   }
 
 #ifdef __BIG_INLINE__
-  inline istream &istream::read( char *__buf, int __len ) {
+  inline istream &istream::read( char *__buf, streamsize __len ) {
     __lock_it( __i_lock );
     if( ipfx1() ) {
         if( rdbuf()->in_avail() > __len ) {
@@ -217,11 +217,11 @@ namespace std {
   }
 #endif
 
-  inline istream &istream::read( signed char *__buf, int __len ) {
+  inline istream &istream::read( signed char *__buf, streamsize __len ) {
     return( read( (char *) __buf, __len ) );
   }
 
-  inline istream &istream::read( unsigned char *__buf, int __len ) {
+  inline istream &istream::read( unsigned char *__buf, streamsize __len ) {
     return( read( (char *) __buf, __len ) );
   }
 
@@ -238,7 +238,7 @@ namespace std {
   inline void istream::isfx() {
   }
 
-  inline int istream::gcount() const {
+  inline streamsize istream::gcount() const {
     return( __last_read_length );
   }
 

--- a/bld/hdr/watcom/ostream.mh
+++ b/bld/hdr/watcom/ostream.mh
@@ -81,9 +81,9 @@ namespace std {
     ostream   &put(          char __c );
     ostream   &put(   signed char __c );
     ostream   &put( unsigned char __c );
-    ostream   &write(          char const *__buf, int __len );
-    ostream   &write(   signed char const *__buf, int __len );
-    ostream   &write( unsigned char const *__buf, int __len );
+    ostream   &write(          char const *__buf, streamsize __len );
+    ostream   &write(   signed char const *__buf, streamsize __len );
+    ostream   &write( unsigned char const *__buf, streamsize __len );
     ostream   &flush();
     ostream   &seekp( streampos __position );
     ostream   &seekp( streamoff __offset, ios::seekdir __direction );
@@ -180,7 +180,7 @@ namespace std {
   }
 
 #ifdef __BIG_INLINE__
-  inline ostream &ostream::write( char const *__buf, int __len ) {
+  inline ostream &ostream::write( char const *__buf, streamsize __len ) {
     __lock_it( __i_lock );
     if( opfx() ) {
         if( __len  ) {
@@ -194,11 +194,11 @@ namespace std {
   }
 #endif
 
-  inline ostream &ostream::write( signed char const *__buf, int __len ) {
+  inline ostream &ostream::write( signed char const *__buf, streamsize __len ) {
     return( write( (char const *) __buf, __len ) );
   }
 
-  inline ostream &ostream::write( unsigned char const *__buf, int __len ) {
+  inline ostream &ostream::write( unsigned char const *__buf, streamsize __len ) {
     return( write( (char const *) __buf, __len ) );
   }
 

--- a/bld/hdr/watcom/streambu.mh
+++ b/bld/hdr/watcom/streambu.mh
@@ -56,10 +56,10 @@ namespace std {
 :include pshpackl.sp
   class _WPRTLINK streambuf {
   public:
-    int  in_avail() const;
+    streamsize  in_avail() const;
     int  out_waiting() const;
     int  snextc();
-    int  sgetn( char *__buf, int __len );
+    streamsize sgetn( char *__buf, streamsize __len );
     int  speekc();
     int  sgetc();
     int  sgetchar();
@@ -67,15 +67,15 @@ namespace std {
     void stossc();
     int  sputbackc( char __c );
     int  sputc( int __c );
-    int  sputn( char const *__buf, int __len );
+    streamsize sputn( char const *__buf, streamsize __len );
     void dbp();
 
-    virtual int        do_sgetn( char *__buf, int __len );
-    virtual int        do_sputn( char const *__buf, int __len );
+    virtual streamsize do_sgetn( char *__buf, streamsize __len );
+    virtual streamsize do_sputn( char const *__buf, streamsize __len );
     virtual int        pbackfail( int __ignored );
     virtual int        overflow( int = EOF ) = 0;
     virtual int        underflow() = 0;
-    virtual streambuf *setbuf( char *__buf, int __len );
+    virtual streambuf *setbuf( char *__buf, streamsize __len );
     virtual streampos  seekoff( streamoff     __ignored1,
                                 ios::seekdir  __ignored2,
                                 ios::openmode __ignored3 = ios::in | ios::out );
@@ -213,9 +213,9 @@ namespace std {
 
   // *********************** Inline input functions **************************
 
-  inline int streambuf::in_avail() const {
+  inline streamsize streambuf::in_avail() const {
     __lock_it( __b_lock );
-    return( (int)(__get_end - __get_ptr) );
+    return( (streamsize)(__get_end - __get_ptr) );
   }
 
   inline int streambuf::sgetchar() {
@@ -244,7 +244,7 @@ namespace std {
     return( speekc() );
   }
 
-  inline int streambuf::sgetn( char *__buf, int __len ) {
+  inline streamsize streambuf::sgetn( char *__buf, streamsize __len ) {
     __lock_it( __b_lock );
     if( __len < (int)(__get_end - __get_ptr) ) {
         memcpy( __buf, __get_ptr, __len );
@@ -280,7 +280,7 @@ namespace std {
                                      : __char_to_int( *__put_ptr++ = (char)__c ) );
   }
 
-  inline int streambuf::sputn( char const *__buf, int __len ) {
+  inline streamsize streambuf::sputn( char const *__buf, streamsize __len ) {
     __lock_it( __b_lock );
     if( __len < (int)(__put_end - __put_ptr) ) {
         memcpy( __put_ptr, __buf, __len );

--- a/bld/hdr/watcom/strstrea.mh
+++ b/bld/hdr/watcom/strstrea.mh
@@ -50,18 +50,18 @@ namespace std {
   class _WPRTLINK strstreambuf : public streambuf {
   public:
     strstreambuf();
-    strstreambuf( int __allocation_size );
+    strstreambuf( streamsize __allocation_size );
     strstreambuf( void *(*__alloc_fn)( long ), void (*__free_fn)( void * ) );
-    strstreambuf( char *__str, int __size, char *__pstart = NULL );
+    strstreambuf( char *__str, streamsize __size, char *__pstart = NULL );
    ~strstreambuf();
 
-    int   alloc_size_increment( int __increment );
-    void  freeze( int __freeze = 1 );
-    char *str();
+    streamsize alloc_size_increment( streamsize __increment );
+    void       freeze( int __freeze = 1 );
+    char      *str();
 
     virtual int        overflow( int = EOF );
     virtual int        underflow();
-    virtual streambuf *setbuf( char *__ignored, int __allocation_size );
+    virtual streambuf *setbuf( char *__ignored, streamsize __allocation_size );
     virtual streampos  seekoff( streamoff     __offset,
                                 ios::seekdir  __direction,
                                 ios::openmode __mode );
@@ -71,11 +71,11 @@ namespace std {
     virtual int doallocate();
 
   private:
-    void  __strstreambuf( char *, int, char * );
+    void  __strstreambuf( char *, streamsize, char * );
 
     void *(*__alloc_fn)( long );
     void  (*__free_fn)( void * );
-    int   __allocation_size;
+    streamsize __allocation_size;
     int   __minbuf_size;
     unsigned  __frozen    : 1;
     unsigned  __dynamic   : 1;
@@ -88,14 +88,14 @@ namespace std {
   }
 
   inline strstreambuf::strstreambuf( char *__ptr,
-                                     int __size,
+                                     streamsize __size,
                                      char *__pstart ) {
     __strstreambuf( __ptr, __size, __pstart );
   }
 
-  inline int strstreambuf::alloc_size_increment( int __increment ) {
+  inline streamsize strstreambuf::alloc_size_increment( streamsize __increment ) {
     __lock_it( __b_lock );
-    int __old_allocation_size = __allocation_size;
+    streamsize __old_allocation_size = __allocation_size;
     __allocation_size        += __increment;
     return( __old_allocation_size );
   }
@@ -113,7 +113,7 @@ namespace std {
 
   protected:
     strstreambase();
-    strstreambase( char *__str, int __size, char *__pstart = NULL );
+    strstreambase( char *__str, streamsize __size, char *__pstart = NULL );
     ~strstreambase();
 
   private:
@@ -133,9 +133,9 @@ namespace std {
     istrstream(          char *__str );
     istrstream(   signed char *__str );
     istrstream( unsigned char *__str );
-    istrstream(          char *__str, int __size );
-    istrstream(   signed char *__str, int __size );
-    istrstream( unsigned char *__str, int __size );
+    istrstream(          char *__str, streamsize __size );
+    istrstream(   signed char *__str, streamsize __size );
+    istrstream( unsigned char *__str, streamsize __size );
    ~istrstream();
   };
 :include poppack.sp


### PR DESCRIPTION
I haven't tested that (compilation takes ages), but changes are quite straightforward: I just used streamsize typedef instead of int type directly wherever C++ standard says to use std::streamsize.

Again, without this change CMake could not be built, because it was using std::streamsize type not defined by the Watcom's C++ library.