### PR TITLE
[CXX11]Removal of auto as storage class specifier (N2546)

### DIFF
--- a/bld/plusplus/c/type.c
+++ b/bld/plusplus/c/type.c
@@ -2442,6 +2442,10 @@ DECL_SPEC *PTypeStgClass( stg_class_t val )
     DECL_SPEC *spec;
 
     spec = makeDeclSpec();
+
+    if( CompFlags.enable_std0x && val == STG_AUTO ) {
+        CErr1 ( ERR_CXX11_AUTO_STORAGE_SPECIFIER );
+    }
     spec->stg_class = val;
     return( spec );
 }

--- a/bld/plusplus/gml/messages.gml
+++ b/bld/plusplus/gml/messages.gml
@@ -80,6 +80,13 @@
 If this message appears, please report the problem directly to the
 Open Watcom development team. See http://www.openwatcom.org/.
 
+:MSGSYM. ERR_CXX11_AUTO_STORAGE_SPECIFIER
+:MSGTXT. 'auto' is no longer a storage specifier in C++11 mode
+:MSGJTXT.
+When C++11 is enabled, the
+.kw auto
+can no longer appear as a storage specifier.
+
 :MSGSYM. WARN_ASSIGN_CONST_IN_BOOL_EXPR
 :MSGTXT. assignment of constant found in boolean expression
 :MSGJTXT. ’è”‚Ì‘ã“ü‚ª˜_—®‚Ì’†‚É‚ ‚è‚Ü‚·

--- a/bld/plusplus/gml/messages.gml
+++ b/bld/plusplus/gml/messages.gml
@@ -80,13 +80,6 @@
 If this message appears, please report the problem directly to the
 Open Watcom development team. See http://www.openwatcom.org/.
 
-:MSGSYM. ERR_CXX11_AUTO_STORAGE_SPECIFIER
-:MSGTXT. 'auto' is no longer a storage specifier in C++11 mode
-:MSGJTXT.
-When C++11 is enabled, the
-.kw auto
-can no longer appear as a storage specifier.
-
 :MSGSYM. WARN_ASSIGN_CONST_IN_BOOL_EXPR
 :MSGTXT. assignment of constant found in boolean expression
 :MSGJTXT. íËêîÇÃë„ì¸Ç™ò_óùéÆÇÃíÜÇ…Ç†ÇËÇ‹Ç∑
@@ -12212,3 +12205,10 @@ disables the specified warning message.
 :MSGJTXT.
 The specified option is not recognized by the compiler
 since there was no character after it (i.e., "-p#@" ).
+
+:MSGSYM. ERR_CXX11_AUTO_STORAGE_SPECIFIER
+:MSGTXT. 'auto' is no longer a storage specifier in C++11 mode
+:MSGJTXT.
+When C++11 is enabled, the
+.kw auto
+can no longer appear as a storage specifier.


### PR DESCRIPTION
Initial work towards supporting some C++11 features.
This change generates an error if auto is used as a storage specifier in c++11 mode (compiler flag -za0x).