### PR TITLE
Fix VIW exiting when pressing weird/system keys like the Windows key

### DIFF
--- a/bld/vi/win/getkey.c
+++ b/bld/vi/win/getkey.c
@@ -190,7 +190,7 @@ static vi_key ConvertWierdCharacter( WORD vk, WORD data )
 
     GetKeyboardState( keyboard_state );
     if( ToAscii( vk, scancode, keyboard_state, &newkey, 0 ) == 0 ) {
-        return( VI_KEY( NULL ) );
+        return( VI_KEY( DUMMY ) );
     }
 
     return( C2VIKEY( newkey ) );
@@ -221,10 +221,6 @@ vi_key MapVirtualKeyToVIKey( WORD vk, WORD data )
         t = vk - 'A';
         if( ctrldown && altdown ) {
             key = ConvertWierdCharacter( vk, data );
-            // check if found no translation:
-            if( key == 0 ) {
-                return( VI_KEY( DUMMY ) );
-            }
         } else if( ctrldown ) {
             key = VI_KEY( CTRL_A ) + t;
         } else if( shiftdown && capsdown ) {


### PR DESCRIPTION
After some refactoring/cleanup in the editor code about a year ago, the editor exits when pressing the Windows key (or any other key that is not a modified and does not correspond to an ascii code, like the Menu key).

This happens because the ConvertWierdCharacter function in getkey.c returns VI_KEY( NULL )  that slips through MapVirtualKeyToVIKey and a change about a year ago in key.c makes it exit when VI_KEY( NULL ) is found. Judging from the fact that in other places (e.g. readstr.c) there are explicit checks for NULL keys that are converted to DUMMY keys and that MapVirtualKeyToVIKey in getkey.c returns DUMMY instead of NULL when it doesn't know how to handle keys in other places, i assume the code in key.c works as expected and that ConvertWierdCharacter should return DUMMY instead of NULL.

ConvertWierdCharacter is only used twice and one of the uses had a NULL-to-DUMMY conversion, so this fix simplifies the code a little by making the function return DUMMY itself and removing the conversion.

This fixes the issue in question - the editor no longer exits when pressing the Windows or Menu keys.