### PR TITLE
Linux Multithreading and POSIX Thread Fixes

### DIFF
--- a/bld/clib/h/atomic.h
+++ b/bld/clib/h/atomic.h
@@ -33,9 +33,12 @@
 #ifndef _ATOMIC_H_INCLUDED
 #define _ATOMIC_H_INCLUDED
 
-#define __atomic_decrement(x)   __atomic_add(x, -1)
+extern void __atomic_increment( volatile int *i );
+extern void __atomic_decrement( volatile int *i );
 
 extern int __atomic_compare_and_swap( volatile int *__dest, int __expected, int __source );
+
+/* Returns 1 if successful, 0 if fails */
 extern int __atomic_add( volatile int *dest, int delta );
 
 #endif /* _ATOMIC_H_INCLUDED */

--- a/bld/clib/h/mthread.h
+++ b/bld/clib/h/mthread.h
@@ -69,6 +69,8 @@
   #elif defined( __LINUX__ )
     extern thread_data  *__LinuxAddThread( thread_data *tdata );
     extern void         __LinuxRemoveThread( void );
+    extern void         __LinuxSetThreadData( void *__data );
+    extern void         *__LinuxGetThreadData( );
   #elif defined( __RDOS__ ) /* || defined( __RDOSDEV__ ) */
     extern int          __RdosThreadInit( void );
     extern int          __RdosAddThread( thread_data * );

--- a/bld/clib/h/sys386.h
+++ b/bld/clib/h/sys386.h
@@ -305,7 +305,21 @@ typedef unsigned long       syscall_res;
 #define SYS_sched_setaffinity   241
 #define SYS_sched_getaffinity   242
 #define SYS_set_thread_area     243
-/* ... */
+#define SYS_get_thread_area     244
+#define SYS_io_setup            245
+#define SYS_io_destroy          246
+#define SYS_io_getevents        247
+#define SYS_io_submit           248
+#define SYS_io_cancel           249
+#define SYS_fadvise64           250
+/* 251 is not implemented */
+#define SYS_exit_group          252
+#define SYS_lookup_dcookie      253
+#define SYS_epoll_create        254
+#define SYS_epoll_ctl           255
+#define SYS_epoll_wait          256
+#define SYS_remap_file_pages    257
+#define SYS_set_tid_address     258
 #define SYS_timer_create        259
 #define SYS_timer_settime       260
 #define SYS_timer_gettime       261
@@ -315,6 +329,9 @@ typedef unsigned long       syscall_res;
 #define SYS_clock_gettime       265
 #define SYS_clock_getres        266
 #define SYS_clock_nanosleep     267
+#define SYS_statfs64            268
+#define SYS_fstatfs64           269
+#define SYS_tgkill              270
 
 /*
  * internal sub-numbers for SYS_socketcall
@@ -382,4 +399,5 @@ syscall_res sys_call5( u_long func, u_long r_ebx, u_long r_ecx, u_long r_edx, u_
     parm [eax] [ebx] [ecx] [edx] [esi] [edi]    \
     value [eax];
 
-#define _sys_exit(rc)   sys_call1n(SYS_exit, rc)
+#define _sys_exit_group(rc) sys_call1n(SYS_exit_group, rc)
+#define _sys_exit(rc)       sys_call1n(SYS_exit, rc)

--- a/bld/clib/linux/c/__futex.c
+++ b/bld/clib/linux/c/__futex.c
@@ -35,7 +35,7 @@
 #include "linuxsys.h"
 
 _WCRTLINK int __futex(volatile int *__address, int __operation, 
-                      int __value, void *__timeout)
+                      int __value, void *__timeout, int id)
 {
 syscall_res res;
 

--- a/bld/clib/linux/c/sem_init.c
+++ b/bld/clib/linux/c/sem_init.c
@@ -75,11 +75,15 @@ _WCRTLINK int sem_init( sem_t *sem, int pshared, unsigned int value )
         _RWD_errno = EINVAL;
         return( -1 );
     }
+    
+    // Debugging...
     if( pshared != 0 ) {
         _RWD_errno = ENOSYS;
         return( -1 );
     }
+    
     sem->value = value;
+    sem->futex = 1;
     return( 0 );
 }
 
@@ -99,4 +103,4 @@ static void __check_cmpxchg( void )
     }
 }
 
-AXI( __check_cmpxchg, INIT_PRIORITY_RUNTIME )
+AXI( __check_cmpxchg, INIT_PRIORITY_THREAD )

--- a/bld/clib/linux/c/sysconf.c
+++ b/bld/clib/linux/c/sysconf.c
@@ -183,9 +183,9 @@ _WCRTLINK long sysconf( int name )
         break;
     case _SC_THREAD_STACK_MIN:
         /* We don't actually have one, but we'll
-         * set the small, but acceptable, 1KB
+         * assume one page
          */
-        ret = (long)1024;
+        ret = (long)PAGE_SIZE;
         break;
     case _SC_THREAD_PRIORITY_SCHEDULING:
     case _SC_THREAD_PROCESS_SHARED:

--- a/bld/clib/linux/h/futex.h
+++ b/bld/clib/linux/h/futex.h
@@ -67,6 +67,6 @@
 #define FUTEX_CMP_REQUEUE_PI_PRIVATE    (FUTEX_CMP_REQUEUE_PI | \
                                          FUTEX_PRIVATE_FLAG)
 
-extern int __futex( volatile int *__address, int __operation, int __value, void *__timeout );
+extern int __futex( volatile int *__address, int __operation, int __value, void *__timeout, int id);
 
 #endif /* _FUTEX_H_INCLUDED */

--- a/bld/clib/linux/objects.mif
+++ b/bld/clib/linux/objects.mif
@@ -120,6 +120,7 @@
 !inject tcgetsid.obj                                                                            l32 lpc lmp
 !inject tcsendbr.obj                                                                            l32 lpc lmp
 !inject tcsetatr.obj                                                                            l32 lpc lmp
+!inject __tgkill.obj                                                                            l32 lpc lmp
 !inject time.obj                                                                                l32 lpc lmp
 !inject timer.obj                                                                               l32 lpc lmp
 !inject times.obj                                                                               l32 lpc lmp

--- a/bld/clib/mthread/c/mthread.c
+++ b/bld/clib/mthread/c/mthread.c
@@ -55,8 +55,15 @@
 #include "fileacc.h"
 #include "trdlstac.h"
 #include "maxthrds.h"
+
 #if defined( __UNIX__ )
+
   #include "semapsx.h"
+  #if defined( __LINUX__ )
+    void *__LinuxGetThreadData( );
+    void  __LinuxSetThreadData( void *__data );
+  #endif
+
 #endif
 
 
@@ -502,8 +509,13 @@ thread_data *__MultipleThread( void )
     }
     return( tdata );
 #elif defined( __LINUX__ )
-    // TODO: Init multiple threads for Linux!
-    return( NULL );
+    thread_data *tdata;
+
+    tdata = (thread_data *)__LinuxGetThreadData( );
+    if( tdata == NULL ) {
+        tdata = __GetThreadData();
+    } 
+    return( tdata );
 #elif defined( __RDOS__ )
     thread_data *tdata;
 
@@ -707,14 +719,22 @@ void __QNXRemoveThread( void )
 thread_data *__LinuxAddThread( thread_data *tdata )
 /***********************************************/
 {
-    // TODO: Implement this for Linux!
-    return( NULL );
+    void    *tmp;
+    tdata = __AllocInitThreadData( tdata );
+    __LinuxSetThreadData( tdata );
+    return( tdata );
 }
 
 void __LinuxRemoveThread( void )
 /****************************/
 {
-    // TODO: Implement this for Linux!
+    thread_data *tdata;
+    
+    tdata = __LinuxGetThreadData();
+    if(tdata != NULL && tdata->__allocated )
+        lib_free( tdata );
+        
+    __LinuxSetThreadData( NULL );
 }
 
   #elif defined( __RDOS__ )

--- a/bld/clib/mthread/c/trdlist.c
+++ b/bld/clib/mthread/c/trdlist.c
@@ -115,6 +115,10 @@ thread_data *__GetThreadData( void )
             tdata = NULL;
         }
     }
+#elif defined(__LINUX__)
+    if( __LinuxAddThread( tdata ) ) {
+        tdata = (thread_data *)__LinuxGetThreadData( );
+    }
 #elif defined(__RDOS__)
     if( __RdosAddThread( tdata ) ) {
         tdata = (thread_data *)__tls_get_value( __TlsIndex );
@@ -216,8 +220,9 @@ thread_data *__ReallocThreadData( void )
     tdata->__resize = 0;
 #if defined(__NT__)
     TlsSetValue( __TlsIndex, tdata );
-#endif
-#if defined(_NETWARE_LIBC)
+#elif defined (__LINUX__)
+    __LinuxSetThreadData( tdata );
+#elif defined(_NETWARE_LIBC)
     if( NXKeySetValue( __NXSlotID, tdata ) ) {
         lib_free( tdata );
         tdata = NULL;

--- a/bld/clib/mthread/h/trdlist.h
+++ b/bld/clib/mthread/h/trdlist.h
@@ -59,6 +59,7 @@
   #include <sys/types.h>
   #include <process.h>
   #include <unistd.h>
+  extern sem_t                  __tls_sem;
   #define TID                   pid_t
   #define GetCurrentThreadId()  (gettid())
 #elif defined( __RDOS__ )

--- a/bld/clib/mthread/objects.mif
+++ b/bld/clib/mthread/objects.mif
@@ -23,8 +23,8 @@
 !inject thrdxwnt.obj                     nt nta ntp
 !inject thredrdu.obj                                                                                        rdu
 !inject thredrdk.obj                                                                                            rdk
-!inject trdalloc.obj                     nt nta ntp nvc ncl nvl nll o16 o32                                 rdu rdk
-!inject trdlist.obj                      nt nta ntp         nvl nll     o32                                 rdu
+!inject trdalloc.obj                     nt nta ntp nvc ncl nvl nll o16 o32                     l32 lpc lmp rdu rdk
+!inject trdlist.obj                      nt nta ntp         nvl nll     o32                     l32 lpc lmp rdu
 
 !include ../../../../objlist.mif
 

--- a/bld/clib/posix/c/ptbar.c
+++ b/bld/clib/posix/c/ptbar.c
@@ -54,7 +54,7 @@ _WCRTLINK int pthread_barrier_init( pthread_barrier_t *__barrier,
     
     __barrier->cond = (pthread_cond_t *)malloc(sizeof(pthread_cond_t));
     if(__barrier->cond == NULL) {
-        free(__barrier->access);
+        free((void *)__barrier->access);
         return( ENOMEM );
     }
     pthread_cond_init(__barrier->cond, NULL);
@@ -83,6 +83,9 @@ int res;
     
     pthread_mutex_unlock(__barrier->access);
     pthread_mutex_destroy(__barrier->access);
+    
+    free((void *)__barrier->access);
+    free((void *)__barrier->cond);
     
     return( 0 );
 }

--- a/bld/clib/posix/c/ptcreate.c
+++ b/bld/clib/posix/c/ptcreate.c
@@ -65,13 +65,13 @@ static void __thread_start( void *data )
     
     passed->thread = __register_thread();
 
-    sem_post(&passed->registered);
-
     start_routine = passed->start_routine;
     arg = passed->arg;
     
     /* Lock our running mutex to allow for future joins */
     pthread_mutex_lock(__get_thread_running_mutex(passed->thread));
+    
+    sem_post(&passed->registered);
     
     /* Call the user routine */
     ret = start_routine(arg);
@@ -125,11 +125,9 @@ _WCRTLINK int pthread_create( pthread_t *thread, const pthread_attr_t *attr,
         }
     }
     
-    if(sem_init(&passed->registered, 0, 1) != 0) {
+    if(sem_init(&passed->registered, 0, 0) != 0) {
         return( -1 );
     }
-    
-    sem_wait(&passed->registered);
     
     ret = _beginthread( __thread_start, NULL, 0, (void *)passed );
     

--- a/bld/clib/posix/c/ptdetach.c
+++ b/bld/clib/posix/c/ptdetach.c
@@ -33,14 +33,9 @@
 #include "variety.h"
 #include <sys/types.h>
 #include <pthread.h>
-
+#include "_ptint.h"
 
 _WCRTLINK int pthread_detach(pthread_t __thr)
 {
-    /* This routine is unnecessary with Open Watcom's
-     * thread implementation, but we'll implement a
-     * dummy function for completeness
-     */
-    
-    return( 0 );
+    return( __set_thread_detached( __thr ) );
 }

--- a/bld/clib/posix/c/ptjoin.c
+++ b/bld/clib/posix/c/ptjoin.c
@@ -43,31 +43,21 @@ _WCRTLINK int pthread_join(pthread_t thread, void **value_ptr)
 int res;
 
     /* Increment the thread's waiters */
-    res = pthread_mutex_lock(__get_thread_waiting_mutex(thread));
-    if(res != 0)
-        return( res );
-        
     __increment_thread_waiters(thread);
-    pthread_mutex_unlock(__get_thread_waiting_mutex(thread));
 
     /* Wait for the thread to release its running lock */
     res = pthread_mutex_lock(__get_thread_running_mutex(thread));
     if(res != 0)
         return( res );
     
+    pthread_mutex_unlock(__get_thread_running_mutex(thread));
+    
     /* Copy the "internal only" payload pointer */
     if(value_ptr != NULL) 
         *value_ptr = __get_thread_return_value(thread);
 
     /* Decrement the waiting count */
-    res = pthread_mutex_lock(__get_thread_waiting_mutex(thread));
-    if(res == 0) {
-        __decrement_thread_waiters(thread);
-        pthread_mutex_unlock(__get_thread_waiting_mutex(thread));
-    }
-    
-    /* Unlock it so others may use it */
-    pthread_mutex_unlock(__get_thread_running_mutex(thread));
+    __decrement_thread_waiters(thread);
     
     return( 0 );
 }    

--- a/bld/clib/posix/h/_ptint.h
+++ b/bld/clib/posix/h/_ptint.h
@@ -37,6 +37,8 @@ extern int              __get_thread_waiters_count( pthread_t thread );
 extern pid_t            __get_thread_id( pthread_t thread );
 extern int              __set_thread_cancel_status( pthread_t thread, int status );
 extern int              __get_thread_cancel_status( pthread_t thread );
+extern int              __set_thread_detached( pthread_t thread );
+extern int              __get_thread_detached( pthread_t thread );
 
 /* Check if a mutex is owned by the current thread 
  * 0  = yes

--- a/bld/clib/posix/objects.mif
+++ b/bld/clib/posix/objects.mif
@@ -46,6 +46,7 @@
 !inject ptexit.obj                                                                      l32 lpc lmp
 !inject _ptint.obj                                                                      l32 lpc lmp
 !inject ptjoin.obj                                                                      l32 lpc lmp
+!inject ptkill.obj                                                                      l32 lpc lmp
 !inject ptkey.obj                                                                       l32 lpc lmp
 !inject ptmattr.obj                                                                     l32 lpc lmp
 !inject ptmutex.obj                                                                     l32 lpc lmp

--- a/bld/clib/startup/a/stkl32.asm
+++ b/bld/clib/startup/a/stkl32.asm
@@ -34,7 +34,7 @@ include mdef.inc
 include struct.inc
 include exitwmsg.inc
 
-ifdef __MT__
+ifdef __SW_BM
         extrn   "C",__GetThreadPtr : dword
 else
         extrn   "C",_STACKLOW : dword
@@ -77,7 +77,7 @@ hextab  db      "0123456789ABCDEF"
           _quif ae                      ; - . . .
           sub   eax,esp                 ; - calculate new low point
           neg   eax                     ; - calc what new SP would be
-ifdef __MT__
+ifdef __SW_BM
           push  esi                     ; - save registers
           push  eax                     ; - save eax
           call  __GetThreadPtr          ; - get thread data address

--- a/bld/clib/startup/a/stkl32.asm
+++ b/bld/clib/startup/a/stkl32.asm
@@ -34,7 +34,7 @@ include mdef.inc
 include struct.inc
 include exitwmsg.inc
 
-ifdef __SW_BM
+ifdef __MT__
         extrn   "C",__GetThreadPtr : dword
 else
         extrn   "C",_STACKLOW : dword
@@ -77,7 +77,7 @@ hextab  db      "0123456789ABCDEF"
           _quif ae                      ; - . . .
           sub   eax,esp                 ; - calculate new low point
           neg   eax                     ; - calc what new SP would be
-ifdef __SW_BM
+ifdef __MT__
           push  esi                     ; - save registers
           push  eax                     ; - save eax
           call  __GetThreadPtr          ; - get thread data address

--- a/bld/clib/startup/c/imthread.c
+++ b/bld/clib/startup/c/imthread.c
@@ -48,17 +48,16 @@
         if( !__LibCThreadInit() )
             return;
     #elif defined(__QNX__)
-    #elif defined(__LINUX__)
     #elif defined(__WARP__)
+    #elif defined(__LINUX__)
         if( __InitThreadProcessing() == 0 )
             return;
     #elif defined(__RDOS__)            
         if( !__RdosThreadInit() )
             return;
     #endif
-    #if !defined(__LINUX__)
-        __InitMultipleThread();
-    #endif
+
+    __InitMultipleThread();
     }
 
     _WCRTDATA XI( __imthread, __imthread_fn, INIT_PRIORITY_RUNTIME + 1 )

--- a/bld/clib/startup/c/mainlnx.c
+++ b/bld/clib/startup/c/mainlnx.c
@@ -31,8 +31,9 @@
 
 #include "variety.h"
 #include <stddef.h>
-#include <string.h>
+#include <stdlib.h>
 #include <sys/types.h>
+#include <process.h>
 #include "rtdata.h"
 #include "rtstack.h"
 #include "stacklow.h"

--- a/bld/hdr/watcom/pthread.mh
+++ b/bld/hdr/watcom/pthread.mh
@@ -192,8 +192,8 @@ _WCRTLINK extern int pthread_once( pthread_once_t *__once_control, void (*__init
 /* NOTE: These utilize internal values and must be synced with
  *       the definitions in sys/types.h
  */
-#define PTHREAD_MUTEX_INITIALIZER   { { 1 }, { 1 }, 100, (pid_t)(-1), PTHREAD_MUTEX_DEFAULT }
-#define PTHREAD_COND_INITIALIZER    { { 1 }, PTHREAD_MUTEX_INITIALIZER, 0 }
+#define PTHREAD_MUTEX_INITIALIZER   { { 1, 1 }, (pid_t)(-1), PTHREAD_MUTEX_DEFAULT }
+#define PTHREAD_COND_INITIALIZER    { { 1, 0 }, { 1, 1 }, 0 }
 #define PTHREAD_RWLOCK_INITIALIZER  { PTHREAD_MUTEX_INITIALIZER, 0 }
 #define PTHREAD_ONCE_INIT           { PTHREAD_MUTEX_INITIALIZER, 0 }
 

--- a/bld/hdr/watcom/semaphor.mh
+++ b/bld/hdr/watcom/semaphor.mh
@@ -17,7 +17,8 @@
 :include timespec.sp
 
 typedef struct {
-    int value;
+    volatile int futex;
+    volatile int value;
 } sem_t;
 
 /* We only support this currently on Intel chips */

--- a/bld/hdr/watcom/signal.mh
+++ b/bld/hdr/watcom/signal.mh
@@ -248,6 +248,7 @@ _WCRTLINK extern int  siginterrupt( int __signo, int __flag );
 _WCRTLINK extern int  sigwait( const sigset_t *__set, int *__sig );
 _WCRTLINK extern int  sigwaitinfo( const sigset_t *__set, siginfo_t *__info );
 _WCRTLINK extern int  sigtimedwait( const sigset_t *__set, siginfo_t *__info, const struct timespec *__timeout );
+_WCRTLINK extern int  pthread_kill( pthread_t __thread, int __sig );
 :endsegment
 :include extepi.sp
 

--- a/bld/hdr/watcom/sys/types.mh
+++ b/bld/hdr/watcom/sys/types.mh
@@ -148,11 +148,9 @@ typedef long long       id_t;   /* pid_t, uid_t or gid_t */
 :include semaphor.sp
 
 typedef struct {
-    sem_t        access;
-    sem_t        mutex;
-    int          status;
-    pid_t        owner;
-    int          type;
+    sem_t mutex;
+    volatile pid_t   owner;
+    int              type;
 } pthread_mutex_t;
 
 typedef struct {
@@ -164,9 +162,9 @@ typedef int pthread_key_t;
 typedef pid_t pthread_t;
 
 typedef struct {
-    sem_t            wait_block;
-    pthread_mutex_t  waiting_mutex;
-    int              waiters;
+    sem_t           wait_block;
+    sem_t           clear_block;
+    volatile int    waiters;
 } pthread_cond_t;
 
 /* Dummy type - nothing supported */

--- a/bld/hdr/watcom/unistd.mh
+++ b/bld/hdr/watcom/unistd.mh
@@ -49,6 +49,18 @@
 #define _POSIX_PROCESS_SCHEDULING   1
 #define _POSIX_TIMERS   1
 
+/* Open Watcom supports pthreads and semaphores on Linux now.
+ * QNX might not conform to the POSIX standards, though.
+ */
+#ifdef __LINUX__
+#define _POSIX_SEMAPHORES   200809L
+#define _POSIX_THREADS      200809L
+
+#define _POSIX_BARRIERS     200809L
+#define _POSIX_SPIN_LOCKS   200809L
+#define _POSIX_READER_WRITER_LOCKS  200809L
+#endif
+
 /* Symbolic constants for sysconf */
 /* caution: the module sysconf.c bound checks _SC_ARG_MAX ... _SC_PAGESIZE */
 #define _SC_ARG_MAX                         1


### PR DESCRIPTION
This pull request covers two major points:

- Implementation of Open Watcom internal Linux TLS
- Major necessary fixes to the pthread and semaphore locking mechanisms

The TLS implementation is relatively basic, similar to the TLS system used for OS/2.

The fixes for locking mechanisms are entirely necessary.  As originally written, mutexes and semaphores (on Linux) were unreliable and led to deadlocks reasonably often.  The fixed implementations now rely on more atomic operations.  Futex lockups have been corrected, and mutex structures have been greatly simplified.  Internal pthread structures are now protected with a semaphore (although a mutex can be optionally re-enabled).  The entire system seems (anectdotally, at least) a bit faster as well.

With these changes, BTW, Open Watcom can now build a function Python 3.5 interpetter with threading that works.  It's a nontrivial test that provides a good testbed.

This pull request is a squashed commit.  The full history is available at https://github.com/ArmstrongJ/open-watcom-v2/tree/posix-thread-2

I wasn't great about pushing changes originally, but this pull request is a few months of work troubleshooting the pthreads implementation.