### PR TITLE
WIP: Analnode cleanups

### DIFF
--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -102,10 +102,10 @@ static PTREE makeCall(          // MAKE A CALL OR INDIRECT CALL
 
     if( direct_call ) {
         node = NodeUnaryCopy( CO_CALL_SETUP, proc );
-        node = NodeBinary( CO_CALL_EXEC, node, args );
+        node = NodeMakeBinary( CO_CALL_EXEC, node, args );
     } else {
         node = VfunSetupCall( proc );
-        node = NodeBinary( CO_CALL_EXEC_IND, node, args );
+        node = NodeMakeBinary( CO_CALL_EXEC_IND, node, args );
     }
     return NodeSetType( node, type, PTF_MEANINGFUL | PTF_SIDE_EFF );
 }
@@ -565,7 +565,7 @@ static PTREE transformVaStart   // TRANSFORM TO CO_VASTART OPCODE
         offset -= TARGET_PACKING;
     }
     NodeFreeDupedExpr( expr );
-    expr = NodeBinary( CO_VASTART, valist, NodeOffset( offset ) );
+    expr = NodeMakeBinary( CO_VASTART, valist, NodeOffset( offset ) );
     return expr;
 }
 #endif

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -1195,7 +1195,7 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
         }
     }
     if( static_fn_this != NULL ) {
-        expr = NodeCommaIfSideEffect( static_fn_this, expr );
+        expr = NodeMakeCommaIfLHSSideEffect( static_fn_this, expr );
     }
     ArgListTempFree( alist, count );
     PtListFree( ptlist, count );

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -279,7 +279,7 @@ static bool convertEllipsisArg( // CONVERT AN ELLIPSIS (...) ARGUMENT
     PTREE afun;                 // - &[ function ]
     TYPE type;                  // - node type
 
-    switch( NodeAddrOfFun( PTreeOpRight( arg ), &afun ) ) {
+    switch( NodeGetOverloadedFnAddr( PTreeOpRight( arg ), &afun ) ) {
       case ADDR_FN_MANY :
       case ADDR_FN_MANY_USED :
         PTreeErrorExpr( arg->u.subtree[1], ERR_ELLIPSE_ADDR_OVERLOAD );

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -565,7 +565,7 @@ static PTREE transformVaStart   // TRANSFORM TO CO_VASTART OPCODE
         offset -= TARGET_PACKING;
     }
     NodeFreeDupedExpr( expr );
-    expr = NodeMakeBinary( CO_VASTART, valist, NodeOffset( offset ) );
+    expr = NodeMakeBinary( CO_VASTART, valist, NodeMakeConstantOffset( offset ) );
     return expr;
 }
 #endif
@@ -1256,7 +1256,7 @@ PTREE MakeDeleteCall(   // MAKE A CALL TO 'OPERATOR DELETE'
     del_args = SymFuncArgList( del_sym );
     args = NULL;
     if( class_parm != NULL ) {
-        size_arg = NodeOffset( class_parm->u.c.info->size );
+        size_arg = NodeMakeConstantOffset( class_parm->u.c.info->size );
         size_arg = NodeMakeConversion( del_args->type_list[1], size_arg );
         args = NodeArgument( args, size_arg );
     }

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -751,7 +751,7 @@ static PTREE insertCDtor(       // INSERT CDTOR NODE INTO CALL LIST
         r_val = PTreeRefRight( arg );
         val = *r_val;
         if( val->op == PT_INT_CONSTANT ) {
-            PTREE new_val = NodeIcUnsigned( IC_CDARG_VAL, val->u.uint_constant );
+            PTREE new_val = NodeMakeIcUnsigned( IC_CDARG_VAL, val->u.uint_constant );
             new_val->type = val->type;
             *r_val = new_val;
             PTreeFree( val );

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -242,7 +242,7 @@ static bool passStructOnStack(  // PASS A STRUCT/CLASS ON STACK
     PTREE right;                // - right operand
     TYPE type;                  // - class type
 
-    right = NodeRvalue( arg->u.subtree[1] );
+    right = NodeGetRValue( arg->u.subtree[1] );
     type = right->type;
     if( right->flags & PTF_CLASS_RVREF ) {
         if( right->op != PT_ERROR ) {
@@ -286,7 +286,7 @@ static bool convertEllipsisArg( // CONVERT AN ELLIPSIS (...) ARGUMENT
         retb = false;
         break;
       default :
-        right = NodeRvalue( arg->u.subtree[1] );
+        right = NodeGetRValue( arg->u.subtree[1] );
         arg->u.subtree[1] = right;
         type =  TypedefModifierRemove( right->type );
         switch( type->id ) {

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -1129,7 +1129,7 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
                 this_node->flags |= PTF_ARG_THIS_VFUN;
             }
             if( sym != NULL && SymIsDtor( sym ) ) {
-                cdtor = NodeArg( NodeCDtorArg( DTOR_NULL ) );
+                cdtor = NodeArg( NodeMakeCDtorArg( DTOR_NULL ) );
             } else {
                 cdtor = NULL;
             }
@@ -1233,7 +1233,7 @@ PTREE AnalyseDtorCall(          // ANALYSIS FOR SPECIAL DTOR CALLS
                           , expr
                           , NULL
                           , this_node
-                          , NodeArg( NodeCDtorArg( extra ) )
+                          , NodeArg( NodeMakeCDtorArg( extra ) )
                           , NULL );
     if( virtual_call ) {
         expr->u.subtree[0] = VfnDecorateCall( expr->u.subtree[0], dtor_sym );

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -297,19 +297,19 @@ static bool convertEllipsisArg( // CONVERT AN ELLIPSIS (...) ARGUMENT
           case TYP_WCHAR :
           case TYP_USHORT :
             type = TypeUnArithResult( type );
-            right = NodeConvert( type, right );
+            right = NodeMakeConversion( type, right );
             arg_finish( right, arg );
             retb = true;
             break;
           case TYP_FLOAT :
             type = GetBasicType( TYP_DOUBLE );
-            right = NodeConvert( type, right );
+            right = NodeMakeConversion( type, right );
             arg_finish( right, arg );
             retb = true;
             break;
           case TYP_ARRAY :
             type = PointerTypeForArray( right->type );
-            right = NodeConvert( type, right );
+            right = NodeMakeConversion( type, right );
             arg_finish( right, arg );
             retb = true;
             break;
@@ -589,7 +589,7 @@ static bool adjustForVirtualCall(   // ADJUSTMENTS FOR POSSIBLE VIRTUAL CALL
         if( OMR_CLASS_VAL == ObjModelArgument( this_type ) ) {
             expr = NodeAssignTemporary( this_type, expr );
         } else {
-            expr = NodeConvert( MakePointerTo( expr->type ), expr );
+            expr = NodeMakeConversion( MakePointerTo( expr->type ), expr );
         }
         *this_node = expr;
     }
@@ -882,7 +882,7 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
             /* NYI: verify dtor call has no arguments */
             expr->u.subtree[0] = NULL;
             NodeFreeDupedExpr( expr );
-            expr = NodeConvert( GetBasicType( TYP_VOID ), this_node );
+            expr = NodeMakeConversion( GetBasicType( TYP_VOID ), this_node );
             expr = NodeComma( expr, left );
             return( expr );
         }
@@ -1257,10 +1257,10 @@ PTREE MakeDeleteCall(   // MAKE A CALL TO 'OPERATOR DELETE'
     args = NULL;
     if( class_parm != NULL ) {
         size_arg = NodeOffset( class_parm->u.c.info->size );
-        size_arg = NodeConvert( del_args->type_list[1], size_arg );
+        size_arg = NodeMakeConversion( del_args->type_list[1], size_arg );
         args = NodeArgument( args, size_arg );
     }
-    ptr = NodeConvert( del_args->type_list[0], ptr );
+    ptr = NodeMakeConversion( del_args->type_list[0], ptr );
     args = NodeArgument( args, ptr );
     expr = NodeMakeCall( del_sym, GetBasicType( TYP_VOID ), NULL );
     expr = CallArgsArrange( del_sym->sym_type

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -951,7 +951,7 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
           case FNOV_NO_MATCH :
             if( this_node == NULL ) {
                 if( SymIsThisFuncMember( orig ) ) {
-                    this_node = NodeThisCopyLocation( left );
+                    this_node = NodeMakeRVThisAtLoc( left );
                 }
             }
             if( this_node != NULL ) {
@@ -987,7 +987,7 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
         if( this_node == NULL ) {
             if( SymIsThisFuncMember( sym ) ) {
                 if( result->use_this ) {
-                    this_node = NodeThisCopyLocation( left );
+                    this_node = NodeMakeRVThisAtLoc( left );
                     if( this_node == NULL ) {
                         PTreeErrorExpr( expr, ERR_INVALID_NONSTATIC_ACCESS );
                         InfSymbolDeclaration( sym );
@@ -1026,7 +1026,7 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
         left->type = type;
         if( this_node == NULL ) {
             if( SymIsThisFuncMember( sym ) ) {
-                this_node = NodeThisCopyLocation( left );
+                this_node = NodeMakeRVThisAtLoc( left );
             }
         } else {
             if( SymIsStaticFuncMember( sym ) ) {

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -1258,10 +1258,10 @@ PTREE MakeDeleteCall(   // MAKE A CALL TO 'OPERATOR DELETE'
     if( class_parm != NULL ) {
         size_arg = NodeMakeConstantOffset( class_parm->u.c.info->size );
         size_arg = NodeMakeConversion( del_args->type_list[1], size_arg );
-        args = NodeArgument( args, size_arg );
+        args = NodeMakeArgument( args, size_arg );
     }
     ptr = NodeMakeConversion( del_args->type_list[0], ptr );
-    args = NodeArgument( args, ptr );
+    args = NodeMakeArgument( args, ptr );
     expr = NodeMakeCall( del_sym, GetBasicType( TYP_VOID ), NULL );
     expr = CallArgsArrange( del_sym->sym_type
                           , expr

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -704,7 +704,7 @@ static PTREE insertRetnCopy(    // INSERT COPY OF RETURN ON STACK
     if( temp != NULL ) {
         PTreeOpLeft( callexpr )->flags |= PTF_MEMORY_EXACT;
         callexpr->flags |= PTF_MEMORY_EXACT;
-        callexpr = NodeCopyClassObject( temp, callexpr );
+        callexpr = NodeMakeClassObjectCopy( temp, callexpr );
     }
     return callexpr;
 }

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -717,7 +717,7 @@ static PTREE insertCppRetnArg(  // INSERT C++ RETURN ARGUMENT
 {
     if( return_kind == OMR_CLASS_REF ) {
         retnnode->flags |= PTF_ARG_RETURN;
-        arglist = insertArg( arglist, NodeArg( retnnode ) );
+        arglist = insertArg( arglist, NodeMakeArg( retnnode ) );
     }
     return arglist;
 }
@@ -1124,12 +1124,12 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
         if( this_node == NULL ) {
             cdtor = NULL;
         } else {
-            this_node = NodeArg( this_node );
+            this_node = NodeMakeArg( this_node );
             if( virtual_call ) {
                 this_node->flags |= PTF_ARG_THIS_VFUN;
             }
             if( sym != NULL && SymIsDtor( sym ) ) {
-                cdtor = NodeArg( NodeMakeCDtorArg( DTOR_NULL ) );
+                cdtor = NodeMakeArg( NodeMakeCDtorArg( DTOR_NULL ) );
             } else {
                 cdtor = NULL;
             }
@@ -1225,7 +1225,7 @@ PTREE AnalyseDtorCall(          // ANALYSIS FOR SPECIAL DTOR CALLS
     virtual_call = adjustForVirtualCall( &this_node, &dtor_id, result );
     return_type = SymFuncReturnType( dtor_sym );
     expr = makeCall( dtor_id, return_type, NULL, ! virtual_call );
-    this_node = NodeArg( this_node );
+    this_node = NodeMakeArg( this_node );
     if( virtual_call ) {
         this_node->flags |= PTF_ARG_THIS_VFUN;
     }
@@ -1233,7 +1233,7 @@ PTREE AnalyseDtorCall(          // ANALYSIS FOR SPECIAL DTOR CALLS
                           , expr
                           , NULL
                           , this_node
-                          , NodeArg( NodeMakeCDtorArg( extra ) )
+                          , NodeMakeArg( NodeMakeCDtorArg( extra ) )
                           , NULL );
     if( virtual_call ) {
         expr->u.subtree[0] = VfnDecorateCall( expr->u.subtree[0], dtor_sym );

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -601,7 +601,7 @@ static bool adjustForVirtualCall(   // ADJUSTMENTS FOR POSSIBLE VIRTUAL CALL
     NodeConvertToBasePtr( this_node, this_type, result, true );
     sym = SymDefaultBase( sym );
     if( SymIsVirtual( sym ) && ((*routine)->flags & PTF_COLON_QUALED) == 0 && !exact_call ) {
-        expr = AccessVirtualFnAddress( NodeDupExpr( this_node )
+        expr = AccessVirtualFnAddress( NodeMakeExprDuplicate( this_node )
                                      , result
                                      , sym );
         expr->type = MakePointerTo( expr->type );
@@ -891,7 +891,7 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
         if( left->flags & PTF_CALLED_ONLY ) {
             /* member pointer dereference being called */
             deref_args = left->u.subtree[1];
-            this_node = NodeDupExpr( &(deref_args->u.subtree[1]) );
+            this_node = NodeMakeExprDuplicate( &(deref_args->u.subtree[1]) );
             membptr_deref = true;
         }
         break;

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -459,7 +459,7 @@ static bool canCoaxVAStartSym( PTREE *parg )
     if( arg->op != PT_SYMBOL ) {
         return( false );
     }
-    *parg = NodeComma( orig_arg, PTreeAssign( NULL, arg ) );
+    *parg = NodeMakeComma( orig_arg, PTreeAssign( NULL, arg ) );
     return( true );
 }
 
@@ -883,7 +883,7 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
             expr->u.subtree[0] = NULL;
             NodeFreeDupedExpr( expr );
             expr = NodeMakeConversion( GetBasicType( TYP_VOID ), this_node );
-            expr = NodeComma( expr, left );
+            expr = NodeMakeComma( expr, left );
             return( expr );
         }
         break;

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -249,7 +249,7 @@ static bool passStructOnStack(  // PASS A STRUCT/CLASS ON STACK
             PTREE temp = NodeMakeTemporary( type );
             right = ClassDefaultCopyDiag( temp, right, &diagEllConv );
             if( right->op != PT_ERROR ) {
-                right = NodeDtorExpr( right, temp->u.symcg.symbol );
+                right = NodeMarkDtorExpr( right, temp->u.symcg.symbol );
                 if( right->op != PT_ERROR ) {
                     right->type = type;
                     right = NodeFetch( right );
@@ -1172,7 +1172,7 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
                               , cdtor
                               , retnnode );
         if( retnnode != NULL ) {
-            expr = NodeDtorExpr( expr, retnnode->u.symcg.symbol );
+            expr = NodeMarkDtorExpr( expr, retnnode->u.symcg.symbol );
             if( SymRequiresDtoring( retnnode->u.symcg.symbol ) ) {
                 expr = PtdCtoredExprType( expr, NULL, type );
             }

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -160,7 +160,7 @@ void NodeBuildArgList(          // BUILD ARGUMENT LIST FROM CALLER ARG.S
     for( ; count > 0; --count ) {
         arg->type = BindTemplateClass( arg->type, &arg->locn, true );
         if( ( arg->flags & PTF_LVALUE )
-         && NodeReferencesTemporary( arg->u.subtree[1] ) ) {
+         && NodeYieldsTemporary( arg->u.subtree[1] ) ) {
             // temporaries may only be bound to const references
             if( NULL == TypeReference( arg->type ) ) {
                 arg->type = MakeConstReferenceTo( arg->type );

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -587,7 +587,7 @@ static bool adjustForVirtualCall(   // ADJUSTMENTS FOR POSSIBLE VIRTUAL CALL
     this_type = StructType( this_type );
     if( this_type != NULL ) {
         if( OMR_CLASS_VAL == ObjModelArgument( this_type ) ) {
-            expr = NodeAssignTemporary( this_type, expr );
+            expr = NodeMakeAssignToNewTmp( this_type, expr );
         } else {
             expr = NodeMakeConversion( MakePointerTo( expr->type ), expr );
         }

--- a/bld/plusplus/c/analcall.c
+++ b/bld/plusplus/c/analcall.c
@@ -246,7 +246,7 @@ static bool passStructOnStack(  // PASS A STRUCT/CLASS ON STACK
     type = right->type;
     if( right->flags & PTF_CLASS_RVREF ) {
         if( right->op != PT_ERROR ) {
-            PTREE temp = NodeTemporary( type );
+            PTREE temp = NodeMakeTemporary( type );
             right = ClassDefaultCopyDiag( temp, right, &diagEllConv );
             if( right->op != PT_ERROR ) {
                 right = NodeDtorExpr( right, temp->u.symcg.symbol );
@@ -1160,7 +1160,7 @@ PTREE AnalyseCall(              // ANALYSIS FOR CALL
             expr->flags |= PTF_LVALUE;
         }
         if( OMR_CLASS_REF == ObjModelArgument( type ) ) {
-            retnnode = NodeTemporary( type );
+            retnnode = NodeMakeTemporary( type );
             retnnode = PTreeCopySrcLocation( retnnode, expr );
         } else {
             retnnode = NULL;

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1945,7 +1945,7 @@ static PTREE forceToDestination // FORCE TO DESTINATION ON CAST, FUNC_ARG
                                                , ctl->diag_cast );
                 } else {
                     if( ctl->tgt.reference ) {
-                        expr = NodeAssignRef( ctl->destination, expr );
+                        expr = NodeMakeRefAssignment( ctl->destination, expr );
                     } else {
                         expr = NodeMakeAssignment( ctl->destination, expr );
                     }

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -242,7 +242,7 @@ static bool getClassRvalue      // GET RVALUE FOR CLASS EXPRESSION
 {
     PTREE expr = ctl->expr->u.subtree[1];
     if( OMR_CLASS_VAL == ObjModelArgument( ctl->tgt.class_type ) ) {
-        expr = NodeRvalue( expr );
+        expr = NodeGetRValue( expr );
     } else {
         expr = NodeRvForRefClass( expr );
     }
@@ -768,7 +768,7 @@ static bool castCtor            // APPLY CTOR
                 if( ctl->tgt.class_type == ClassTypeForType( inp_node->type )
                  && OMR_CLASS_VAL == ObjModelArgument( ctl->tgt.class_type ) ) {
                     ctl->conv_fun = NULL;
-                    inp_node = NodeRvalue( inp_node->u.subtree[1] );
+                    inp_node = NodeGetRValue( inp_node->u.subtree[1] );
                     PTreeFree( ctl->expr->u.subtree[1] );
                     ctl->expr->u.subtree[1] = NULL;
                     node = NodeCopyClassObject( temp, inp_node );
@@ -898,7 +898,7 @@ static PTREE castUdcf           // APPLY USER-DEFINED CONVERSION FUNCTION
                 if( ! ctl->tgt.reference
                  && okSoFar( ctl ) ) {
                     ctl->expr->u.subtree[1] =
-                        NodeRvalue( ctl->expr->u.subtree[1] );
+                        NodeGetRValue( ctl->expr->u.subtree[1] );
                 }
                 SetCurrScope(curr);
 
@@ -1436,7 +1436,7 @@ static CAST_RESULT analysePtrToPtr  // ANALYSE PTR --> PTR
             PTREE node = ctl->expr->u.subtree[1];
             TYPE tgt_type;
             if( ctl->src.reference ) {
-                node = NodeRvalue( node );
+                node = NodeGetRValue( node );
             }
             tgt_type = ctl->tgt.unmod->of;
             result = CAST_DO_CGCONV;
@@ -1960,7 +1960,7 @@ static PTREE forceToDestination // FORCE TO DESTINATION ON CAST, FUNC_ARG
                 expr = NodeDtorExpr( expr, ctl->destination->u.symcg.symbol );
             }
             if( PT_ERROR != expr->op && !ctl->tgt.reference ) {
-                expr = NodeRvalue( expr );
+                expr = NodeGetRValue( expr );
             }
             fold_it = false;
         }

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -338,7 +338,7 @@ static CAST_RESULT checkConstRef// CHECK FOR TEMP -> NON-CONST REFERENCE
         PTREE expr;
         expr = ctl->expr->u.subtree[1];
         if( ! ExprIsLvalue( expr )
-         || NodeReferencesTemporary( expr ) ) {
+         || NodeYieldsTemporary( expr ) ) {
             result = diagNonConstRefBinding( ctl );
         } else {
             // always an error if not a temp.

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1663,7 +1663,7 @@ static PTREE doCastResult           // DO CAST RESULT
         break;
       case CAST_TO_VOID :
         ctl->expr->type = ctl->tgt.orig;
-        ctl->expr->u.subtree[1] = NodeConvertFlags( ctl->tgt.orig
+        ctl->expr->u.subtree[1] = NodeMakeConversionFlags( ctl->tgt.orig
                                     , ctl->expr->u.subtree[1]
                                     , PTF_MEANINGFUL | PTF_SIDE_EFF );
         markUserCast( ctl );

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1710,7 +1710,7 @@ static PTREE doCastResult           // DO CAST RESULT
         break;
       case CAST_REPLACE_INTEGRAL :
       { expr = PTreeOp( &ctl->expr->u.subtree[1] );
-        expr = NodeIntegralConstant( NodeConstantValue( expr ), ctl->tgt.orig );
+        expr = NodeIntegralConstant( NodeGetConstantValue( expr ), ctl->tgt.orig );
         expr = PTreeCopySrcLocation( expr, ctl->expr->u.subtree[1] );
         expr = NodeReplace( ctl->expr, expr );
 //      expr = CheckCharPromotion( expr );

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1947,7 +1947,7 @@ static PTREE forceToDestination // FORCE TO DESTINATION ON CAST, FUNC_ARG
                     if( ctl->tgt.reference ) {
                         expr = NodeAssignRef( ctl->destination, expr );
                     } else {
-                        expr = NodeAssign( ctl->destination, expr );
+                        expr = NodeMakeAssignment( ctl->destination, expr );
                     }
                     if( MemberPtrType( ctl->tgt.unmod ) ) {
                         PTREE dup = expr;

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -738,7 +738,7 @@ static bool castCtor            // APPLY CTOR
 
     retb = false;
     if( ctl->src.reference || getLvalue( ctl, false ) ) {
-        inp_node = NodeArg( ctl->expr->u.subtree[1] );
+        inp_node = NodeMakeArg( ctl->expr->u.subtree[1] );
         ctl->expr->u.subtree[1] = inp_node;
         NodeConvertCallArgList( ctl->expr
                               , 1
@@ -773,7 +773,7 @@ static bool castCtor            // APPLY CTOR
                     ctl->expr->u.subtree[1] = NULL;
                     node = NodeCopyClassObject( temp, inp_node );
                 } else {
-                    temp = NodeArg( temp );
+                    temp = NodeMakeArg( temp );
                     node = NodeMakeCall( ctl->conv_fun
                                        , SymFuncReturnType( ctl->conv_fun )
                                        , ctl->expr->u.subtree[1] );

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1710,7 +1710,7 @@ static PTREE doCastResult           // DO CAST RESULT
         break;
       case CAST_REPLACE_INTEGRAL :
       { expr = PTreeOp( &ctl->expr->u.subtree[1] );
-        expr = NodeIntegralConstant( NodeGetConstantValue( expr ), ctl->tgt.orig );
+        expr = NodeMakeIntegralConstant( NodeGetConstantValue( expr ), ctl->tgt.orig );
         expr = PTreeCopySrcLocation( expr, ctl->expr->u.subtree[1] );
         expr = NodeReplace( ctl->expr, expr );
 //      expr = CheckCharPromotion( expr );

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -265,7 +265,7 @@ static bool getLvalue           // GET LVALUE FOR EXPRESSION
         switch( obj_model ) {
           case OMR_CLASS_VAL :
             if( force_to_temp ) {
-                expr = NodeCopyClassObject( NodeTemporary( type ), expr );
+                expr = NodeCopyClassObject( NodeMakeTemporary( type ), expr );
             } else {
                 expr = NodeForceLvalue( expr );
             }
@@ -755,7 +755,7 @@ static bool castCtor            // APPLY CTOR
                     CAST_RESULT result = reqdConstRef( ctl );
                     if( result != CAST_TESTED_OK ) return false;
                 }
-                temp = NodeTemporary( ctl->tgt.class_type );
+                temp = NodeMakeTemporary( ctl->tgt.class_type );
                 ctl->destination = temp;
                 ctl->dtor_destination = true;
             }
@@ -1991,7 +1991,7 @@ static void allocClassDestination//ALLOCATE DESTINATION WHEN CLASS
     if( NULL == ctl->destination ) {
         if( ctl->tgt.class_operand
          && ! ctl->tgt.reference ) {
-            ctl->destination = NodeTemporary( ctl->tgt.orig );
+            ctl->destination = NodeMakeTemporary( ctl->tgt.orig );
             ctl->dtor_destination = true;
         }
     }

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1340,7 +1340,7 @@ static PTREE convertToBool          // CONVERT TO BOOL
     ( CONVCTL* ctl )                // - cast info
 {
     stripOffCastOrig( ctl );
-    return NodeConvertToBool( ctl->expr );
+    return NodeMakeBoolConversion( ctl->expr );
 }
 
 

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -863,7 +863,7 @@ static PTREE castUdcf           // APPLY USER-DEFINED CONVERSION FUNCTION
                 new_targ = MakeConstTypeOf( new_targ );
                 new_targ = MakeReferenceTo( new_targ );
                 if( NULL != ctl->destination ) {
-                    ctl->destination = NodeConvert( new_targ
+                    ctl->destination = NodeMakeConversion( new_targ
                                                   , ctl->destination ) ;
                 }
             } else {
@@ -1316,12 +1316,12 @@ static PTREE doReintPtrToArith  // DO REINTERPRET: PTR -> ARITH
                 stripOffCastOrig( ctl );
                 argument = MakeModifiedType( GetBasicType( TYP_VOID ), TF1_FAR );
                 argument = MakePointerTo( argument );
-                expr = NodeConvert( argument, ctl->expr );
+                expr = NodeMakeConversion( argument, ctl->expr );
                 argument = GetBasicType( TYP_ULONG );
-                expr = NodeConvert( argument, expr );
+                expr = NodeMakeConversion( argument, expr );
                 expr = NodeMakeBinary( CO_RSHIFT, expr, NodeOffset( 16 ) );
                 expr->type = argument;
-                expr = NodeConvert( TypeSegmentShort(), expr );
+                expr = NodeMakeConversion( TypeSegmentShort(), expr );
                 expr->locn = locn;
             #else
                 expr = doCgConversion( ctl );

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -267,7 +267,7 @@ static bool getLvalue           // GET LVALUE FOR EXPRESSION
             if( force_to_temp ) {
                 expr = NodeMakeClassObjectCopy( NodeMakeTemporary( type ), expr );
             } else {
-                expr = NodeForceLvalue( expr );
+                expr = NodeForceLValue( expr );
             }
             break;
           case OMR_CLASS_REF :

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -265,7 +265,7 @@ static bool getLvalue           // GET LVALUE FOR EXPRESSION
         switch( obj_model ) {
           case OMR_CLASS_VAL :
             if( force_to_temp ) {
-                expr = NodeCopyClassObject( NodeMakeTemporary( type ), expr );
+                expr = NodeMakeClassObjectCopy( NodeMakeTemporary( type ), expr );
             } else {
                 expr = NodeForceLvalue( expr );
             }
@@ -771,7 +771,7 @@ static bool castCtor            // APPLY CTOR
                     inp_node = NodeGetRValue( inp_node->u.subtree[1] );
                     PTreeFree( ctl->expr->u.subtree[1] );
                     ctl->expr->u.subtree[1] = NULL;
-                    node = NodeCopyClassObject( temp, inp_node );
+                    node = NodeMakeClassObjectCopy( temp, inp_node );
                 } else {
                     temp = NodeMakeArg( temp );
                     node = NodeMakeCall( ctl->conv_fun

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1957,7 +1957,7 @@ static PTREE forceToDestination // FORCE TO DESTINATION ON CAST, FUNC_ARG
                 }
             }
             if( ctl->dtor_destination && ctl->tgt.class_operand && PT_ERROR != expr->op ) {
-                expr = NodeDtorExpr( expr, ctl->destination->u.symcg.symbol );
+                expr = NodeMarkDtorExpr( expr, ctl->destination->u.symcg.symbol );
             }
             if( PT_ERROR != expr->op && !ctl->tgt.reference ) {
                 expr = NodeGetRValue( expr );

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -783,7 +783,7 @@ static bool castCtor            // APPLY CTOR
                                               , node
                                               , node->u.subtree[1]
                                               , temp
-                                              , CallArgumentExactCtor
+                                              , MakeArgCtorCall
                                                     ( ctl->tgt.class_type
                                                     , true )
                                               , NULL );

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1319,7 +1319,7 @@ static PTREE doReintPtrToArith  // DO REINTERPRET: PTR -> ARITH
                 expr = NodeMakeConversion( argument, ctl->expr );
                 argument = GetBasicType( TYP_ULONG );
                 expr = NodeMakeConversion( argument, expr );
-                expr = NodeMakeBinary( CO_RSHIFT, expr, NodeOffset( 16 ) );
+                expr = NodeMakeBinary( CO_RSHIFT, expr, NodeMakeConstantOffset( 16 ) );
                 expr->type = argument;
                 expr = NodeMakeConversion( TypeSegmentShort(), expr );
                 expr->locn = locn;

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1450,7 +1450,7 @@ static CAST_RESULT analysePtrToPtr  // ANALYSE PTR --> PTR
                 }
             }
             if( result != CAST_ERR_NODE ) {
-                node = NodeAssignTemporary( tgt_type, node );
+                node = NodeMakeAssignToNewTmp( tgt_type, node );
                 ctl->expr->u.subtree[1] = node;
                 if( PT_ERROR == node->op ) {
                     result = CAST_ERR_NODE;

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1319,7 +1319,7 @@ static PTREE doReintPtrToArith  // DO REINTERPRET: PTR -> ARITH
                 expr = NodeConvert( argument, ctl->expr );
                 argument = GetBasicType( TYP_ULONG );
                 expr = NodeConvert( argument, expr );
-                expr = NodeBinary( CO_RSHIFT, expr, NodeOffset( 16 ) );
+                expr = NodeMakeBinary( CO_RSHIFT, expr, NodeOffset( 16 ) );
                 expr->type = argument;
                 expr = NodeConvert( TypeSegmentShort(), expr );
                 expr->locn = locn;
@@ -2671,7 +2671,7 @@ PTREE AddCastNode               // ADD A CAST NODE
     PTF_FLAG flags;             // - flags for cast node
     flags = expr->flags & PTF_CONVERT;
     type = BindTemplateClass( type, &expr->locn, true );
-    expr = NodeBinary( CO_CONVERT, PTreeType( type ), expr );
+    expr = NodeMakeBinary( CO_CONVERT, PTreeType( type ), expr );
     expr = NodeSetType( expr, type, flags );
     expr = PTreeCopySrcLocation( expr, expr->u.subtree[1] );
     return CheckCharPromotion( expr );

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1306,7 +1306,7 @@ static PTREE doReintPtrToArith  // DO REINTERPRET: PTR -> ARITH
     if( NULL == IntegralType( ctl->tgt.unmod ) ) {
         expr = diagnoseCast( ctl, ERR_CAST_ILLEGAL );
     } else if( NULL != SegmentShortType( ctl->tgt.unmod ) ) {
-        if( ! NodeDerefPtr( &ctl->expr->u.subtree[1] ) ) {
+        if( ! NodeTryDerefPtr( &ctl->expr->u.subtree[1] ) ) {
             expr = diagnoseCast( ctl, ERR_CAST_ILLEGAL );
         } else {
             #if _CPU == 8086

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -538,7 +538,7 @@ static void emitOpeqCall(       // EMIT AN ASSIGNMENT FOR DEFAULT OP=
       case TITER_CLASS_DBASE :
       case TITER_NAKED_DTOR  :
         if( NULL == StructType( cltype ) ) {
-            expr = bitFieldNodeAssign( tgt, src, NodeRvalue );
+            expr = bitFieldNodeAssign( tgt, src, NodeGetRValue );
         } else {
             expr = NodeAssign( tgt, src );
             expr = ClassAssign( expr );
@@ -782,7 +782,7 @@ static PTREE doBinaryCopy(      // DO A BINARY COPY
     tgt_type = NodeType( tgt );
     tgt_type = TypeReferenced( tgt_type );
 
-    src = NodeRvalue( src );
+    src = NodeGetRValue( src );
 
     if( OMR_CLASS_REF == ObjModelArgument( tgt_type ) ) {
         src->flags &= ~PTF_CLASS_RVREF;
@@ -1277,7 +1277,7 @@ static PTREE generateArrayDtorCall( // CALL R/T ROUTINE TO DTOR ARRAY
     if( error_occurred ) {
         expr = NULL;
     } else {
-        node_this = NodeRvalue( node_this );
+        node_this = NodeGetRValue( node_this );
         TypeSigReferenced( base_sig );
         expr = generateArrayClassCall( array_type
                                      , base_sig

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -568,7 +568,7 @@ static void emitOpeqCall(       // EMIT AN ASSIGNMENT FOR DEFAULT OP=
                 CDtorScheduleArgRemap( assop );
                 assop = ClassFunMakeAddressable( assop );
                 assop->flag |= SF_ADDR_TAKEN;
-                expr = NodeArguments( MakeNodeSymbol( assop )
+                expr = NodeMakeArgList( MakeNodeSymbol( assop )
                                     , NodeMakeConstantOffset( CgMemorySize( cltype ) )
                                     , NULL );
                 expr = classArrayRtCall( expr

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -955,7 +955,7 @@ static PTREE genDefaultCopyDiag(// GENERATE COPY TO CLASS OBJECT, WITH DIAGNOSIS
         } else {
             this_arg = NodeGetCallExpr( expr )->u.subtree[1];
             this_arg->u.subtree[0]
-                = NodeArgumentExactCtor( this_arg->u.subtree[0]
+                = NodeMakeArgCtor( this_arg->u.subtree[0]
                                        , tgt_type
                                        , true );
             *a_ctor_used = ctor;

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -1186,13 +1186,13 @@ PTREE ClassCopyTemp(            // COPY A TEMPORARY
         }
 #if 0
         expr = defaultCopyDiag( temp_node, expr, &diagCopy, &ctor );
-        expr = NodeDtorExpr( expr, temp_node->u.symcg.symbol );
+        expr = NodeMarkDtorExpr( expr, temp_node->u.symcg.symbol );
         if( ctor != NULL ) {
             expr = PtdCtoredExprType( expr, ctor, cl_type );
         }
 #else
         expr = CopyInit( expr, temp_node, cl_type, &diagTempCopy );
-        expr = NodeDtorExpr( expr, temp_node->u.symcg.symbol );
+        expr = NodeMarkDtorExpr( expr, temp_node->u.symcg.symbol );
 #endif
     }
     return expr;

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -547,8 +547,8 @@ static void emitOpeqCall(       // EMIT AN ASSIGNMENT FOR DEFAULT OP=
       case TITER_ARRAY_EXACT :
       case TITER_ARRAY_VBASE :
         if( NULL == StructType( cltype ) ) {
-            src = NodeConvertFlags( artype, src, PTF_MEMORY_EXACT | PTF_LVALUE );
-            tgt = NodeConvertFlags( artype, tgt, PTF_MEMORY_EXACT | PTF_LVALUE );
+            src = NodeMakeConversionFlags( artype, src, PTF_MEMORY_EXACT | PTF_LVALUE );
+            tgt = NodeMakeConversionFlags( artype, tgt, PTF_MEMORY_EXACT | PTF_LVALUE );
             expr = bitFieldNodeAssign( tgt, src, NodeFetch );
         } else if( ClassNeedsAssign( cltype, true ) ) {
             if( qualifier != 0 ) {
@@ -787,13 +787,13 @@ static PTREE doBinaryCopy(      // DO A BINARY COPY
     if( OMR_CLASS_REF == ObjModelArgument( tgt_type ) ) {
         src->flags &= ~PTF_CLASS_RVREF;
         src->flags |= PTF_LVALUE | PTF_MEMORY_EXACT;
-        src = NodeConvertFlags( tgt_type, src, PTF_MEMORY_EXACT | PTF_LVALUE );
+        src = NodeMakeConversionFlags( tgt_type, src, PTF_MEMORY_EXACT | PTF_LVALUE );
         src = NodeFetch( src );
         src->flags |= PTF_MEMORY_EXACT;
     } else {
-        src = NodeConvertFlags( tgt_type, src, PTF_MEMORY_EXACT );
+        src = NodeMakeConversionFlags( tgt_type, src, PTF_MEMORY_EXACT );
     }
-    tgt = NodeConvertFlags( tgt_type, tgt, PTF_MEMORY_EXACT | PTF_LVALUE );
+    tgt = NodeMakeConversionFlags( tgt_type, tgt, PTF_MEMORY_EXACT | PTF_LVALUE );
     return NodeCopyClassObject( tgt, src );
 }
 

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -1033,7 +1033,7 @@ static PTREE defaultCopyDiag(   // COPY TO CLASS OBJECT, WITH DIAGNOSIS
         FnovFreeDiag( &fnov_diag );
         opt = CALL_OPT_NONE;
         if( is_ctor ) {
-            src = NodeLvExtract( src );
+            src = NodeExtractLValue( src );
             result = classResult( type, &ctor_udc, ctor_udc->name->name, NULL );
         } else {
             TYPE src_class = ClassTypeForType( type_right );
@@ -1172,11 +1172,11 @@ PTREE ClassCopyTemp(            // COPY A TEMPORARY
 #if 0
     SYMBOL ctor;                // - CTOR used
 #endif
-    expr = NodeLvExtract( expr );
+    expr = NodeExtractLValue( expr );
     if( NodeYieldsTemporary( expr )
      && cl_type == ClassTypeForType( expr->type ) ) {
         NodeFreeDupedExpr( temp_node );
-        expr = NodeLvExtract( expr );
+        expr = NodeExtractLValue( expr );
         expr->type = cl_type;
         expr->flags |= PTF_LVALUE;
     } else {

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -450,11 +450,11 @@ static PTREE classArrayRtCall(  // GENERATE R/T CALL FOR ARRAY
     target_size_t nelem;        // - number of array elements
 
     nelem = ArrayTypeNumberItems( artype );
-    expr = NodeArgument( expr, NodeMakeConstantOffset( nelem ) );
+    expr = NodeMakeArgument( expr, NodeMakeConstantOffset( nelem ) );
     if( src != NULL ) {
-        expr = NodeArgument( expr, src );
+        expr = NodeMakeArgument( expr, src );
     }
-    expr = NodeArgument( expr, tgt );
+    expr = NodeMakeArgument( expr, tgt );
     expr = RunTimeCall( expr
                       , PointerTypeForArray( artype )
                       , rtn_code );

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -163,7 +163,7 @@ static void returnThis(         // RETURN "this" value
 
 static PTREE addOffset( PTREE node, target_offset_t offset, TYPE type )
 {
-    node = NodeMakeBinary( CO_DOT, node, NodeOffset( offset ) );
+    node = NodeMakeBinary( CO_DOT, node, NodeMakeConstantOffset( offset ) );
     node->type = type;
     node->flags |= PTF_LVALUE;
     return( node );
@@ -289,7 +289,7 @@ static PTREE setThisFromOffset( // SET "THIS" BACK BY AN OFFSET
         /* bit-fields do not have l-values that can be adjusted */
         return( expr );
     }
-    offset_node = NodeOffset( offset );
+    offset_node = NodeMakeConstantOffset( offset );
     offset_node->cgop = CO_IGNORE;
     expr = NodeMakeBinary( CO_RESET_THIS, expr, offset_node );
     expr->type = this_type;
@@ -450,7 +450,7 @@ static PTREE classArrayRtCall(  // GENERATE R/T CALL FOR ARRAY
     target_size_t nelem;        // - number of array elements
 
     nelem = ArrayTypeNumberItems( artype );
-    expr = NodeArgument( expr, NodeOffset( nelem ) );
+    expr = NodeArgument( expr, NodeMakeConstantOffset( nelem ) );
     if( src != NULL ) {
         expr = NodeArgument( expr, src );
     }
@@ -569,7 +569,7 @@ static void emitOpeqCall(       // EMIT AN ASSIGNMENT FOR DEFAULT OP=
                 assop = ClassFunMakeAddressable( assop );
                 assop->flag |= SF_ADDR_TAKEN;
                 expr = NodeArguments( MakeNodeSymbol( assop )
-                                    , NodeOffset( CgMemorySize( cltype ) )
+                                    , NodeMakeConstantOffset( CgMemorySize( cltype ) )
                                     , NULL );
                 expr = classArrayRtCall( expr
                                        , src
@@ -2103,7 +2103,7 @@ static void emitOffset( target_offset_t offset )
 {
     PTREE expr;
 
-    expr = NodeOffset( offset );
+    expr = NodeMakeConstantOffset( offset );
     DgStoreScalar( expr, 0, expr->type );
     PTreeFreeSubtrees( expr );
 }

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -2424,7 +2424,7 @@ static void genDeleteVector(
         if( ! TypeAbstract( class_type ) ) {
             CgFrontCode( IC_DTOR_DAR_BEG );
             testExtraParm( DTOR_DELETE_VECTOR, false );
-            stmt = NodeUnary( CO_DELETE_ARRAY, NodeThis() );
+            stmt = NodeMakeUnary( CO_DELETE_ARRAY, NodeThis() );
             stmt->flags |= PTF_MEMORY_EXACT;
             stmt = AnalyseDelete( stmt, true );
             EmitAnalysedStmt( stmt );
@@ -2539,7 +2539,7 @@ static void genDeleteThis( SYMBOL dtor )
     if( ! TypeAbstract( SymClass( dtor ) ) && SymIsVirtual( dtor ) ) {
         CgFrontCode( IC_DTOR_DLT_BEG );
         testExtraParm( DTOR_DELETE_THIS, false );
-        stmt = NodeUnary( CO_DELETE, NodeThis() );
+        stmt = NodeMakeUnary( CO_DELETE, NodeThis() );
         stmt->flags |= PTF_MEMORY_EXACT;
         stmt = AnalyseDelete( stmt, true );
         EmitAnalysedStmt( stmt );

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -2211,7 +2211,7 @@ static void emitRttiRef( SYMBOL sym, target_offset_t offset )
         sym->flag |= SF_ADDR_TAKEN;
         expr = MakeNodeSymbol( sym );
     } else {
-        expr = NodeZero();
+        expr = NodeMakeZeroConstant();
     }
     type = TypePtrToVoid();
     DgStoreScalar( expr, offset, type );
@@ -2230,7 +2230,7 @@ static void emitVFNPointer( SYMBOL sym )
         }
         expr = NodeMakeCallee( sym );
     } else {
-        expr = NodeZero();
+        expr = NodeMakeZeroConstant();
     }
     type = TypeVoidFunOfVoid();
     type = MakePointerTo( type );

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -478,7 +478,7 @@ static void generateCopyObject( // GENERATE COPY OF OBJECT
     tgt = NodeMakeThis();
     tgt->type = TypedefModifierRemove( tgt->type )->of;
     tgt->flags |= PTF_LVALUE;
-    expr = NodeCopyClassObject( tgt, expr );
+    expr = NodeMakeClassObjectCopy( tgt, expr );
     EmitAnalysedStmt( expr );
 }
 
@@ -794,7 +794,7 @@ static PTREE doBinaryCopy(      // DO A BINARY COPY
         src = NodeMakeConversionFlags( tgt_type, src, PTF_MEMORY_EXACT );
     }
     tgt = NodeMakeConversionFlags( tgt_type, tgt, PTF_MEMORY_EXACT | PTF_LVALUE );
-    return NodeCopyClassObject( tgt, src );
+    return NodeMakeClassObjectCopy( tgt, src );
 }
 
 static PTREE doClassAssign(     // ASSIGN TO CLASS OBJECT

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -1092,7 +1092,7 @@ static PTREE defaultCopyDiag(   // COPY TO CLASS OBJECT, WITH DIAGNOSIS
             } else {
                 src_type = SymFuncArgList( ctor_udc )->type_list[0];
             }
-            if( !temp_ok && NodeNonConstRefToTemp( src_type, right ) ) {
+            if( !temp_ok && NodeIsNonConstRefToTemp( src_type, right ) ) {
                 opt = CALL_OPT_ERR;
             }
         }

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -171,7 +171,7 @@ static PTREE addOffset( PTREE node, target_offset_t offset, TYPE type )
 
 static PTREE addOffsetToThis( target_offset_t offset, TYPE type )
 {
-    return( addOffset( NodeThis(), offset, type ) );
+    return( addOffset( NodeMakeThis(), offset, type ) );
 }
 
 static PTREE nodeFirstParm(     // GET FIRST PARM AS A NODE
@@ -219,7 +219,7 @@ static PTREE addVBOffsetToThis(
     BASE_CLASS *base,
     TYPE type )
 {
-    return addVBOffsetToExpr( scope, base, type, NodeThis() );
+    return addVBOffsetToExpr( scope, base, type, NodeMakeThis() );
 }
 
 static PTREE accessSourceBase( SCOPE scope, BASE_CLASS *base )
@@ -475,7 +475,7 @@ static void generateCopyObject( // GENERATE COPY OF OBJECT
     expr = NodeSetMemoryExact( expr );
     expr = NodeFetch( expr );
     expr->flags &= ~ PTF_LVALUE;
-    tgt = NodeThis();
+    tgt = NodeMakeThis();
     tgt->type = TypedefModifierRemove( tgt->type )->of;
     tgt->flags |= PTF_LVALUE;
     expr = NodeCopyClassObject( tgt, expr );
@@ -1512,7 +1512,7 @@ void RtnGenCallBackArrayDtor(   // GENERATE ARRAY DTOR
     scope = ScopeFunctionScopeInProgress();
     p1 = SymMakeDummy( MakeCDtorExtraArgType(), &name );
     p1 = ScopeInsert( scope, p1, name );
-    stmt = generateArrayDtorCall( ar_type, NodeThis() );
+    stmt = generateArrayDtorCall( ar_type, NodeMakeThis() );
     retn = SymFunctionReturn();
     stmt = NodeAssignRef( MakeNodeSymbol( retn ), stmt );
     EmitAnalysedStmt( stmt );
@@ -2424,7 +2424,7 @@ static void genDeleteVector(
         if( ! TypeAbstract( class_type ) ) {
             CgFrontCode( IC_DTOR_DAR_BEG );
             testExtraParm( DTOR_DELETE_VECTOR, false );
-            stmt = NodeMakeUnary( CO_DELETE_ARRAY, NodeThis() );
+            stmt = NodeMakeUnary( CO_DELETE_ARRAY, NodeMakeThis() );
             stmt->flags |= PTF_MEMORY_EXACT;
             stmt = AnalyseDelete( stmt, true );
             EmitAnalysedStmt( stmt );
@@ -2539,7 +2539,7 @@ static void genDeleteThis( SYMBOL dtor )
     if( ! TypeAbstract( SymClass( dtor ) ) && SymIsVirtual( dtor ) ) {
         CgFrontCode( IC_DTOR_DLT_BEG );
         testExtraParm( DTOR_DELETE_THIS, false );
-        stmt = NodeMakeUnary( CO_DELETE, NodeThis() );
+        stmt = NodeMakeUnary( CO_DELETE, NodeMakeThis() );
         stmt->flags |= PTF_MEMORY_EXACT;
         stmt = AnalyseDelete( stmt, true );
         EmitAnalysedStmt( stmt );

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -499,7 +499,7 @@ static PTREE bitFieldNodeAssign( PTREE tgt, PTREE src, PTREE (*fetch)( PTREE ) )
     src = bitFieldLValueAdjust( src );
     src = fetch( src );
     tgt = bitFieldLValueAdjust( tgt );
-    return( NodeAssign( tgt, src ) );
+    return( NodeMakeAssignment( tgt, src ) );
 }
 
 
@@ -540,7 +540,7 @@ static void emitOpeqCall(       // EMIT AN ASSIGNMENT FOR DEFAULT OP=
         if( NULL == StructType( cltype ) ) {
             expr = bitFieldNodeAssign( tgt, src, NodeGetRValue );
         } else {
-            expr = NodeAssign( tgt, src );
+            expr = NodeMakeAssignment( tgt, src );
             expr = ClassAssign( expr );
         }
         break;
@@ -584,7 +584,7 @@ static void emitOpeqCall(       // EMIT AN ASSIGNMENT FOR DEFAULT OP=
             tgt->type = artype;
 #endif
             src = NodeFetch( src );
-            expr = NodeAssign( tgt, src );
+            expr = NodeMakeAssignment( tgt, src );
         }
         break;
     }

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -163,7 +163,7 @@ static void returnThis(         // RETURN "this" value
 
 static PTREE addOffset( PTREE node, target_offset_t offset, TYPE type )
 {
-    node = NodeBinary( CO_DOT, node, NodeOffset( offset ) );
+    node = NodeMakeBinary( CO_DOT, node, NodeOffset( offset ) );
     node->type = type;
     node->flags |= PTF_LVALUE;
     return( node );
@@ -291,7 +291,7 @@ static PTREE setThisFromOffset( // SET "THIS" BACK BY AN OFFSET
     }
     offset_node = NodeOffset( offset );
     offset_node->cgop = CO_IGNORE;
-    expr = NodeBinary( CO_RESET_THIS, expr, offset_node );
+    expr = NodeMakeBinary( CO_RESET_THIS, expr, offset_node );
     expr->type = this_type;
     return( expr );
 }
@@ -829,7 +829,7 @@ static PTREE doClassAssign(     // ASSIGN TO CLASS OBJECT
                 fun = PTreeCopySrcLocation( fun, expr );
                 tgt = NodeDottedFunction( tgt, fun );
                 tgt = PTreeCopySrcLocation( tgt, expr );
-                call_expr = NodeBinary( CO_CALL_NOOVLD, tgt, NodeArg( src ) );
+                call_expr = NodeMakeBinary( CO_CALL_NOOVLD, tgt, NodeArg( src ) );
                 call_expr = PTreeCopySrcLocation( call_expr, expr );
                 call_expr = AnalyseCall( call_expr, &diagAssign );
                 PTreeFree( expr );
@@ -945,9 +945,9 @@ static PTREE genDefaultCopyDiag(// GENERATE COPY TO CLASS OBJECT, WITH DIAGNOSIS
         fun->u.symcg.result = result;
         fun->cgop = CO_NAME_DOT;
         fun = PTreeCopySrcLocation( fun, src );
-        tgt = NodeBinary( CO_ARROW, tgt, fun );
+        tgt = NodeMakeBinary( CO_ARROW, tgt, fun );
         tgt = PTreeCopySrcLocation( tgt, src );
-        expr = NodeBinary( CO_CALL_NOOVLD, tgt, NodeArg( src ) );
+        expr = NodeMakeBinary( CO_CALL_NOOVLD, tgt, NodeArg( src ) );
         expr = PTreeCopySrcLocation( expr, src );
         expr = AnalyseCall( expr, diagnosis );
         if( expr->op == PT_ERROR ) {

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -1514,7 +1514,7 @@ void RtnGenCallBackArrayDtor(   // GENERATE ARRAY DTOR
     p1 = ScopeInsert( scope, p1, name );
     stmt = generateArrayDtorCall( ar_type, NodeMakeThis() );
     retn = SymFunctionReturn();
-    stmt = NodeAssignRef( MakeNodeSymbol( retn ), stmt );
+    stmt = NodeMakeRefAssignment( MakeNodeSymbol( retn ), stmt );
     EmitAnalysedStmt( stmt );
     CgFrontCodePtr( IC_PROC_RETURN, retn );
     finiClassFunction( dtor, &fn_data, &check );

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -829,7 +829,7 @@ static PTREE doClassAssign(     // ASSIGN TO CLASS OBJECT
                 fun = PTreeCopySrcLocation( fun, expr );
                 tgt = NodeDottedFunction( tgt, fun );
                 tgt = PTreeCopySrcLocation( tgt, expr );
-                call_expr = NodeMakeBinary( CO_CALL_NOOVLD, tgt, NodeArg( src ) );
+                call_expr = NodeMakeBinary( CO_CALL_NOOVLD, tgt, NodeMakeArg( src ) );
                 call_expr = PTreeCopySrcLocation( call_expr, expr );
                 call_expr = AnalyseCall( call_expr, &diagAssign );
                 PTreeFree( expr );
@@ -947,7 +947,7 @@ static PTREE genDefaultCopyDiag(// GENERATE COPY TO CLASS OBJECT, WITH DIAGNOSIS
         fun = PTreeCopySrcLocation( fun, src );
         tgt = NodeMakeBinary( CO_ARROW, tgt, fun );
         tgt = PTreeCopySrcLocation( tgt, src );
-        expr = NodeMakeBinary( CO_CALL_NOOVLD, tgt, NodeArg( src ) );
+        expr = NodeMakeBinary( CO_CALL_NOOVLD, tgt, NodeMakeArg( src ) );
         expr = PTreeCopySrcLocation( expr, src );
         expr = AnalyseCall( expr, diagnosis );
         if( expr->op == PT_ERROR ) {
@@ -2050,7 +2050,7 @@ static void ctorPrologueMember( // GENERATE PROLOGUE FOR MEMBER
                 if( NULL != TypeReference( sym->sym_type ) ) {
                     expr = NodeUnaryCopy( CO_FETCH, expr );
                 }
-                data->comp_expr = NodeArg( expr );
+                data->comp_expr = NodeMakeArg( expr );
             }
             data->comp_options = CI_NULL;
             ctorPrologueComponents( data );
@@ -2323,7 +2323,7 @@ static void ctorPrologueBaseGen(    // GENERATE FOR CTOR BASE CLASS
     data->comp_expr = extractBaseInit( data, base->type );
     if( data->comp_expr == NULL ) {
         if( data->gen_copy ) {
-            data->comp_expr = NodeArg( accessSourceBase( data->scope
+            data->comp_expr = NodeMakeArg( accessSourceBase( data->scope
                                                        , base ) );
         }
         data->comp_options = CI_NULL;

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -1173,7 +1173,7 @@ PTREE ClassCopyTemp(            // COPY A TEMPORARY
     SYMBOL ctor;                // - CTOR used
 #endif
     expr = NodeLvExtract( expr );
-    if( NodeReferencesTemporary( expr )
+    if( NodeYieldsTemporary( expr )
      && cl_type == ClassTypeForType( expr->type ) ) {
         NodeFreeDupedExpr( temp_node );
         expr = NodeLvExtract( expr );

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -1255,7 +1255,7 @@ static PTREE generateArrayClassCall( // CALL CTOR/DTOR FOR ARRAY OF CLASS OBJ.s
 {
     PTREE expr;                 // - generated expression
 
-    expr = classArrayRtCall( NodeTypeSigArg( sig )
+    expr = classArrayRtCall( NodeMakeTypeSignatureArg( sig )
                            , NULL
                            , sym
                            , artype
@@ -1753,7 +1753,7 @@ static PTREE ctorPrologueArray( // GENERATE INITIALIZATION FOR CTOR OF ARRAY
     sig = TypeSigFind( tsa, cltype, NULL, &errors );
     DbgVerify( ! errors, "ctorPrologueArray -- unexpected errors" );
     TypeSigReferenced( sig );
-    stmt = classArrayRtCall( NodeTypeSigArg( sig )
+    stmt = classArrayRtCall( NodeMakeTypeSignatureArg( sig )
                            , init_expr
                            , init_item
                            , init_type

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -827,7 +827,7 @@ static PTREE doClassAssign(     // ASSIGN TO CLASS OBJECT
                 fun->u.symcg.result = result;
                 fun->cgop = CO_NAME_DOT;
                 fun = PTreeCopySrcLocation( fun, expr );
-                tgt = NodeDottedFunction( tgt, fun );
+                tgt = NodeMakeDottedFunction( tgt, fun );
                 tgt = PTreeCopySrcLocation( tgt, expr );
                 call_expr = NodeMakeBinary( CO_CALL_NOOVLD, tgt, NodeMakeArg( src ) );
                 call_expr = PTreeCopySrcLocation( call_expr, expr );

--- a/bld/plusplus/c/analclss.c
+++ b/bld/plusplus/c/analclss.c
@@ -1181,7 +1181,7 @@ PTREE ClassCopyTemp(            // COPY A TEMPORARY
         expr->flags |= PTF_LVALUE;
     } else {
         if( NULL == temp_node ) {
-            temp_node = NodeTemporary( cl_type );
+            temp_node = NodeMakeTemporary( cl_type );
             temp_node = PTreeCopySrcLocation( temp_node, expr );
         }
 #if 0

--- a/bld/plusplus/c/analconv.c
+++ b/bld/plusplus/c/analconv.c
@@ -351,7 +351,7 @@ bool ConvertCommonType(         // CONVERT TO COMMON TYPE (:, ==, !=)
     } else
     if( nodeMemberPtr( expr->u.subtree[0] )
      || nodeMemberPtr( expr->u.subtree[1] ) ) {
-        expr->u.subtree[0] = NodeRvalueLeft( expr );
+        expr->u.subtree[0] = NodeSetRValueLeft( expr );
         expr->u.subtree[1] = NodeRvalueRight( expr );
         expr = MembPtrCommonType( expr );
         *a_expr = expr;

--- a/bld/plusplus/c/analctor.c
+++ b/bld/plusplus/c/analctor.c
@@ -532,7 +532,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
             node = NodeConvert( base_type, initial );
         } else {
             if( base_type->id == TYP_MEMBER_POINTER ) {
-                node = NodeBinary( CO_INIT, this_node, initial );
+                node = NodeMakeBinary( CO_INIT, this_node, initial );
                 node->type = this_node->type;
                 retn = MembPtrAssign( &node );
                 /* value of expression is 'this_node' */
@@ -548,7 +548,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
                     this_node = NodeUnaryCopy( CO_BITFLD_CONVERT, this_node );
                     this_node->type = base_type->of;
                 }
-                node = NodeBinary( NULL == TypeReference( base_type )
+                node = NodeMakeBinary( NULL == TypeReference( base_type )
                                    ? CO_INIT : CO_INIT_REF
                                  , this_node
                                  , initial );

--- a/bld/plusplus/c/analctor.c
+++ b/bld/plusplus/c/analctor.c
@@ -526,7 +526,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
       case TYP_POINTER :
       case TYP_MEMBER_POINTER :
         if( initial == NULL ) {
-            initial = NodeZero();
+            initial = NodeMakeZeroConstant();
         }
         if( this_node == NULL ) {
             node = NodeMakeConversion( base_type, initial );

--- a/bld/plusplus/c/analctor.c
+++ b/bld/plusplus/c/analctor.c
@@ -554,7 +554,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
                                  , initial );
                 node->type = this_node->type;
                 if( dup != NULL ) {
-                    node = NodeComma( node, dup );
+                    node = NodeMakeComma( node, dup );
                 }
             }
         }

--- a/bld/plusplus/c/analctor.c
+++ b/bld/plusplus/c/analctor.c
@@ -656,7 +656,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
         }
         break;
       case TYP_VOID :
-        node = NodeUnary( CO_TRASH_EXPR, node );
+        node = NodeMakeUnary( CO_TRASH_EXPR, node );
         node->type = base_type;
         break;
       default :

--- a/bld/plusplus/c/analctor.c
+++ b/bld/plusplus/c/analctor.c
@@ -621,7 +621,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
                     node = CallArgsArrange( ctor->sym_type
                                           , node
                                           , node->u.subtree[1]
-                                          , NodeArg( this_node )
+                                          , NodeMakeArg( this_node )
                                           , CallArgumentExactCtor
                                               ( base_type
                                               , ( control & EFFECT_EXACT ) != 0 )

--- a/bld/plusplus/c/analctor.c
+++ b/bld/plusplus/c/analctor.c
@@ -569,7 +569,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
             PTREE bare;             // - bare source operand
             PTREE co_dtor;          // - CO_DTOR operand
             if( this_node == NULL ) {
-                this_node = NodeTemporary( base_type );
+                this_node = NodeMakeTemporary( base_type );
                 this_node = PTreeSetLocn( this_node, err_locn );
                 check_dtoring = true;
             } else {

--- a/bld/plusplus/c/analctor.c
+++ b/bld/plusplus/c/analctor.c
@@ -637,7 +637,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
             }
             if( node->op == PT_ERROR ) break;
             if( check_dtoring ) {
-                node = NodeDtorExpr( node, this_node->u.symcg.symbol );
+                node = NodeMarkDtorExpr( node, this_node->u.symcg.symbol );
                 if( node->op == PT_ERROR ) break;
             }
             if( control & EFFECT_EXACT ) {

--- a/bld/plusplus/c/analctor.c
+++ b/bld/plusplus/c/analctor.c
@@ -542,7 +542,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
 
                 dup = NULL;
                 if( control & EFFECT_VALUE_THIS ) {
-                    dup = NodeDupExpr( &this_node );
+                    dup = NodeMakeExprDuplicate( &this_node );
                 }
                 if( base_type->id == TYP_BITFIELD ) {
                     this_node = NodeUnaryCopy( CO_BITFLD_CONVERT, this_node );

--- a/bld/plusplus/c/analctor.c
+++ b/bld/plusplus/c/analctor.c
@@ -529,7 +529,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
             initial = NodeZero();
         }
         if( this_node == NULL ) {
-            node = NodeConvert( base_type, initial );
+            node = NodeMakeConversion( base_type, initial );
         } else {
             if( base_type->id == TYP_MEMBER_POINTER ) {
                 node = NodeMakeBinary( CO_INIT, this_node, initial );

--- a/bld/plusplus/c/analctor.c
+++ b/bld/plusplus/c/analctor.c
@@ -622,7 +622,7 @@ PTREE EffectCtor(               // EFFECT A CONSTRUCTION
                                           , node
                                           , node->u.subtree[1]
                                           , NodeMakeArg( this_node )
-                                          , CallArgumentExactCtor
+                                          , MakeArgCtorCall
                                               ( base_type
                                               , ( control & EFFECT_EXACT ) != 0 )
                                           , NULL );

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -202,7 +202,7 @@ bool AnalyseThisDataItem(       // ANALYSE "THIS" DATA ITEM IN PARSE TREE
             expr->flags |= PTF_PTR_NONZERO;
             NodeConvertToBasePtr( &expr, type, result, true );
             expr->flags |= PTF_LVALUE | PTF_LV_CHECKED;
-            expr = NodeBinary( CO_DOT, expr, NodeOffset( result->offset ) );
+            expr = NodeMakeBinary( CO_DOT, expr, NodeOffset( result->offset ) );
         }
         expr->type = type;
         expr->flags |= PTF_LVALUE;
@@ -247,7 +247,7 @@ static PTREE thisPointsNode(    // MAKE this->node
         PTreeErrorExpr( node, ERR_INVALID_NONSTATIC_ACCESS );
     } else {
         type = node->type;
-        node = NodeBinary( CO_ARROW, left, node );
+        node = NodeMakeBinary( CO_ARROW, left, node );
         node->type = type;
         node->flags |= PTF_LVALUE;
         node = PTreeCopySrcLocation( node, left );

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -945,7 +945,7 @@ PTREE AnalyseLvDot(             // ANALYSE LVALUE "."
                     }
                     expr->u.subtree[0] = left;
 #else
-                    expr->u.subtree[0] = NodeForceLvalue( left );
+                    expr->u.subtree[0] = NodeForceLValue( left );
 #endif
                 }
             }

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -718,7 +718,7 @@ static TYPE analyseClPtrLeft(   // ANALYSE A CLASS POINTER ON LEFT
                 InfClassDecl( type );
                 PTreeErrorNode( expr );
                 type = NULL;
-            } else if( ! NodeDerefPtr( &expr->u.subtree[0] ) ) {
+            } else if( ! NodeTryDerefPtr( &expr->u.subtree[0] ) ) {
                 PTreeErrorNode( expr );
                 type = NULL;
             }

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -702,7 +702,7 @@ static TYPE analyseClPtrLeft(   // ANALYSE A CLASS POINTER ON LEFT
     TYPE type;                  // - node type
 
     expr = *a_expr;
-    left = NodeRvalueLeft( expr );
+    left = NodeSetRValueLeft( expr );
     type = TypedefModifierRemove( left->type );
     if( ( type->id != TYP_POINTER ) || ( TF1_REFERENCE & type->flag ) ) {
         type = diagMember( left, expr, ERR_MUST_BE_PTR_TO_STRUCT_OR_UNION );

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -378,7 +378,7 @@ static bool analyseBareSymbol(  // ANALYSE AN BARE SYMBOL
         alias = NodeSymbol( NULL, sym->u.alias, expr->u.symcg.result );
         alias = PTreeCopySrcLocation( alias, expr );
         if( PointerType( sym->sym_type ) != NULL ) {
-            alias = NodeConvert( sym->sym_type, alias );
+            alias = NodeMakeConversion( sym->sym_type, alias );
         }
         PTreeFree( expr );
         *a_expr = alias;
@@ -937,7 +937,7 @@ PTREE AnalyseLvDot(             // ANALYSE LVALUE "."
                 if( cl_type != NULL ) {
 #if 0
                     if( OMR_CLASS_REF == ObjModelArgument( cl_type ) ) {
-                        left = NodeConvert( MakeReferenceTo( left->type )
+                        left = NodeMakeConversion( MakeReferenceTo( left->type )
                                           , left );
                         left->flags |= PTF_LVALUE;
                     } else {

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -190,11 +190,11 @@ bool AnalyseThisDataItem(       // ANALYSE "THIS" DATA ITEM IN PARSE TREE
         right->u.symcg.result = NULL;
         if( expr->u.subtree[0]->flags & PTF_MEMORY_EXACT ) {
             offset = result->exact_delta + result->offset;
-            right = NodeReplace( right, NodeOffset( offset ) );
+            right = NodeReplace( right, NodeMakeConstantOffset( offset ) );
             *r_right = right;
         } else if( result->non_virtual ) {
             offset = result->delta + result->offset;
-            right = NodeReplace( right, NodeOffset( offset ) );
+            right = NodeReplace( right, NodeMakeConstantOffset( offset ) );
             *r_right = right;
         } else {
             expr = NodePruneRight( expr );
@@ -202,7 +202,7 @@ bool AnalyseThisDataItem(       // ANALYSE "THIS" DATA ITEM IN PARSE TREE
             expr->flags |= PTF_PTR_NONZERO;
             NodeConvertToBasePtr( &expr, type, result, true );
             expr->flags |= PTF_LVALUE | PTF_LV_CHECKED;
-            expr = NodeMakeBinary( CO_DOT, expr, NodeOffset( result->offset ) );
+            expr = NodeMakeBinary( CO_DOT, expr, NodeMakeConstantOffset( result->offset ) );
         }
         expr->type = type;
         expr->flags |= PTF_LVALUE;
@@ -1092,7 +1092,7 @@ PTREE AnalyseOffsetOf(          // ANALYSE OFFSETOF
     PTreeFreeSubtrees( field );
     if( curr == NULL ) {
         PTreeFreeSubtrees( expr );
-        expr = NodeOffset( offset );
+        expr = NodeMakeConstantOffset( offset );
     }
     return expr;
 }

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -435,7 +435,7 @@ static bool massageStaticEnumAccess( // x.static, x.enum adjustments
     expr->u.subtree[1] = NULL;
     PTreeFree( expr );
     retb = analyseBareSymbol( &rhs );
-    *a_expr = NodeCommaIfSideEffect( lhs, rhs );
+    *a_expr = NodeMakeCommaIfLHSSideEffect( lhs, rhs );
 #endif
     return( retb );
 }

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -941,7 +941,7 @@ PTREE AnalyseLvDot(             // ANALYSE LVALUE "."
                                           , left );
                         left->flags |= PTF_LVALUE;
                     } else {
-                        left = NodeAssignTemporary( left->type, left );
+                        left = NodeMakeAssignToNewTmp( left->type, left );
                     }
                     expr->u.subtree[0] = left;
 #else

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -242,7 +242,7 @@ static PTREE thisPointsNode(    // MAKE this->node
     TYPE type;                  // - node type
     PTREE left;                 // - this node to left
 
-    left = NodeThisCopyLocation( node );
+    left = NodeMakeRVThisAtLoc( node );
     if( left == NULL ) {
         PTreeErrorExpr( node, ERR_INVALID_NONSTATIC_ACCESS );
     } else {
@@ -811,7 +811,7 @@ bool AnalyseLvalue(             // ANALYSE AN LVALUE
     switch( expr->op ) {
     case PT_ID :
         if( expr->cgop == CO_NAME_THIS ) {
-            right = NodeThisCopyLocation( expr );
+            right = NodeMakeRVThisAtLoc( expr );
             if( NULL == right ) {
                 PTreeErrorExpr( expr, ERR_NO_THIS_PTR_DEFINED );
             } else {

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -399,7 +399,7 @@ static bool analyseBareSymbol(  // ANALYSE AN BARE SYMBOL
             if( SymIsEnumeration( sym ) ) {
                 sym = expr->u.symcg.symbol;
                 PTreeFree( expr );
-                expr = NodeFromConstSym( sym );
+                expr = NodeMakeFromConstSym( sym );
                 expr->type = sym->sym_type;
             } else {
                 expr = NodeSetMemoryExact( expr );

--- a/bld/plusplus/c/anallval.c
+++ b/bld/plusplus/c/anallval.c
@@ -821,7 +821,7 @@ bool AnalyseLvalue(             // ANALYSE AN LVALUE
                 retb = true;
             }
         } else if( expr->cgop == CO_NAME_CDTOR_EXTRA ) {
-            *a_expr = NodeCDtorExtra();
+            *a_expr = NodeMakeCDtorExtraParm();
             PTreeFree( expr );
             retb = true;
         } else if( expr->cgop == CO_NAME_DTOR ) {

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -54,7 +54,7 @@ static PTREE newCheckForNULL( PTREE value, PTREE t_expr )
     PTREE f_expr;
 
     f_expr = value;
-    value = NodeDupExpr( &f_expr );
+    value = NodeMakeExprDuplicate( &f_expr );
     b_expr = NodeMakeZeroCompare( value );
     return( NodeTestExpr( b_expr, t_expr, f_expr ) );
 }
@@ -495,7 +495,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
         /* calculate "nelem * sizeof( elem )" */
         dup = array_number;
         if( sym_ctor != NULL || flag.needs_count ) {
-            array_number = NodeDupExpr( &dup );
+            array_number = NodeMakeExprDuplicate( &dup );
             flag.free_array_no = true;
         }
         node = NodeMakeBinary( CO_TIMES, dup, elem_size );
@@ -597,7 +597,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
             node = RunTimeCall( args, new_expr_type, rt_code );
             if( placement != NULL ) {
                 dup = node;
-                node = NodeDupExpr( &dup );
+                node = NodeMakeExprDuplicate( &dup );
                 node = newCheckForNULL( dup, node );
             }
         } else {
@@ -605,7 +605,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
             /* no constructor req'd */
             if( flag.needs_count ) {
                 dup = node;
-                node = NodeDupExpr( &dup );
+                node = NodeMakeExprDuplicate( &dup );
                 expr = setupArrayStorage( dup, new_expr_type, array_number );
                 node = newCheckForNULL( node, expr );
             }
@@ -614,7 +614,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
         ScopeFreeResult( result_dlt );
         if( initial != NULL || sym_ctor != NULL ) {
             dup = node;
-            node = NodeDupExpr( &dup );
+            node = NodeMakeExprDuplicate( &dup );
 #if 0
             dup->type = type;
             dup->flags |= PTF_LVALUE;
@@ -780,7 +780,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
             }
             flag.test_null = true;
             dup = data;
-            data = NodeDupExpr( &dup );
+            data = NodeMakeExprDuplicate( &dup );
             expr = AnalyseDtorCall( cltype, data, dtor_code );
         } else {
             target_size_t elem_size;    // - size of an element
@@ -806,7 +806,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                     if( flag.array_delete ) {
                         flag.test_null = true;
                         dup = data;
-                        data = NodeDupExpr( &dup );
+                        data = NodeMakeExprDuplicate( &dup );
                         expr = NodeMakeBinary( CO_MINUS, data, sizeOfUInt() );
                         expr->type = expr->u.subtree[0]->type;
                     } else {
@@ -834,7 +834,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                     // handle case: 2
                     flag.test_null = true;
                     dup = data;
-                    data = NodeDupExpr( &dup );
+                    data = NodeMakeExprDuplicate( &dup );
                     if( num_args == 2 ) {
                         data = PtdDltDtorSize( data, elem_size );
                     }
@@ -858,7 +858,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                     if( flag.adjust_for_num ) {
                         flag.test_null = true;
                         dup = data;
-                        data = NodeDupExpr( &dup );
+                        data = NodeMakeExprDuplicate( &dup );
                         expr = NodeMakeBinary( CO_MINUS, data, sizeOfUInt() );
                         expr->type = expr->u.subtree[0]->type;
                     } else {
@@ -875,7 +875,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
 
                     // 'expr' must already be adjusted down by sizeof(unsigned)
                     dup2 = expr;
-                    expr = NodeDupExpr( &dup2 );
+                    expr = NodeMakeExprDuplicate( &dup2 );
                     expr = NodeMakeConversion( MakeReferenceTo( GetBasicType( TYP_UINT ) ), expr );
                     args = NodeMakeBinary( CO_TIMES, NodeGetRValue( expr ), args );
                     offset_type = args->u.subtree[1]->type;
@@ -885,7 +885,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                     if( ! flag.test_null ) {
                         flag.test_null = true;
                         dup = expr;
-                        expr = NodeDupExpr( &dup );
+                        expr = NodeMakeExprDuplicate( &dup );
                     }
                 }
             } else {

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -56,7 +56,7 @@ static PTREE newCheckForNULL( PTREE value, PTREE t_expr )
     f_expr = value;
     value = NodeMakeExprDuplicate( &f_expr );
     b_expr = NodeMakeZeroCompare( value );
-    return( NodeTestExpr( b_expr, t_expr, f_expr ) );
+    return( NodeMakeTernaryExpr( b_expr, t_expr, f_expr ) );
 }
 
 static TYPE figureOutNewType( PTREE *pnumber, TYPE *of_type )
@@ -655,7 +655,7 @@ static PTREE deleteCheckForNULL( PTREE value, PTREE t_expr )
 
     b_expr = NodeMakeZeroCompare( value );
     f_expr = NodeMakeConstantOffset( 0 );
-    return( NodeTestExpr( b_expr, t_expr, f_expr ) );
+    return( NodeMakeTernaryExpr( b_expr, t_expr, f_expr ) );
 }
 
 

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -512,7 +512,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
     // build call to appropriate operator new
     //
     node->locn = err_locn;
-    node = NodeArgument( placement, node );
+    node = NodeMakeArgument( placement, node );
     ++count_placement;
     node = buildNewCall( node
                        , opNewSearchScope( class_type, cgop )
@@ -591,9 +591,9 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
                 args = NodeArg( MakeNodeSymbol( addr_op_del ) );
                 args = PtdScopeCall( args, op_dlt );
             }
-            args = NodeArgument( args, NodeTypeSig( sig ) );
-            args = NodeArgument( args, array_number );
-            args = NodeArgument( args, node );
+            args = NodeMakeArgument( args, NodeTypeSig( sig ) );
+            args = NodeMakeArgument( args, array_number );
+            args = NodeMakeArgument( args, node );
             node = RunTimeCall( args, new_expr_type, rt_code );
             if( placement != NULL ) {
                 dup = node;
@@ -768,7 +768,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
     flag.test_null = false;
     if( cltype == NULL ) {
         // delete a simple type; call op del() or op del []()
-        args = NodeArgument( NULL, data );
+        args = NodeMakeArgument( NULL, data );
         expr = NodeMakeCall( sym, GetBasicType( TYP_VOID ), args );
     } else {
         if( ! flag.inside_dtor && info->needs_vdtor ) {
@@ -894,7 +894,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
             if( args != NULL ) {
                 args = NodeArg( args );
             }
-            args = NodeArgument( args, expr );
+            args = NodeMakeArgument( args, expr );
             expr = NodeMakeCall( sym, GetBasicType( TYP_VOID ), args );
         }
     }

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -93,7 +93,7 @@ static TYPE figureOutNewType( PTREE *pnumber, TYPE *of_type )
         number = size / CgTypeSize( base_type );
         extra_number = NodeOffset( number );
         if( array_number != NULL ) {
-            array_number = NodeRvalue( array_number );
+            array_number = NodeGetRValue( array_number );
             array_number = NodeMakeBinary( CO_TIMES, array_number, extra_number );
             array_number->type = extra_number->type;
             array_number = FoldBinary( array_number );
@@ -473,7 +473,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
         if( flag.needs_dtor || num_args == 2 ) {
             flag.needs_count = true;
         }
-        array_number = NodeRvalue( array_number );
+        array_number = NodeGetRValue( array_number );
         if( IntegralType( array_number->type ) == NULL ) {
             PTreeErrorExpr( array_number, ERR_NEW_ARRAY_EXPRESSION );
             ScopeFreeResult( result_dlt );
@@ -705,7 +705,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
     data = expr->u.subtree[0];
     PTreeExtractLocn( expr, &err_locn );
     PTreeFree( expr );
-    data = NodeRvalue( data );
+    data = NodeGetRValue( data );
     type = data->type;
     ptr_type = PointerType( type );
     if( ptr_type == NULL ) {
@@ -877,7 +877,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                     dup2 = expr;
                     expr = NodeDupExpr( &dup2 );
                     expr = NodeMakeConversion( MakeReferenceTo( GetBasicType( TYP_UINT ) ), expr );
-                    args = NodeMakeBinary( CO_TIMES, NodeRvalue( expr ), args );
+                    args = NodeMakeBinary( CO_TIMES, NodeGetRValue( expr ), args );
                     offset_type = args->u.subtree[1]->type;
                     args->type = offset_type;
                     args = NodeAddToLeft( args, sizeOfUInt(), offset_type );

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -582,13 +582,13 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
                     } else {
                         rt_code = RTF_CTAS_1M;
                     }
-                    args = NodeArg( MakeNodeSymbol( addr_op_del ) );
+                    args = NodeMakeArg( MakeNodeSymbol( addr_op_del ) );
                     args = PtdScopeCall( args, op_dlt );
                 }
             } else {
                 DbgVerify( flag.needs_count, "AnalyseNew -- flags mismatch" );
                 rt_code = RTF_CTAS_2S;
-                args = NodeArg( MakeNodeSymbol( addr_op_del ) );
+                args = NodeMakeArg( MakeNodeSymbol( addr_op_del ) );
                 args = PtdScopeCall( args, op_dlt );
             }
             args = NodeMakeArgument( args, NodeTypeSig( sig ) );
@@ -892,7 +892,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                 args = NULL;
             }
             if( args != NULL ) {
-                args = NodeArg( args );
+                args = NodeMakeArg( args );
             }
             args = NodeMakeArgument( args, expr );
             expr = NodeMakeCall( sym, GetBasicType( TYP_VOID ), args );

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -824,7 +824,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                         data = PtdDltDtorArr( data, sym );
                         TypeSigReferenced( sig );
                         arg = NodeTypeSig( sig );
-                        args = NodeArguments( arg, data, NULL );
+                        args = NodeMakeArgList( arg, data, NULL );
                         expr = RunTimeCall( args, type, RTF_DTOR_AR_STORE );
                         expr = PtdDltDtorEnd( expr );
                     } else {

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -45,7 +45,7 @@
 
 static PTREE sizeOfUInt( void )
 {
-    return NodeOffset( SizeTargetSizeT() );
+    return NodeMakeConstantOffset( SizeTargetSizeT() );
 }
 
 static PTREE newCheckForNULL( PTREE value, PTREE t_expr )
@@ -76,7 +76,7 @@ static TYPE figureOutNewType( PTREE *pnumber, TYPE *of_type )
     if( array_number == NULL ) {
         test_type = ArrayType( type );
         if( test_type != NULL ) {
-            array_number = NodeOffset( test_type->u.a.array_size );
+            array_number = NodeMakeConstantOffset( test_type->u.a.array_size );
             new_expr_type = PointerTypeForArray( type );
             type = test_type->of;
         } else {
@@ -91,7 +91,7 @@ static TYPE figureOutNewType( PTREE *pnumber, TYPE *of_type )
         size = CgTypeSize( type );
         base_type = ArrayBaseType( type );
         number = size / CgTypeSize( base_type );
-        extra_number = NodeOffset( number );
+        extra_number = NodeMakeConstantOffset( number );
         if( array_number != NULL ) {
             array_number = NodeGetRValue( array_number );
             array_number = NodeMakeBinary( CO_TIMES, array_number, extra_number );
@@ -419,7 +419,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
     NodeFreeDupedExpr( expr );
     /* 'type', 'placement', 'array_number', and 'initial' are set now */
     new_expr_type = figureOutNewType( &array_number, &type );
-    elem_size = NodeOffset( CgTypeSize( type ) );
+    elem_size = NodeMakeConstantOffset( CgTypeSize( type ) );
     offset_type = elem_size->type;
     base_type = ArrayBaseType( type );
     class_type = StructType( type );
@@ -654,7 +654,7 @@ static PTREE deleteCheckForNULL( PTREE value, PTREE t_expr )
     PTREE f_expr;
 
     b_expr = NodeMakeZeroCompare( value );
-    f_expr = NodeOffset( 0 );
+    f_expr = NodeMakeConstantOffset( 0 );
     return( NodeTestExpr( b_expr, t_expr, f_expr ) );
 }
 
@@ -869,7 +869,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                 }
             }
             if( num_args == 2 ) {
-                args = NodeOffset( elem_size );
+                args = NodeMakeConstantOffset( elem_size );
                 if( flag.array_delete ) {
                     PTREE dup2;
 

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -185,7 +185,7 @@ static PTREE setupArrayStorage( // STORE COUNT IN ARRAY_STORAGE,POINT TO ARRAY
     TYPE new_expr_type,         // - TYPE of expression
     PTREE array_number )        // - expression for count
 {
-    expr = NodeConvertFlags( GetBasicType( TYP_UINT ), expr, PTF_LVALUE );
+    expr = NodeMakeConversionFlags( GetBasicType( TYP_UINT ), expr, PTF_LVALUE );
     expr = NodeAssign( expr, array_number );
     expr = NodeMakeConversion( new_expr_type, expr );
     expr = NodeAddToLeft( expr, sizeOfUInt(), new_expr_type );
@@ -619,7 +619,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
             dup->type = type;
             dup->flags |= PTF_LVALUE;
 #else
-            dup = NodeConvertFlags( type, dup, PTF_LVALUE );
+            dup = NodeMakeConversionFlags( type, dup, PTF_LVALUE );
 #endif
             if( sym_ctor != NULL && placement == NULL ) {
                 dup = PtdNewAlloc( dup );
@@ -661,7 +661,7 @@ static PTREE deleteCheckForNULL( PTREE value, PTREE t_expr )
 
 static PTREE setDeleteType( PTREE expr, TOKEN_LOCN *locn )
 {
-    expr = NodeConvertFlags( GetBasicType( TYP_VOID ), expr, PTF_MEANINGFUL | PTF_SIDE_EFF );
+    expr = NodeMakeConversionFlags( GetBasicType( TYP_VOID ), expr, PTF_MEANINGFUL | PTF_SIDE_EFF );
     PTreeSetLocn( expr, locn );
     return( expr );
 }

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -187,7 +187,7 @@ static PTREE setupArrayStorage( // STORE COUNT IN ARRAY_STORAGE,POINT TO ARRAY
 {
     expr = NodeConvertFlags( GetBasicType( TYP_UINT ), expr, PTF_LVALUE );
     expr = NodeAssign( expr, array_number );
-    expr = NodeConvert( new_expr_type, expr );
+    expr = NodeMakeConversion( new_expr_type, expr );
     expr = NodeAddToLeft( expr, sizeOfUInt(), new_expr_type );
     return expr;
 }
@@ -638,7 +638,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
                     FunctionHasRegistration();
                     expr = PtdNewCtor( expr, class_type );
                 }
-                expr = NodeConvert( new_expr_type, expr );
+                expr = NodeMakeConversion( new_expr_type, expr );
                 node = newCheckForNULL( node, expr );
             }
         }
@@ -876,7 +876,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                     // 'expr' must already be adjusted down by sizeof(unsigned)
                     dup2 = expr;
                     expr = NodeDupExpr( &dup2 );
-                    expr = NodeConvert( MakeReferenceTo( GetBasicType( TYP_UINT ) ), expr );
+                    expr = NodeMakeConversion( MakeReferenceTo( GetBasicType( TYP_UINT ) ), expr );
                     args = NodeMakeBinary( CO_TIMES, NodeRvalue( expr ), args );
                     offset_type = args->u.subtree[1]->type;
                     args->type = offset_type;

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -94,7 +94,7 @@ static TYPE figureOutNewType( PTREE *pnumber, TYPE *of_type )
         extra_number = NodeOffset( number );
         if( array_number != NULL ) {
             array_number = NodeRvalue( array_number );
-            array_number = NodeBinary( CO_TIMES, array_number, extra_number );
+            array_number = NodeMakeBinary( CO_TIMES, array_number, extra_number );
             array_number->type = extra_number->type;
             array_number = FoldBinary( array_number );
         } else {
@@ -234,7 +234,7 @@ static CNV_RETN checkNewCtor(   // CHECK CTOR'ING OK FOR NEW
             CErr1( ERR_NO_CTOR_FOR_NEW );
         } else {
             ConversionTypesSet( NodeType( initial ), base_type );
-            initial = NodeBinary( CO_CTOR, NULL, initial );
+            initial = NodeMakeBinary( CO_CTOR, NULL, initial );
             *a_initial = initial;
             initial = PTreeCopySrcLocation( initial, initial->u.subtree[1] );
             CtorDiagNoMatch( initial, ERR_NO_CTOR_FOR_NEW, &fnov_diag );
@@ -498,7 +498,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
             array_number = NodeDupExpr( &dup );
             flag.free_array_no = true;
         }
-        node = NodeBinary( CO_TIMES, dup, elem_size );
+        node = NodeMakeBinary( CO_TIMES, dup, elem_size );
         node->type = offset_type;
         node = FoldBinary( node );
         if( flag.needs_count ) {
@@ -807,7 +807,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                         flag.test_null = true;
                         dup = data;
                         data = NodeDupExpr( &dup );
-                        expr = NodeBinary( CO_MINUS, data, sizeOfUInt() );
+                        expr = NodeMakeBinary( CO_MINUS, data, sizeOfUInt() );
                         expr->type = expr->u.subtree[0]->type;
                     } else {
                         expr = data;
@@ -859,7 +859,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                         flag.test_null = true;
                         dup = data;
                         data = NodeDupExpr( &dup );
-                        expr = NodeBinary( CO_MINUS, data, sizeOfUInt() );
+                        expr = NodeMakeBinary( CO_MINUS, data, sizeOfUInt() );
                         expr->type = expr->u.subtree[0]->type;
                     } else {
                         expr = data;
@@ -877,7 +877,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                     dup2 = expr;
                     expr = NodeDupExpr( &dup2 );
                     expr = NodeConvert( MakeReferenceTo( GetBasicType( TYP_UINT ) ), expr );
-                    args = NodeBinary( CO_TIMES, NodeRvalue( expr ), args );
+                    args = NodeMakeBinary( CO_TIMES, NodeRvalue( expr ), args );
                     offset_type = args->u.subtree[1]->type;
                     args->type = offset_type;
                     args = NodeAddToLeft( args, sizeOfUInt(), offset_type );

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -186,7 +186,7 @@ static PTREE setupArrayStorage( // STORE COUNT IN ARRAY_STORAGE,POINT TO ARRAY
     PTREE array_number )        // - expression for count
 {
     expr = NodeMakeConversionFlags( GetBasicType( TYP_UINT ), expr, PTF_LVALUE );
-    expr = NodeAssign( expr, array_number );
+    expr = NodeMakeAssignment( expr, array_number );
     expr = NodeMakeConversion( new_expr_type, expr );
     expr = NodeAddToLeft( expr, sizeOfUInt(), new_expr_type );
     return expr;

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -55,7 +55,7 @@ static PTREE newCheckForNULL( PTREE value, PTREE t_expr )
 
     f_expr = value;
     value = NodeDupExpr( &f_expr );
-    b_expr = NodeCompareToZero( value );
+    b_expr = NodeMakeZeroCompare( value );
     return( NodeTestExpr( b_expr, t_expr, f_expr ) );
 }
 
@@ -653,7 +653,7 @@ static PTREE deleteCheckForNULL( PTREE value, PTREE t_expr )
     PTREE b_expr;
     PTREE f_expr;
 
-    b_expr = NodeCompareToZero( value );
+    b_expr = NodeMakeZeroCompare( value );
     f_expr = NodeOffset( 0 );
     return( NodeTestExpr( b_expr, t_expr, f_expr ) );
 }

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -591,7 +591,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
                 args = NodeMakeArg( MakeNodeSymbol( addr_op_del ) );
                 args = PtdScopeCall( args, op_dlt );
             }
-            args = NodeMakeArgument( args, NodeTypeSig( sig ) );
+            args = NodeMakeArgument( args, NodeMakeTypeSignature( sig ) );
             args = NodeMakeArgument( args, array_number );
             args = NodeMakeArgument( args, node );
             node = RunTimeCall( args, new_expr_type, rt_code );
@@ -823,7 +823,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                         }
                         data = PtdDltDtorArr( data, sym );
                         TypeSigReferenced( sig );
-                        arg = NodeTypeSig( sig );
+                        arg = NodeMakeTypeSignature( sig );
                         args = NodeMakeArgList( arg, data, NULL );
                         expr = RunTimeCall( args, type, RTF_DTOR_AR_STORE );
                         expr = PtdDltDtorEnd( expr );

--- a/bld/plusplus/c/analnew.c
+++ b/bld/plusplus/c/analnew.c
@@ -188,7 +188,7 @@ static PTREE setupArrayStorage( // STORE COUNT IN ARRAY_STORAGE,POINT TO ARRAY
     expr = NodeMakeConversionFlags( GetBasicType( TYP_UINT ), expr, PTF_LVALUE );
     expr = NodeMakeAssignment( expr, array_number );
     expr = NodeMakeConversion( new_expr_type, expr );
-    expr = NodeAddToLeft( expr, sizeOfUInt(), new_expr_type );
+    expr = NodeMakeLeftAddition( expr, sizeOfUInt(), new_expr_type );
     return expr;
 }
 
@@ -502,7 +502,7 @@ PTREE AnalyseNew(               // ANALYSE A "NEW" OPERATOR (WITH OVERLOADING)
         node->type = offset_type;
         node = FoldBinary( node );
         if( flag.needs_count ) {
-            node = NodeAddToLeft( node, sizeOfUInt(), offset_type );
+            node = NodeMakeLeftAddition( node, sizeOfUInt(), offset_type );
             node = FoldBinary( node );
         }
     } else {
@@ -880,7 +880,7 @@ PTREE AnalyseDelete(            // ANALYSE DELETE OPERATOR
                     args = NodeMakeBinary( CO_TIMES, NodeGetRValue( expr ), args );
                     offset_type = args->u.subtree[1]->type;
                     args->type = offset_type;
-                    args = NodeAddToLeft( args, sizeOfUInt(), offset_type );
+                    args = NodeMakeLeftAddition( args, sizeOfUInt(), offset_type );
                     expr = dup2;
                     if( ! flag.test_null ) {
                         flag.test_null = true;

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1851,7 +1851,7 @@ static CNV_DIAG diag_deref =    // diagnosis for de-referencing
 };
 
 
-bool NodeDerefPtr(              // DEREFERENCE A POINTER
+bool NodeTryDerefPtr(              // DEREFERENCE A POINTER
     PTREE *a_ptr )              // - addr[ ptr operand ]
 {
     bool retb;                  // - true ==> all ok

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -800,7 +800,7 @@ bool NodeIsZeroIntConstant(     // TEST IF A ZERO INTEGER CONSTANT
 }
 
 
-PTREE NodeFromConstSym(         // BUILD CONSTANT NODE FROM CONSTANT SYMBOL
+PTREE NodeMakeFromConstSym(         // BUILD CONSTANT NODE FROM CONSTANT SYMBOL
     SYMBOL con )                // - constant symbol
 {
     INT_CONSTANT icon;          // - integral constant
@@ -1055,7 +1055,7 @@ PTREE NodeRvalue(               // GET RVALUE, IF LVALUE
                     SYMBOL con;     // constant symbol
                     con = curr->u.symcg.symbol;
                     orig = curr;
-                    curr = NodeFromConstSym( con );
+                    curr = NodeMakeFromConstSym( con );
                     curr = PTreeCopySrcLocation( curr, orig );
                     NodeFreeSearchResult( orig );
                     PTreeFree( orig );

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1677,7 +1677,7 @@ static addr_func_t checkFunction(   // CHECK IF FUNCTION
 }
 
 
-addr_func_t NodeAddrOfFun(      // GET PTREE FOR &FUN (FUN IS OVERLOADED)
+addr_func_t NodeGetOverloadedFnAddr(      // GET PTREE FOR &FUN (FUN IS OVERLOADED)
     PTREE oper,                 // - expression
     PTREE *addr_func )          // - addr[ function ]
 {

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2338,7 +2338,7 @@ PTREE NodeSetType               // SET NODE TYPE, FLAGS
 }
 
 
-PTREE NodeLvExtract             // EXTRACT LVALUE, IF POSSIBLE
+PTREE NodeExtractLValue             // EXTRACT LVALUE, IF POSSIBLE
     ( PTREE expr )              // - expression
 {
     TYPE expr_type;             // - expression type
@@ -2393,7 +2393,7 @@ PTREE NodeLvExtract             // EXTRACT LVALUE, IF POSSIBLE
 PTREE NodeForceLvalue           // FORCE EXPRESSION TO BE LVALUE
     ( PTREE expr )              // - expression
 {
-    expr = NodeLvExtract( expr );
+    expr = NodeExtractLValue( expr );
     if( ! ExprIsLvalue( expr ) ) {
         TYPE type = TypeReferenced( expr->type );
         TEMP_TYPE old = TemporaryClass( TEMP_TYPE_EXPR );

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1333,7 +1333,7 @@ PTREE NodeMakeExprDuplicate(              // DUPLICATE EXPRESSION
 }
 
 
-bool NodeBitField(              // TEST IF NODE IS A BIT FIELD
+bool NodeIsBitField(              // TEST IF NODE IS A BIT FIELD
     PTREE node )                // - the node
 {
     bool retb;                  // - true ==> is a bit field

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1782,7 +1782,7 @@ TYPE NodeType(                  // GET TYPE FOR A NODE
 }
 
 
-PTREE NodeDtorExpr(             // MARK FOR DTOR'ING AFTER EXPRESSION
+PTREE NodeMarkDtorExpr(             // MARK FOR DTOR'ING AFTER EXPRESSION
     PTREE expr,                 // - expression computing symbol
     SYMBOL sym )                // - SYMBOL being computed
 {

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1186,7 +1186,7 @@ PTREE NodeRvalueExactRight(     // SET RVALUE (EXACT) ON RIGHT
 }
 
 
-PTREE NodeCDtorArg(             // BUILD CONSTANT NODE FOR CDTOR EXTRA ARG
+PTREE NodeMakeCDtorArg(             // BUILD CONSTANT NODE FOR CDTOR EXTRA ARG
     target_offset_t code )      // - the code
 {
     return NodeIntegralConstant( code, MakeCDtorExtraArgType() );
@@ -1628,7 +1628,7 @@ PTREE CallArgumentExactCtor(    // GET EXACT CTOR ARG., IF REQUIRED
         } else {
             ctor_code = CTOR_COMPONENT;
         }
-        arg = NodeArg( NodeCDtorArg( ctor_code ) );
+        arg = NodeArg( NodeMakeCDtorArg( ctor_code ) );
     } else {
         arg = NULL;
     }

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1247,7 +1247,7 @@ PTREE NodeMakeArg(                  // MAKE A SINGLE ARGUMENT NODE
 }
 
 
-PTREE NodeArguments(            // MAKE A LIST OF ARGUMENTS
+PTREE NodeMakeArgList(            // MAKE A LIST OF ARGUMENTS
     PTREE first,                // - first arg
     ... )                       // - NULL terminated, in reverse order
 {

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1240,7 +1240,7 @@ PTREE NodeMakeArgument(             // MAKE AN ARGUMENT NODE
 }
 
 
-PTREE NodeArg(                  // MAKE A SINGLE ARGUMENT NODE
+PTREE NodeMakeArg(                  // MAKE A SINGLE ARGUMENT NODE
     PTREE argval )              // - value for argument
 {
     return NodeMakeArgument( NULL, argval );
@@ -1628,7 +1628,7 @@ PTREE CallArgumentExactCtor(    // GET EXACT CTOR ARG., IF REQUIRED
         } else {
             ctor_code = CTOR_COMPONENT;
         }
-        arg = NodeArg( NodeMakeCDtorArg( ctor_code ) );
+        arg = NodeMakeArg( NodeMakeCDtorArg( ctor_code ) );
     } else {
         arg = NULL;
     }
@@ -2317,7 +2317,7 @@ PTREE NodeTypeSig               // MAKE NODE FOR TYPE-SIG ADDRESS
 PTREE NodeTypeSigArg            // MAKE ARGUMENT NODE FOR TYPE-SIG ADDRESS
     ( TYPE_SIG* sig )           // - type signature
 {
-    return NodeArg( NodeTypeSig( sig ) );
+    return NodeMakeArg( NodeTypeSig( sig ) );
 }
 
 

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1982,7 +1982,7 @@ static bool nodeMakesTemporary( // CHECK IF NODE PRODUCES A TEMPORARY
 
     fun = NULL;
     if( NodeIsBinaryOp( node, CO_CALL_EXEC ) ) {
-        fun = NodeFuncForCall( node )->u.symcg.symbol;
+        fun = NodeGetFnForCall( node )->u.symcg.symbol;
         if( SymIsCtor( fun ) ) {
             retb = true;
         } else {
@@ -2015,7 +2015,7 @@ static bool nodeMakesTemporary( // CHECK IF NODE PRODUCES A TEMPORARY
             }
         } else if( NodeIsBinaryOp( node, CO_CALL_EXEC_IND ) ) {
             TYPE ret_type;
-            node = NodeFuncForCall( node );
+            node = NodeGetFnForCall( node );
             ret_type = TypeFunctionCalled( node->type );
             DbgVerify( ret_type != NULL
                      , "nodeMakesTemporary -- not function type" );
@@ -2228,7 +2228,7 @@ PTREE NodeAddSideEffect(        // ADD A SIDE-EFFECT EXPRESSION
 }
 
 
-PTREE NodeFuncForCall(          // GET FUNCTION NODE FOR CALL
+PTREE NodeGetFnForCall(          // GET FUNCTION NODE FOR CALL
     PTREE call_node )           // - a call node
 {
     call_node = call_node->u.subtree[0];

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2096,7 +2096,7 @@ static void assignBitDup(      // ASSIGN DUPLICATED BIT FIELD EXPRESSION
 }
 
 
-PTREE NodeBitQuestAssign(       // ASSIGN (expr?bit-fld:bit-fld) = expr
+PTREE NodeMakeBitQuestAssign(       // ASSIGN (expr?bit-fld:bit-fld) = expr
     PTREE expr )                // - the expression
 {
     PTREE result;               // - result expression

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2497,7 +2497,7 @@ PTREE NodeMakeZeroConstant                  // BUILD A ZERO NODE
 }
 
 
-PTREE NodeIntDummy              // BUILD A DUMMY INTEGRAL NODE
+PTREE NodeMakeIntDummy              // BUILD A DUMMY INTEGRAL NODE
     ( void )
 {
     return PTreeIntConstant( 12345, TYP_SINT );

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -402,7 +402,7 @@ static PTREE nodeMakeConvert(   // MAKE A CONVERSION NODE
 }
 
 
-PTREE NodeConvert(              // MAKE A CONVERSION NODE IF REQ'D
+PTREE NodeMakeConversion(              // MAKE A CONVERSION NODE IF REQ'D
     TYPE type,                  // - type for conversion
     PTREE expr )                // - expression to be converted
 {
@@ -424,7 +424,7 @@ PTREE NodeConvertFlags(         // MAKE A CONVERSION NODE WITH FLAGS, IF REQ'D
             type = MakeReferenceTo( type );
         }
     }
-    expr = NodeConvert( type, expr );
+    expr = NodeMakeConversion( type, expr );
     expr = NodeSetType( expr, type, flags );
     return expr;
 }
@@ -2351,7 +2351,7 @@ PTREE NodeLvExtract             // EXTRACT LVALUE, IF POSSIBLE
     if( NULL == TypeReference( expr_type ) ) {
         TYPE cltype = StructType( expr_type );
         if( NULL != cltype && OMR_CLASS_REF == ObjModelArgument( cltype ) ) {
-            expr = NodeConvert( MakeReferenceTo( expr_type ), expr );
+            expr = NodeMakeConversion( MakeReferenceTo( expr_type ), expr );
         } else {
             for( last = NULL, curr = expr; ; ) {
                 if( NodeIsBinaryOp( curr, CO_CONVERT )

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1636,7 +1636,7 @@ PTREE MakeArgCtorCall(    // GET EXACT CTOR ARG., IF REQUIRED
 }
 
 
-PTREE NodeArgumentExactCtor(    // ADD EXACT CTOR ARG., IF REQUIRED
+PTREE NodeMakeArgCtor(    // ADD EXACT CTOR ARG., IF REQUIRED
     PTREE args,                 // - other arguments
     TYPE type,                  // - type for class
     bool exact )                // - true ==> exact CTORing of classes

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1386,7 +1386,7 @@ PTREE NodeMakeComma(                // MAKE A COMMA PTREE NODE
 }
 
 
-PTREE NodeCommaIfSideEffect(    // MAKE A COMMA PTREE NODE (IF LHS HAS side-effects)
+PTREE NodeMakeCommaIfLHSSideEffect(    // MAKE A COMMA PTREE NODE (IF LHS HAS side-effects)
     PTREE left,                 // - left operand
     PTREE right )               // - right operand
 {

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1450,7 +1450,7 @@ PTREE NodeMakeThis(                 // MAKE A "THIS" NODE
     return node;
 }
 
-PTREE NodeThisCopyLocation(     // MAKE A RVALUE "THIS" NODE WITH LOCATION
+PTREE NodeMakeRVThisAtLoc(     // MAKE A RVALUE "THIS" NODE WITH LOCATION
     PTREE use_locn )            // - node to grab locn from
 {
     PTREE this_node;

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1517,7 +1517,7 @@ PTREE NodeMakeTemporary(            // CREATE TEMPORARY AND NODE FOR IT
 }
 
 
-PTREE NodeAssignTemporaryNode(  // ASSIGN NODE TO A TEMPORARY NODE
+PTREE NodeMakeAssignToTmp(  // ASSIGN NODE TO A TEMPORARY NODE
     TYPE type,                  // - type of temporary
     PTREE expr,                 // - the expression to be assigned to temp
     PTREE temp_node )           // - node for temporary symbol
@@ -1554,7 +1554,7 @@ PTREE NodeAssignTemporary(      // ASSIGN NODE TO A TEMPORARY
     TYPE type,                  // - type of temporary
     PTREE expr )                // - the expression to be assigned to temp
 {
-    return NodeAssignTemporaryNode( type, expr, NodeMakeTemporary( type ) );
+    return NodeMakeAssignToTmp( type, expr, NodeMakeTemporary( type ) );
 }
 
 

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1047,7 +1047,7 @@ PTREE NodeGetRValue(               // GET RVALUE, IF LVALUE
                     curr->flags &= ~ PTF_LVALUE;
                 } else if( curr->cgop == CO_NAME_CDTOR_EXTRA ) {
                     orig = curr;
-                    curr = NodeIc( IC_CDARG_FETCH );
+                    curr = NodeMakeIc( IC_CDARG_FETCH );
                     curr->type = TypeReferenced( node_type );
                     curr = PTreeCopySrcLocation( curr, orig );
                     PTreeFree( orig );
@@ -2156,7 +2156,7 @@ PTREE NodeMakeIcUnsigned(           // ADD A PTREE-IC NODE, UNSIGNED OPERAND
 }
 
 
-PTREE NodeIc(                   // ADD A PTREE-IC NODE
+PTREE NodeMakeIc(                   // ADD A PTREE-IC NODE
     CGINTEROP opcode )          // - opcode
 {
     return NodeMakeIcUnsigned( opcode, 0 );

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1172,7 +1172,7 @@ PTREE NodeSetRValueExact(          // SET RVALUE (EXACT)
 }
 
 
-PTREE NodeRvalueExactLeft(      // SET RVALUE (EXACT) ON LEFT
+PTREE NodeSetRValueExactLeft(      // SET RVALUE (EXACT) ON LEFT
     PTREE node )                // - current node
 {
     return NodeSetRValueExact( nodeRefedRvalue( &node->u.subtree[0] ) );

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1829,7 +1829,7 @@ PTREE NodeSetMemoryExact(       // SET PTF_MEMORY_EXACT, IF REQ'D
 }
 
 
-PTREE NodeBasedStr(             // BUILD EXPRESSION FOR TF1_BASED_STRING TYPE
+PTREE NodeMakeBasedStr(             // BUILD EXPRESSION FOR TF1_BASED_STRING TYPE
     TYPE expr_type )            // - TF1_BASED_STRING type
 {
     PTREE node;                 // - new node

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2314,7 +2314,7 @@ PTREE NodeMakeTypeSignature               // MAKE NODE FOR TYPE-SIG ADDRESS
 }
 
 
-PTREE NodeTypeSigArg            // MAKE ARGUMENT NODE FOR TYPE-SIG ADDRESS
+PTREE NodeMakeTypeSignatureArg            // MAKE ARGUMENT NODE FOR TYPE-SIG ADDRESS
     ( TYPE_SIG* sig )           // - type signature
 {
     return NodeMakeArg( NodeMakeTypeSignature( sig ) );

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1494,7 +1494,7 @@ static PTREE assignNode(        // CREATE ASSIGNMENT NODE
 }
 
 
-PTREE NodeAssign(               // CREATE ASSIGNMENT NODE FOR VALUE
+PTREE NodeMakeAssignment(               // CREATE ASSIGNMENT NODE FOR VALUE
     PTREE tgt,                  // - target
     PTREE src )                 // - source
 {
@@ -1531,7 +1531,7 @@ PTREE NodeAssignTemporaryNode(  // ASSIGN NODE TO A TEMPORARY NODE
         expr = ClassCopyTemp( TypeReferenced( type ), expr, temp_node );
     } else {
         if( NULL == TypeReference( type ) ) {
-            expr = NodeAssign( temp_node, expr );
+            expr = NodeMakeAssignment( temp_node, expr );
             if( expr->op != PT_ERROR
              && NULL != MemberPtrType( type ) ) {
                 PTREE a_expr = expr;
@@ -2204,7 +2204,7 @@ PTREE NodeAddSideEffect(        // ADD A SIDE-EFFECT EXPRESSION
                     expr = NodeAssignRef( MakeNodeSymbol( temp ), expr );
                 } else {
                     temp = TemporaryAlloc( temp_type );
-                    expr = NodeAssign( MakeNodeSymbol( temp ), expr );
+                    expr = NodeMakeAssignment( MakeNodeSymbol( temp ), expr );
                 }
             } else {
                 temp = TemporaryAlloc( temp_type );
@@ -2398,7 +2398,7 @@ PTREE NodeForceLvalue           // FORCE EXPRESSION TO BE LVALUE
         TYPE type = TypeReferenced( expr->type );
         TEMP_TYPE old = TemporaryClass( TEMP_TYPE_EXPR );
         SYMBOL temp = TemporaryAllocNoStorage( type );
-        expr = NodeAssign( MakeNodeSymbol( temp ), expr );
+        expr = NodeMakeAssignment( MakeNodeSymbol( temp ), expr );
         TemporaryClass( old );
     }
     return expr;

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2390,7 +2390,7 @@ PTREE NodeExtractLValue             // EXTRACT LVALUE, IF POSSIBLE
 }
 
 
-PTREE NodeForceLvalue           // FORCE EXPRESSION TO BE LVALUE
+PTREE NodeForceLValue           // FORCE EXPRESSION TO BE LVALUE
     ( PTREE expr )              // - expression
 {
     expr = NodeExtractLValue( expr );
@@ -2483,7 +2483,7 @@ PTREE NodeDottedFunction        // BUILD A DOT NODE FOR A FUNCTION
 {
     PTREE node;                 // - node
 
-    node = NodeMakeBinary( CO_DOT, NodeForceLvalue( left ), right );
+    node = NodeMakeBinary( CO_DOT, NodeForceLValue( left ), right );
     node->flags = right->flags | PTF_LVALUE | PTF_LV_CHECKED;
     node->type = right->type;
     return node;

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1140,7 +1140,7 @@ PTREE NodeRvalueRight(          // SET RVALUE ON RIGHT
 }
 
 
-PTREE NodeRvalueExact(          // SET RVALUE (EXACT)
+PTREE NodeSetRValueExact(          // SET RVALUE (EXACT)
     PTREE node )                // - current node
 {
     TYPE exact_type;            // - exact type
@@ -1175,14 +1175,14 @@ PTREE NodeRvalueExact(          // SET RVALUE (EXACT)
 PTREE NodeRvalueExactLeft(      // SET RVALUE (EXACT) ON LEFT
     PTREE node )                // - current node
 {
-    return NodeRvalueExact( nodeRefedRvalue( &node->u.subtree[0] ) );
+    return NodeSetRValueExact( nodeRefedRvalue( &node->u.subtree[0] ) );
 }
 
 
 PTREE NodeRvalueExactRight(     // SET RVALUE (EXACT) ON RIGHT
     PTREE node )                // - current node
 {
-    return NodeRvalueExact( nodeRefedRvalue( &node->u.subtree[1] ) );
+    return NodeSetRValueExact( nodeRefedRvalue( &node->u.subtree[1] ) );
 }
 
 

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -468,7 +468,7 @@ PTREE NodeMakeZeroCompare(        // MAKE A COMPARE-TO-ZERO NODE, IF REQ'D
             type = GetBasicType( TYP_SINT );
         }
         operand = expr;
-        zero = NodeIntegralConstant( 0, type );
+        zero = NodeMakeIntegralConstant( 0, type );
         expr = NodeMakeBinary( CO_NE, operand, zero );
         expr = PTreeCopySrcLocation( expr, operand );
         expr = NodeSetBooleanType( expr );
@@ -507,7 +507,7 @@ PTREE NodeMakeBoolConversion(        // MAKE A CONVERT-TO-BOOL NODE, IF REQ'D
         expr = CastImplicit( expr, bool_type, CNV_EXPR, &diagConvertToBool );
     } else {
         operand = expr;
-        zero = NodeIntegralConstant( 0, GetBasicType( TYP_SINT ) );
+        zero = NodeMakeIntegralConstant( 0, GetBasicType( TYP_SINT ) );
         expr = NodeMakeBinary( CO_NE, expr, zero );
         expr = PTreeCopySrcLocation( expr, operand );
         expr = AnalyseOperator( expr );
@@ -1189,11 +1189,11 @@ PTREE NodeRvalueExactRight(     // SET RVALUE (EXACT) ON RIGHT
 PTREE NodeMakeCDtorArg(             // BUILD CONSTANT NODE FOR CDTOR EXTRA ARG
     target_offset_t code )      // - the code
 {
-    return NodeIntegralConstant( code, MakeCDtorExtraArgType() );
+    return NodeMakeIntegralConstant( code, MakeCDtorExtraArgType() );
 }
 
 
-PTREE NodeIntegralConstant      // BUILD AN INTEGRAL NODE FOR A VALUE
+PTREE NodeMakeIntegralConstant      // BUILD AN INTEGRAL NODE FOR A VALUE
     ( int val                   // - value
     , TYPE type )               // - node type (integral,enum,ptr)
 {
@@ -1222,7 +1222,7 @@ PTREE NodeOffset(               // BUILD CONSTANT NODE FOR AN OFFSET
     TYPE otype;
 
     otype = GetBasicType( TYP_UINT );
-    return NodeIntegralConstant( offset, otype );
+    return NodeMakeIntegralConstant( offset, otype );
 }
 
 

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1732,7 +1732,7 @@ addr_func_t NodeGetOverloadedFnAddr(      // GET PTREE FOR &FUN (FUN IS OVERLOAD
 }
 
 
-bool NodePtrNonZero(            // TEST IF A PTR NODE IS ALWAYS NON-ZERO
+bool NodeIsNonNullPtr(            // TEST IF A PTR NODE IS ALWAYS NON-ZERO
     PTREE node )                // - node to be tested
 {
     bool non_zero;              // - true ==> is non-zero

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2295,7 +2295,7 @@ bool NodeGetIbpSymbol(          // GET BOUND-REFERENCE SYMBOL, IF POSSIBLE
 }
 
 
-PTREE NodeTypeSig               // MAKE NODE FOR TYPE-SIG ADDRESS
+PTREE NodeMakeTypeSignature               // MAKE NODE FOR TYPE-SIG ADDRESS
     ( TYPE_SIG* sig )           // - type signature
 {
     SYMBOL sym;                 // - symbol
@@ -2317,7 +2317,7 @@ PTREE NodeTypeSig               // MAKE NODE FOR TYPE-SIG ADDRESS
 PTREE NodeTypeSigArg            // MAKE ARGUMENT NODE FOR TYPE-SIG ADDRESS
     ( TYPE_SIG* sig )           // - type signature
 {
-    return NodeMakeArg( NodeTypeSig( sig ) );
+    return NodeMakeArg( NodeMakeTypeSignature( sig ) );
 }
 
 

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2477,7 +2477,7 @@ PTREE NodeUnComma(              // EXTRACT OUT UNCOMMA'D EXPR (rest is stashed)
 }
 
 
-PTREE NodeDottedFunction        // BUILD A DOT NODE FOR A FUNCTION
+PTREE NodeMakeDottedFunction        // BUILD A DOT NODE FOR A FUNCTION
     ( PTREE left                // - left operand
     , PTREE right )             // - right operand
 {

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1597,13 +1597,13 @@ PTREE NodeFetchReference(       // FETCH A REFERENCE, IF REQ'D
 }
 
 
-PTREE NodeCopyClassObject(      // COPY OBJECT W/O CTOR
+PTREE NodeMakeClassObjectCopy(      // COPY OBJECT W/O CTOR
     PTREE tgt,                  // - target object (LVALUE)
     PTREE src )                 // - source object (RVALUE)
 {
     PTREE expr;                 // - created expression
 
-    DbgVerify( (tgt->flags & PTF_LVALUE), "NodeCopyClassObject to non-lvalue" );
+    DbgVerify( (tgt->flags & PTF_LVALUE), "NodeMakeClassObjectCopy to non-lvalue" );
     tgt->flags |= PTF_MEMORY_EXACT;
     expr = NodeMakeBinary( CO_COPY_OBJECT, tgt, src );
     expr->type = tgt->type;

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -87,7 +87,7 @@ PTREE NodeMakeBinary(               // MAKE A BINARY NODE
 }
 
 
-PTREE NodeUnary(                // MAKE A UNARY NODE
+PTREE NodeMakeUnary(                // MAKE A UNARY NODE
     CGOP op,                    // - operator
     PTREE expr )                // - operand
 {
@@ -101,7 +101,7 @@ PTREE NodeUnaryCopy(            // MAKE A UNARY NODE, COPY ATTRIBUTES
 {
     PTREE node;                 // - new node
 
-    node = NodeUnary( op, expr );
+    node = NodeMakeUnary( op, expr );
     node->type = expr->type;
     node->flags = expr->flags;
     node->flags &= ~PTF_NEVER_PROPPED;
@@ -920,7 +920,7 @@ static PTREE nodeDoFetch(       // FETCH A VALUE
         ref = &curr;
     }
     old = *ref;
-    fet = NodeUnary( opcode, old );
+    fet = NodeMakeUnary( opcode, old );
     *ref = fet;
     result_type = TypeReferenced( old->type );
     fet->type = result_type;

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2073,7 +2073,7 @@ bool NodeYieldsTemporary(   // CHECK IF NODE PRODUCES OR IS TEMPORARY
 }
 
 
-PTREE NodeSegname(              // BUILD EXPRESSION FOR __segname
+PTREE NodeMakeSegname(              // BUILD EXPRESSION FOR __segname
     char* segname )             // - name of segment
 {
     PTREE node;                 // - new node

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1502,7 +1502,7 @@ PTREE NodeMakeAssignment(               // CREATE ASSIGNMENT NODE FOR VALUE
 }
 
 
-PTREE NodeAssignRef(            // CREATE ASSIGNMENT NODE FOR REFERENCE
+PTREE NodeMakeRefAssignment(            // CREATE ASSIGNMENT NODE FOR REFERENCE
     PTREE tgt,                  // - target
     PTREE src )                 // - source
 {
@@ -1539,7 +1539,7 @@ PTREE NodeAssignTemporaryNode(  // ASSIGN NODE TO A TEMPORARY NODE
                 expr = a_expr;
             }
         } else {
-            expr = NodeAssignRef( temp_node, expr );
+            expr = NodeMakeRefAssignment( temp_node, expr );
         }
     }
     if( expr->op != PT_ERROR ) {
@@ -2201,14 +2201,14 @@ PTREE NodeAddSideEffect(        // ADD A SIDE-EFFECT EXPRESSION
             if( NULL == TypeReference( temp_type ) ) {
                 if( expr->flags & PTF_CLASS_RVREF ) {
                     temp = TemporaryAlloc( MakeReferenceTo( temp_type ) );
-                    expr = NodeAssignRef( MakeNodeSymbol( temp ), expr );
+                    expr = NodeMakeRefAssignment( MakeNodeSymbol( temp ), expr );
                 } else {
                     temp = TemporaryAlloc( temp_type );
                     expr = NodeMakeAssignment( MakeNodeSymbol( temp ), expr );
                 }
             } else {
                 temp = TemporaryAlloc( temp_type );
-                expr = NodeAssignRef( MakeNodeSymbol( temp ), expr );
+                expr = NodeMakeRefAssignment( MakeNodeSymbol( temp ), expr );
             }
             expr = NodeMakeComma( expr, side_effect );
             side_effect = NodeFetch( MakeNodeSymbol( temp ) );

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -485,7 +485,7 @@ static CNV_DIAG diagConvertToBool = // DIAGNOSIS FOR CONVERT-TO-BOOL NODE
 ,   ERR_CALL_WATCOM             // - private violation
 };
 
-PTREE NodeConvertToBool(        // MAKE A CONVERT-TO-BOOL NODE, IF REQ'D
+PTREE NodeMakeBoolConversion(        // MAKE A CONVERT-TO-BOOL NODE, IF REQ'D
     PTREE expr )
 {
     PTREE zero;                 // - constant node (contains zero)

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2490,7 +2490,7 @@ PTREE NodeMakeDottedFunction        // BUILD A DOT NODE FOR A FUNCTION
 }
 
 
-PTREE NodeZero                  // BUILD A ZERO NODE
+PTREE NodeMakeZeroConstant                  // BUILD A ZERO NODE
     ( void )
 {
     return PTreeIntConstant( 0, TYP_SINT );

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1558,7 +1558,7 @@ PTREE NodeMakeAssignToNewTmp(      // ASSIGN NODE TO A TEMPORARY
 }
 
 
-PTREE NodeDone(                 // MAKE A NODE-DONE
+PTREE NodeMakeDone(                 // MAKE A NODE-DONE
     PTREE expr )                // - expression
 {
     if( expr->op != PT_ERROR ) {

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -414,7 +414,7 @@ PTREE NodeMakeConversion(              // MAKE A CONVERSION NODE IF REQ'D
 }
 
 
-PTREE NodeConvertFlags(         // MAKE A CONVERSION NODE WITH FLAGS, IF REQ'D
+PTREE NodeMakeConversionFlags(         // MAKE A CONVERSION NODE WITH FLAGS, IF REQ'D
     TYPE type,                  // - type for conversion
     PTREE expr,                 // - expression to be converted
     PTF_FLAG flags )            // - flags to be added
@@ -989,7 +989,7 @@ static PTREE nodeRvalueFetch(   // FETCH RVALUE IF REQUIRED
                 curr = NodeFetch( curr );
                 curr->flags &= ~ PTF_LVALUE;
             } else {
-                curr = NodeConvertFlags( unmod, curr, PTF_CLASS_RVREF );
+                curr = NodeMakeConversionFlags( unmod, curr, PTF_CLASS_RVREF );
             }
             break;
           case TYP_FUNCTION :
@@ -2411,7 +2411,7 @@ PTREE NodeRvForRefClass         // MAKE RVALUE FOR REF CLASS
     TYPE type = TypeForLvalue( expr );
     DbgVerify( OMR_CLASS_REF == ObjModelArgument( type )
              , "NodeRvForRefClass -- not reference class" );
-    expr = NodeConvertFlags( type, expr, PTF_CLASS_RVREF );
+    expr = NodeMakeConversionFlags( type, expr, PTF_CLASS_RVREF );
     return expr;
 }
 
@@ -2424,7 +2424,7 @@ PTREE NodeLvForRefClass         // MAKE LVALUE FOR REF CLASS
     DbgVerify( ! ExprIsLvalue( expr ), "NodeRvForRefClass -- not lvalue" );
     DbgVerify( OMR_CLASS_REF == ObjModelArgument( ClassTypeForType( type ) )
              , "NodeRvForRefClass -- not reference class" );
-    expr = NodeConvertFlags( type, expr, flags );
+    expr = NodeMakeConversionFlags( type, expr, flags );
     return expr;
 }
 

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -540,7 +540,7 @@ PTREE NodeRemoveCastsCommas(    // REMOVE COMMAS, DTORING, CASTING FROM NODE
 {
     PTREE not_used;             // - dtoring, not used
 
-    return *NodeReturnSrc( &node, &not_used );
+    return *NodeGetReturnSrc( &node, &not_used );
 }
 
 
@@ -1900,7 +1900,7 @@ PTREE NodeActualNonOverloaded(  // POSITION OVER DEFAULT-ARG SYMBOLS
 }
 
 
-PTREE* NodeReturnSrc(           // GET ADDR OF SOURCE OPERAND RETURNED
+PTREE* NodeGetReturnSrc(           // GET ADDR OF SOURCE OPERAND RETURNED
     PTREE* src,                 // - addr[ operand ]
     PTREE* dtor )               // - addr[ addr[ CO_DTOR operand ] ]
 {

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2033,7 +2033,7 @@ static bool nodeMakesTemporary( // CHECK IF NODE PRODUCES A TEMPORARY
 }
 
 
-bool NodeNonConstRefToTemp(     // CHECK IF TEMP. PASSED AS NON-CONST REF
+bool NodeIsNonConstRefToTemp(     // CHECK IF TEMP. PASSED AS NON-CONST REF
     TYPE arg_type,              // - possible non-const reference
     PTREE node )                // - possible temporary
 {

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -697,7 +697,7 @@ bool NodeIsConstant(            // TEST IF NODE IS A CONSTANT
 }
 
 
-int NodeConstantValue(  // GET CONSTANT VALUE FOR A NODE
+int NodeGetConstantValue(  // GET CONSTANT VALUE FOR A NODE
     PTREE node )        // - a constant node
 {
     SYMBOL sym;         // - symbol for node
@@ -712,7 +712,7 @@ int NodeConstantValue(  // GET CONSTANT VALUE FOR A NODE
         sym = node->u.symcg.symbol;
         retn = sym->u.sval;
         break;
-    DbgDefault( "non-constant node passed to NodeConstantValue" );
+    DbgDefault( "non-constant node passed to NodeGetConstantValue" );
     }
     return( retn );
 }

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1422,7 +1422,7 @@ TYPE NodeSetReference(          // MAKE AN LVALUE IF REFERENCE TYPE
 }
 
 
-PTREE NodeThis(                 // MAKE A "THIS" NODE
+PTREE NodeMakeThis(                 // MAKE A "THIS" NODE
     void )
 {
     TYPE type;                  // - type of "this" node
@@ -1455,7 +1455,7 @@ PTREE NodeThisCopyLocation(     // MAKE A RVALUE "THIS" NODE WITH LOCATION
 {
     PTREE this_node;
 
-    this_node = NodeThis();
+    this_node = NodeMakeThis();
     if( this_node != NULL && use_locn != NULL ) {
         this_node = PTreeCopySrcLocation( this_node, use_locn );
     }

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -439,7 +439,7 @@ PTREE NodeSetBooleanType(       // SET NODE TO TYPE OF A REL-OP EXPR
 }
 
 
-PTREE NodeCompareToZero(        // MAKE A COMPARE-TO-ZERO NODE, IF REQ'D
+PTREE NodeMakeZeroCompare(        // MAKE A COMPARE-TO-ZERO NODE, IF REQ'D
     PTREE expr )
 {
     PTREE zero;                 // - constant node (contains zero)

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1752,7 +1752,7 @@ bool NodeIsNonNullPtr(            // TEST IF A PTR NODE IS ALWAYS NON-ZERO
 }
 
 
-PTREE NodeTestExpr(             // GENERATE A TERNARY TEST EXPRESSION
+PTREE NodeMakeTernaryExpr(             // GENERATE A TERNARY TEST EXPRESSION
     PTREE b_expr,               // - bool expression
     PTREE t_expr,               // - true expression
     PTREE f_expr )              // - false expression

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1027,7 +1027,7 @@ PTREE NodeGetRValue(               // GET RVALUE, IF LVALUE
             PTREE new_right;    // - new right of colon
             PTREE new_left;     // - new left of colon
             colon = PTreeOpRight( curr );
-            new_left = NodeRvalueLeft( colon );
+            new_left = NodeSetRValueLeft( colon );
             new_right = NodeRvalueRight( colon );
             colon->flags &= ~ PTF_LVALUE;
             mod_flags = (new_right->flags | new_left->flags) & (PTF_FETCH & ~ PTF_MEANINGFUL);
@@ -1126,7 +1126,7 @@ static PTREE nodeRefedRvalue(   // PROPOGATE RVALUE RESULT
 }
 
 
-PTREE NodeRvalueLeft(           // SET RVALUE ON LEFT
+PTREE NodeSetRValueLeft(           // SET RVALUE ON LEFT
     PTREE node )                // - current node
 {
     return nodeRefedRvalue( &node->u.subtree[0] );

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2056,7 +2056,7 @@ bool NodeIsNonConstRefToTemp(     // CHECK IF TEMP. PASSED AS NON-CONST REF
 }
 
 
-bool NodeReferencesTemporary(   // CHECK IF NODE PRODUCES OR IS TEMPORARY
+bool NodeYieldsTemporary(   // CHECK IF NODE PRODUCES OR IS TEMPORARY
     PTREE node )                // - possible temporary
 {
     PTREE dtor;                 // - addr CO_DTOR ( not used )

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1615,7 +1615,7 @@ PTREE NodeMakeClassObjectCopy(      // COPY OBJECT W/O CTOR
 }
 
 
-PTREE CallArgumentExactCtor(    // GET EXACT CTOR ARG., IF REQUIRED
+PTREE MakeArgCtorCall(    // GET EXACT CTOR ARG., IF REQUIRED
     TYPE type,                  // - type for class
     bool exact )                // - true ==> exact CTORing of classes
 {
@@ -1641,7 +1641,7 @@ PTREE NodeArgumentExactCtor(    // ADD EXACT CTOR ARG., IF REQUIRED
     TYPE type,                  // - type for class
     bool exact )                // - true ==> exact CTORing of classes
 {
-    PTREE arg = CallArgumentExactCtor( type, exact );
+    PTREE arg = MakeArgCtorCall( type, exact );
 
     if( arg != NULL ) {
         arg->u.subtree[0] = args;

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -459,7 +459,7 @@ PTREE NodeMakeZeroCompare(        // MAKE A COMPARE-TO-ZERO NODE, IF REQ'D
     } else {
         if( ( NULL == StructType( type ) )
           &&( NULL == MemberPtrType( type ) ) ) {
-            expr = NodeRvalue( expr );
+            expr = NodeGetRValue( expr );
             if( ! ArithType( type ) ) {
                 // may be &fn or array decay to a pointer
                 type = expr->type;
@@ -1011,7 +1011,7 @@ static PTREE nodeRvalueFetch(   // FETCH RVALUE IF REQUIRED
 }
 
 
-PTREE NodeRvalue(               // GET RVALUE, IF LVALUE
+PTREE NodeGetRValue(               // GET RVALUE, IF LVALUE
     PTREE curr )                // - node to be transformed
 {
     TYPE node_type;             // - type of node
@@ -1116,7 +1116,7 @@ static PTREE nodeRefedRvalue(   // PROPOGATE RVALUE RESULT
 
 //    src_type = (*r_start)->type;
     r_mod = PTreeRef( r_start );
-    mod = NodeRvalue( *r_mod );
+    mod = NodeGetRValue( *r_mod );
     *r_mod = mod;
     for( start = *r_start; start != mod; start = start->u.subtree[1] ) {
         start->flags = mod->flags;
@@ -1146,7 +1146,7 @@ PTREE NodeRvalueExact(          // SET RVALUE (EXACT)
     TYPE exact_type;            // - exact type
 
     exact_type = node->type;
-    node = NodeRvalue( node );
+    node = NodeGetRValue( node );
     switch( TypedefModifierRemove( exact_type )->id ) {
       case TYP_BOOL :
       case TYP_CHAR :
@@ -1439,7 +1439,7 @@ PTREE NodeThis(                 // MAKE A "THIS" NODE
         node->flags |= PTF_LVALUE | PTF_PTR_NONZERO | PTF_LV_CHECKED;
         node->u.symcg.symbol = NULL;
         node->u.symcg.result = NULL;
-        node = NodeRvalue( node );
+        node = NodeGetRValue( node );
         node->flags |= PTF_PTR_NONZERO | PTF_LV_CHECKED;
         cl_type = StructType( TypePointedAtModified( type ) );
         if( ! TypeHasVirtualBases( cl_type )
@@ -1474,7 +1474,7 @@ PTREE NodeCDtorExtra(           // MAKE A CTOR/DTOR EXTRA PARM NODE
     node->flags |= PTF_LVALUE | PTF_LV_CHECKED;
     node->u.symcg.symbol = NULL;
     node->u.symcg.result = NULL;
-    node = NodeRvalue( node );
+    node = NodeGetRValue( node );
     return node;
 }
 
@@ -1858,7 +1858,7 @@ bool NodeDerefPtr(              // DEREFERENCE A POINTER
     PTREE ptr;                  // - ptr operand
 
     ptr = *a_ptr;
-    ptr = NodeRvalue( ptr );
+    ptr = NodeGetRValue( ptr );
     if( TypeIsBasedPtr( ptr->type ) ) {
         ptr = CastImplicit( ptr
                           , TypeConvertFromPcPtr( ptr->type )

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1216,7 +1216,7 @@ PTREE NodeMakeIntegralConstant      // BUILD AN INTEGRAL NODE FOR A VALUE
 }
 
 
-PTREE NodeOffset(               // BUILD CONSTANT NODE FOR AN OFFSET
+PTREE NodeMakeConstantOffset(               // BUILD CONSTANT NODE FOR AN OFFSET
     target_offset_t offset )    // - the offset
 {
     TYPE otype;
@@ -2306,7 +2306,7 @@ PTREE NodeTypeSig               // MAKE NODE FOR TYPE-SIG ADDRESS
     node = MakeNodeSymbol( sym );
     if( 0 != offset ) {
         PTREE snode = node;
-        node = NodeMakeBinary( CO_DOT, snode, NodeOffset( offset ) );
+        node = NodeMakeBinary( CO_DOT, snode, NodeMakeConstantOffset( offset ) );
         node->type = snode->type;
         node->flags = snode->flags;
     }

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -341,7 +341,7 @@ PTREE NodeReplaceTop(           // REPLACE TOP EXPRESSION WITH ANOTHER
     if( old != NULL ) {
         old = PTreeCopySrcLocation( old, replace );
         old = NodePruneTop( old );
-        replace = NodeComma( old, replace );
+        replace = NodeMakeComma( old, replace );
     }
     return replace;
 }
@@ -1368,7 +1368,7 @@ bool NodeIsBitField(              // TEST IF NODE IS A BIT FIELD
 }
 
 
-PTREE NodeComma(                // MAKE A COMMA PTREE NODE
+PTREE NodeMakeComma(                // MAKE A COMMA PTREE NODE
     PTREE left,                 // - left operand
     PTREE right )               // - right operand
 {
@@ -2192,7 +2192,7 @@ PTREE NodeAddSideEffect(        // ADD A SIDE-EFFECT EXPRESSION
         orig = expr;
         if( top->op == PT_SYMBOL
          || NodeIsConstantInt( top ) ) {
-            *ref = NodeComma( side_effect, *ref );
+            *ref = NodeMakeComma( side_effect, *ref );
             expr = dup;
         } else {
             old = TemporaryClass( TEMP_TYPE_EXPR );
@@ -2210,13 +2210,13 @@ PTREE NodeAddSideEffect(        // ADD A SIDE-EFFECT EXPRESSION
                 temp = TemporaryAlloc( temp_type );
                 expr = NodeAssignRef( MakeNodeSymbol( temp ), expr );
             }
-            expr = NodeComma( expr, side_effect );
+            expr = NodeMakeComma( expr, side_effect );
             side_effect = NodeFetch( MakeNodeSymbol( temp ) );
             if( NULL != TypeReference( temp_type ) ) {
                 side_effect->flags |= PTF_LVALUE;
                 side_effect->type = TypeReferenced( temp_type );
             }
-            expr = NodeComma( expr, side_effect );
+            expr = NodeMakeComma( expr, side_effect );
             TemporaryClass( old );
         }
         side_effect = expr;
@@ -2432,7 +2432,7 @@ PTREE NodeLvForRefClass         // MAKE LVALUE FOR REF CLASS
 //      'expr'
 //      expr = NodeUnComma( expr, &extra );
 //      create/modify 'expr'
-//      expr = NodeComma( extra, expr );
+//      expr = NodeMakeComma( extra, expr );
 //
 PTREE NodeUnComma(              // EXTRACT OUT UNCOMMA'D EXPR (rest is stashed)
     PTREE expr,                 // - (possibly comma'd) expr

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1510,7 +1510,7 @@ PTREE NodeMakeRefAssignment(            // CREATE ASSIGNMENT NODE FOR REFERENCE
 }
 
 
-PTREE NodeTemporary(            // CREATE TEMPORARY AND NODE FOR IT
+PTREE NodeMakeTemporary(            // CREATE TEMPORARY AND NODE FOR IT
     TYPE type )                 // - type of temporary
 {
     return MakeNodeSymbol( TemporaryAlloc( type ) );
@@ -1554,7 +1554,7 @@ PTREE NodeAssignTemporary(      // ASSIGN NODE TO A TEMPORARY
     TYPE type,                  // - type of temporary
     PTREE expr )                // - the expression to be assigned to temp
 {
-    return NodeAssignTemporaryNode( type, expr, NodeTemporary( type ) );
+    return NodeAssignTemporaryNode( type, expr, NodeMakeTemporary( type ) );
 }
 
 

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2145,7 +2145,7 @@ static PTREE nodeIcCgValue(     // ADD A PTREE NODE
 }
 
 
-PTREE NodeIcUnsigned(           // ADD A PTREE-IC NODE, UNSIGNED OPERAND
+PTREE NodeMakeIcUnsigned(           // ADD A PTREE-IC NODE, UNSIGNED OPERAND
     CGINTEROP opcode,           // - opcode
     unsigned operand )          // - operand
 {
@@ -2159,7 +2159,7 @@ PTREE NodeIcUnsigned(           // ADD A PTREE-IC NODE, UNSIGNED OPERAND
 PTREE NodeIc(                   // ADD A PTREE-IC NODE
     CGINTEROP opcode )          // - opcode
 {
-    return NodeIcUnsigned( opcode, 0 );
+    return NodeMakeIcUnsigned( opcode, 0 );
 }
 
 

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1550,7 +1550,7 @@ PTREE NodeMakeAssignToTmp(  // ASSIGN NODE TO A TEMPORARY NODE
 }
 
 
-PTREE NodeAssignTemporary(      // ASSIGN NODE TO A TEMPORARY
+PTREE NodeMakeAssignToNewTmp(      // ASSIGN NODE TO A TEMPORARY
     TYPE type,                  // - type of temporary
     PTREE expr )                // - the expression to be assigned to temp
 {

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -2504,7 +2504,7 @@ PTREE NodeMakeIntDummy              // BUILD A DUMMY INTEGRAL NODE
 }
 
 
-PTREE NodeAddToLeft(            // FABRICATE AN ADDITION TO LEFT
+PTREE NodeMakeLeftAddition(            // FABRICATE AN ADDITION TO LEFT
     PTREE left,                 // - left operand
     PTREE right,                // - right operand
     TYPE type )                 // - type of result

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1300,7 +1300,7 @@ static PTREE makeDupNode(       // DUPLICATE THE EXPRESSION
 }
 
 
-PTREE NodeDupExpr(              // DUPLICATE EXPRESSION
+PTREE NodeMakeExprDuplicate(              // DUPLICATE EXPRESSION
     PTREE *expr )               // - addr( expression )
 {
     PTREE node;                 // - new node (partner)
@@ -2107,7 +2107,7 @@ PTREE NodeBitQuestAssign(       // ASSIGN (expr?bit-fld:bit-fld) = expr
     expr->u.subtree[0] = NULL;
     expr->flags &= ~PTF_LVALUE;
     dup = PTreeAssign( NULL, expr );
-    dup->u.subtree[1] = NodeDupExpr( &expr->u.subtree[1] );
+    dup->u.subtree[1] = NodeMakeExprDuplicate( &expr->u.subtree[1] );
     colon = PTreeOpRight( PTreeOp( &result ) );
     assignBitDup( &colon->u.subtree[0], expr );
     assignBitDup( &colon->u.subtree[1], dup );

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1463,7 +1463,7 @@ PTREE NodeMakeRVThisAtLoc(     // MAKE A RVALUE "THIS" NODE WITH LOCATION
 }
 
 
-PTREE NodeCDtorExtra(           // MAKE A CTOR/DTOR EXTRA PARM NODE
+PTREE NodeMakeCDtorExtraParm(           // MAKE A CTOR/DTOR EXTRA PARM NODE
     void )
 {
     PTREE node;                 // - "this" node

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -78,7 +78,7 @@ bool NodeIsBinaryOp(            // TEST IF BINARY OPERATION OF GIVEN TYPE
 #endif
 
 
-PTREE NodeBinary(               // MAKE A BINARY NODE
+PTREE NodeMakeBinary(               // MAKE A BINARY NODE
     CGOP op,                    // - operator
     PTREE left,                 // - left operand
     PTREE right )               // - right operand
@@ -364,7 +364,7 @@ static PTREE nodeMakeConvert(   // MAKE A CONVERSION NODE
     orig = expr;
     cast = PTreeType( type );
     cast = PTreeCopySrcLocation( cast, orig );
-    expr = NodeBinary( CO_CONVERT, cast, orig );
+    expr = NodeMakeBinary( CO_CONVERT, cast, orig );
     expr = PTreeCopySrcLocation( expr, orig );
     expr = NodeSetType( expr, type, orig->flags & PTF_CONVERT );
     if( flags & PTF_MEMORY_EXACT ) {
@@ -469,7 +469,7 @@ PTREE NodeCompareToZero(        // MAKE A COMPARE-TO-ZERO NODE, IF REQ'D
         }
         operand = expr;
         zero = NodeIntegralConstant( 0, type );
-        expr = NodeBinary( CO_NE, operand, zero );
+        expr = NodeMakeBinary( CO_NE, operand, zero );
         expr = PTreeCopySrcLocation( expr, operand );
         expr = NodeSetBooleanType( expr );
         expr = ConvertBoolean( expr );
@@ -508,7 +508,7 @@ PTREE NodeConvertToBool(        // MAKE A CONVERT-TO-BOOL NODE, IF REQ'D
     } else {
         operand = expr;
         zero = NodeIntegralConstant( 0, GetBasicType( TYP_SINT ) );
-        expr = NodeBinary( CO_NE, expr, zero );
+        expr = NodeMakeBinary( CO_NE, expr, zero );
         expr = PTreeCopySrcLocation( expr, operand );
         expr = AnalyseOperator( expr );
     }
@@ -1232,7 +1232,7 @@ PTREE NodeArgument(             // MAKE AN ARGUMENT NODE
 {
     PTREE arg;                  // - the argument
 
-    arg = NodeBinary( CO_LIST, left, right );
+    arg = NodeMakeBinary( CO_LIST, left, right );
     arg->type = right->type;
     arg->flags = right->flags;
     arg = PTreeCopySrcLocation( arg, right );
@@ -1379,7 +1379,7 @@ PTREE NodeComma(                // MAKE A COMMA PTREE NODE
     } else if( right == NULL ) {
         node = left;
     } else {
-        node = NodeBinary( CO_COMMA, left, right );
+        node = NodeMakeBinary( CO_COMMA, left, right );
         node = nodeCommaPropogate( node );
     }
     return node;
@@ -1398,7 +1398,7 @@ PTREE NodeCommaIfSideEffect(    // MAKE A COMMA PTREE NODE (IF LHS HAS side-effe
         node = left;
     } else {
         if( (left->flags & PTF_SIDE_EFF) != 0 ) {
-            node = NodeBinary( CO_COMMA, left, right );
+            node = NodeMakeBinary( CO_COMMA, left, right );
             node = nodeCommaPropogate( node );
         } else {
             NodeFreeDupedExpr( left );
@@ -1486,7 +1486,7 @@ static PTREE assignNode(        // CREATE ASSIGNMENT NODE
 {
     PTREE expr;                 // - result
 
-    expr = NodeBinary( opcode, tgt, src );
+    expr = NodeMakeBinary( opcode, tgt, src );
     expr->type = tgt->type;
     expr->flags |= PTF_LVALUE | PTF_LV_CHECKED;
     expr = PTreeCopySrcLocation( expr, src );
@@ -1605,7 +1605,7 @@ PTREE NodeCopyClassObject(      // COPY OBJECT W/O CTOR
 
     DbgVerify( (tgt->flags & PTF_LVALUE), "NodeCopyClassObject to non-lvalue" );
     tgt->flags |= PTF_MEMORY_EXACT;
-    expr = NodeBinary( CO_COPY_OBJECT, tgt, src );
+    expr = NodeMakeBinary( CO_COPY_OBJECT, tgt, src );
     expr->type = tgt->type;
     expr->flags |= PTF_LVALUE
                  | PTF_SIDE_EFF
@@ -1761,9 +1761,9 @@ PTREE NodeTestExpr(             // GENERATE A TERNARY TEST EXPRESSION
     TYPE type;
 
     type = t_expr->type;
-    expr = NodeBinary( CO_COLON, t_expr, f_expr );
+    expr = NodeMakeBinary( CO_COLON, t_expr, f_expr );
     expr->type = type;
-    expr = NodeBinary( CO_QUESTION, b_expr, expr );
+    expr = NodeMakeBinary( CO_QUESTION, b_expr, expr );
     expr->type = type;
     return expr;
 }
@@ -1809,7 +1809,7 @@ PTREE NodeDtorExpr(             // MARK FOR DTOR'ING AFTER EXPRESSION
             SymMarkRefed( dtor );
             dtored = MakeNodeSymbol( sym );
             dtored->cgop = CO_NAME_DTOR_SYM;
-            expr = NodeBinary( CO_DTOR, dtored, expr );
+            expr = NodeMakeBinary( CO_DTOR, dtored, expr );
             expr->locn = err_locn;
             expr->type = orig->type;
             expr->flags = orig->flags;
@@ -2306,7 +2306,7 @@ PTREE NodeTypeSig               // MAKE NODE FOR TYPE-SIG ADDRESS
     node = MakeNodeSymbol( sym );
     if( 0 != offset ) {
         PTREE snode = node;
-        node = NodeBinary( CO_DOT, snode, NodeOffset( offset ) );
+        node = NodeMakeBinary( CO_DOT, snode, NodeOffset( offset ) );
         node->type = snode->type;
         node->flags = snode->flags;
     }
@@ -2483,7 +2483,7 @@ PTREE NodeDottedFunction        // BUILD A DOT NODE FOR A FUNCTION
 {
     PTREE node;                 // - node
 
-    node = NodeBinary( CO_DOT, NodeForceLvalue( left ), right );
+    node = NodeMakeBinary( CO_DOT, NodeForceLvalue( left ), right );
     node->flags = right->flags | PTF_LVALUE | PTF_LV_CHECKED;
     node->type = right->type;
     return node;
@@ -2511,7 +2511,7 @@ PTREE NodeAddToLeft(            // FABRICATE AN ADDITION TO LEFT
 {
     PTREE expr;                 // - resultant expression
 
-    expr = NodeBinary( CO_PLUS, left, right );
+    expr = NodeMakeBinary( CO_PLUS, left, right );
     expr->type = type;
     return( expr );
 }

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -1226,7 +1226,7 @@ PTREE NodeMakeConstantOffset(               // BUILD CONSTANT NODE FOR AN OFFSET
 }
 
 
-PTREE NodeArgument(             // MAKE AN ARGUMENT NODE
+PTREE NodeMakeArgument(             // MAKE AN ARGUMENT NODE
     PTREE left,                 // - left subtree
     PTREE right )               // - right subtree
 {
@@ -1243,7 +1243,7 @@ PTREE NodeArgument(             // MAKE AN ARGUMENT NODE
 PTREE NodeArg(                  // MAKE A SINGLE ARGUMENT NODE
     PTREE argval )              // - value for argument
 {
-    return NodeArgument( NULL, argval );
+    return NodeMakeArgument( NULL, argval );
 }
 
 
@@ -1259,7 +1259,7 @@ PTREE NodeArguments(            // MAKE A LIST OF ARGUMENTS
     expr = NULL;
     argument = first;
     while( argument != NULL ) {
-        expr = NodeArgument( expr, argument );
+        expr = NodeMakeArgument( expr, argument );
         argument = va_arg( args, PTREE );
     }
     va_end( args );

--- a/bld/plusplus/c/analpcnv.c
+++ b/bld/plusplus/c/analpcnv.c
@@ -205,7 +205,7 @@ void NodeConvertToBasePtr(      // CONVERT TO A BASE PTR, USING SEARCH_RESULT
             node = NodeReplace( node, expr );
         } else {
             dup = NULL;
-            if( ! NodePtrNonZero( node ) ) {
+            if( ! NodeIsNonNullPtr( node ) ) {
                 dup = NodeMakeExprDuplicate( &node );
             }
             vb_offset = result->vb_offset;

--- a/bld/plusplus/c/analpcnv.c
+++ b/bld/plusplus/c/analpcnv.c
@@ -99,7 +99,7 @@ PTREE NodeConvertVirtualPtr(    // EXECUTE A VIRTUAL BASE CAST
     PTREE dup;
 
     vbptr_type = MakeVBTableFieldType( true );
-    offset = NodeOffset( vb_offset );
+    offset = NodeMakeConstantOffset( vb_offset );
     expr = NodeMakeBinary( CO_DOT, expr, offset );
     expr->flags |= PTF_LVALUE | PTF_PTR_NONZERO;
     expr->type = vbptr_type;
@@ -110,7 +110,7 @@ PTREE NodeConvertVirtualPtr(    // EXECUTE A VIRTUAL BASE CAST
     expr->flags &= ~ PTF_LVALUE;
     expr->flags |= PTF_PTR_NONZERO;
     adjust_type = TypePointedAtModified( vbptr_type );
-    offset = NodeOffset( vb_index * CgMemorySize( adjust_type ) );
+    offset = NodeMakeConstantOffset( vb_index * CgMemorySize( adjust_type ) );
     expr = NodeMakeBinary( CO_DOT, expr, offset );
     expr->type = adjust_type;
     expr->flags |= PTF_LVALUE | PTF_PTR_NONZERO;
@@ -135,7 +135,7 @@ static void adjust_by_delta(    // COMPUTE DELTA ADJUSTMENT
     if( delta == 0 ) {
         *a_expr = NodeMakeConversion( base, *a_expr );
     } else {
-        offset = NodeOffset( delta );
+        offset = NodeMakeConstantOffset( delta );
         if( ! positive ) {
             offset->u.int_constant = - delta;
         }
@@ -213,7 +213,7 @@ void NodeConvertToBasePtr(      // CONVERT TO A BASE PTR, USING SEARCH_RESULT
             node = NodeConvertVirtualPtr( node, base, vb_offset, vb_index );
             delta = result->delta;
             if( delta != 0 ) {
-                node = NodeMakeBinary( CO_DOT, node, NodeOffset( delta ) );
+                node = NodeMakeBinary( CO_DOT, node, NodeMakeConstantOffset( delta ) );
                 node->type = base;
                 node->flags |= orig_prop;
             }

--- a/bld/plusplus/c/analpcnv.c
+++ b/bld/plusplus/c/analpcnv.c
@@ -79,9 +79,9 @@ static PTREE adjust_base_ptr(   // ADJUST BASE PTR AS true/TESTING CONVERSION
     TYPE type )                 // - type, after conversion
 {
     if( orig->flags & PTF_PTR_NONZERO ) {
-        orig = NodeBinary( CO_DOT, orig, offset );
+        orig = NodeMakeBinary( CO_DOT, orig, offset );
     } else {
-        orig = NodeBinary( CO_PTR_DELTA, orig, offset );
+        orig = NodeMakeBinary( CO_PTR_DELTA, orig, offset );
     }
     orig->type = type;
     return orig;
@@ -100,7 +100,7 @@ PTREE NodeConvertVirtualPtr(    // EXECUTE A VIRTUAL BASE CAST
 
     vbptr_type = MakeVBTableFieldType( true );
     offset = NodeOffset( vb_offset );
-    expr = NodeBinary( CO_DOT, expr, offset );
+    expr = NodeMakeBinary( CO_DOT, expr, offset );
     expr->flags |= PTF_LVALUE | PTF_PTR_NONZERO;
     expr->type = vbptr_type;
     dup = NodeDupExpr( &expr );
@@ -111,13 +111,13 @@ PTREE NodeConvertVirtualPtr(    // EXECUTE A VIRTUAL BASE CAST
     expr->flags |= PTF_PTR_NONZERO;
     adjust_type = TypePointedAtModified( vbptr_type );
     offset = NodeOffset( vb_index * CgMemorySize( adjust_type ) );
-    expr = NodeBinary( CO_DOT, expr, offset );
+    expr = NodeMakeBinary( CO_DOT, expr, offset );
     expr->type = adjust_type;
     expr->flags |= PTF_LVALUE | PTF_PTR_NONZERO;
     expr = NodeFetch( expr );
     expr->type = adjust_type;
     expr->flags |= PTF_PTR_NONZERO;
-    expr = NodeBinary( CO_DOT, dup, expr );
+    expr = NodeMakeBinary( CO_DOT, dup, expr );
     expr->type = final_type;
     expr->flags |= PTF_LVALUE | PTF_PTR_NONZERO;
     return expr;
@@ -213,7 +213,7 @@ void NodeConvertToBasePtr(      // CONVERT TO A BASE PTR, USING SEARCH_RESULT
             node = NodeConvertVirtualPtr( node, base, vb_offset, vb_index );
             delta = result->delta;
             if( delta != 0 ) {
-                node = NodeBinary( CO_DOT, node, NodeOffset( delta ) );
+                node = NodeMakeBinary( CO_DOT, node, NodeOffset( delta ) );
                 node->type = base;
                 node->flags |= orig_prop;
             }

--- a/bld/plusplus/c/analpcnv.c
+++ b/bld/plusplus/c/analpcnv.c
@@ -133,7 +133,7 @@ static void adjust_by_delta(    // COMPUTE DELTA ADJUSTMENT
     PTREE offset;               // - node containing delta
 
     if( delta == 0 ) {
-        *a_expr = NodeConvert( base, *a_expr );
+        *a_expr = NodeMakeConversion( base, *a_expr );
     } else {
         offset = NodeOffset( delta );
         if( ! positive ) {
@@ -464,7 +464,7 @@ CNV_RETN NodeConvertPtr(        // CONVERT A POINTER
                                 , TypePointedAtModified( tgt ) ) ) {
       case CTD_NO :
         if( ptr_to_void( tgt ) ) {
-            *expr = NodeConvert( tgt, *expr );
+            *expr = NodeMakeConversion( tgt, *expr );
             retn = check_result_cv( expr, src, tgt, reqd_cnvptr );
         } else {
             retn = CNV_IMPOSSIBLE;

--- a/bld/plusplus/c/analpcnv.c
+++ b/bld/plusplus/c/analpcnv.c
@@ -194,7 +194,7 @@ void NodeConvertToBasePtr(      // CONVERT TO A BASE PTR, USING SEARCH_RESULT
                 expr = NodeMakeCallee( ibp );
                 expr->cgop = CO_IGNORE;
             }
-            expr = NodeUnary( CO_VBASE_FETCH, expr );
+            expr = NodeMakeUnary( CO_VBASE_FETCH, expr );
             expr = PtdVbaseFetch( expr
                                 , result->vb_offset
                                 , result->vb_index

--- a/bld/plusplus/c/analpcnv.c
+++ b/bld/plusplus/c/analpcnv.c
@@ -219,7 +219,7 @@ void NodeConvertToBasePtr(      // CONVERT TO A BASE PTR, USING SEARCH_RESULT
             }
             if( dup != NULL ) {
                 orig = NodeMakeExprDuplicate( &dup );
-                node = NodeTestExpr( NodeMakeZeroCompare( orig ), node, dup );
+                node = NodeMakeTernaryExpr( NodeMakeZeroCompare( orig ), node, dup );
             }
         }
         *a_expr = node;

--- a/bld/plusplus/c/analpcnv.c
+++ b/bld/plusplus/c/analpcnv.c
@@ -219,7 +219,7 @@ void NodeConvertToBasePtr(      // CONVERT TO A BASE PTR, USING SEARCH_RESULT
             }
             if( dup != NULL ) {
                 orig = NodeDupExpr( &dup );
-                node = NodeTestExpr( NodeCompareToZero( orig ), node, dup );
+                node = NodeTestExpr( NodeMakeZeroCompare( orig ), node, dup );
             }
         }
         *a_expr = node;

--- a/bld/plusplus/c/analpcnv.c
+++ b/bld/plusplus/c/analpcnv.c
@@ -103,7 +103,7 @@ PTREE NodeConvertVirtualPtr(    // EXECUTE A VIRTUAL BASE CAST
     expr = NodeMakeBinary( CO_DOT, expr, offset );
     expr->flags |= PTF_LVALUE | PTF_PTR_NONZERO;
     expr->type = vbptr_type;
-    dup = NodeDupExpr( &expr );
+    dup = NodeMakeExprDuplicate( &expr );
     expr->flags |= PTF_LVALUE | PTF_PTR_NONZERO;
     expr = NodeFetch( expr );
     expr->type = vbptr_type;
@@ -206,7 +206,7 @@ void NodeConvertToBasePtr(      // CONVERT TO A BASE PTR, USING SEARCH_RESULT
         } else {
             dup = NULL;
             if( ! NodePtrNonZero( node ) ) {
-                dup = NodeDupExpr( &node );
+                dup = NodeMakeExprDuplicate( &node );
             }
             vb_offset = result->vb_offset;
             vb_index = result->vb_index;
@@ -218,7 +218,7 @@ void NodeConvertToBasePtr(      // CONVERT TO A BASE PTR, USING SEARCH_RESULT
                 node->flags |= orig_prop;
             }
             if( dup != NULL ) {
-                orig = NodeDupExpr( &dup );
+                orig = NodeMakeExprDuplicate( &dup );
                 node = NodeTestExpr( NodeMakeZeroCompare( orig ), node, dup );
             }
         }

--- a/bld/plusplus/c/analretn.c
+++ b/bld/plusplus/c/analretn.c
@@ -218,7 +218,7 @@ PTREE AnalyseReturnSimpleVal    // RETURN A SIMPLE VALUE
             PTREE tgt = getReturnSym();
             if( NULL == TypeReference( retn_type ) ) {
                 expr = NodeGetRValue( expr );
-                expr = NodeAssign( tgt, expr );
+                expr = NodeMakeAssignment( tgt, expr );
                 if( NULL != MemberPtrType( retn_type ) ) {
                     PTREE new_expr = expr;
                     MembPtrAssign( &new_expr );

--- a/bld/plusplus/c/analretn.c
+++ b/bld/plusplus/c/analretn.c
@@ -217,7 +217,7 @@ PTREE AnalyseReturnSimpleVal    // RETURN A SIMPLE VALUE
         if( expr->op != PT_ERROR ) {
             PTREE tgt = getReturnSym();
             if( NULL == TypeReference( retn_type ) ) {
-                expr = NodeRvalue( expr );
+                expr = NodeGetRValue( expr );
                 expr = NodeAssign( tgt, expr );
                 if( NULL != MemberPtrType( retn_type ) ) {
                     PTREE new_expr = expr;

--- a/bld/plusplus/c/analretn.c
+++ b/bld/plusplus/c/analretn.c
@@ -129,7 +129,7 @@ static void checkAutoReturn(    // CHECK IF AUTOMATIC BEING RETURNED
                 }
                 break;
             } else if( NodeIsBinaryOp( node, CO_CALL_EXEC_IND ) ) {
-                func_ret = TypeFunctionCalled( NodeFuncForCall( node )->type );
+                func_ret = TypeFunctionCalled( NodeGetFnForCall( node )->type );
                 func_ret = func_ret->of;
                 if( NULL != StructType( func_ret ) ) {
                     PTreeErrorExpr( expr, ERR_RET_AUTO_REF );

--- a/bld/plusplus/c/analretn.c
+++ b/bld/plusplus/c/analretn.c
@@ -225,7 +225,7 @@ PTREE AnalyseReturnSimpleVal    // RETURN A SIMPLE VALUE
                     expr = new_expr;
                 }
             } else {
-                expr = NodeAssignRef( tgt, expr );
+                expr = NodeMakeRefAssignment( tgt, expr );
             }
         }
     }

--- a/bld/plusplus/c/analtyid.c
+++ b/bld/plusplus/c/analtyid.c
@@ -134,7 +134,7 @@ PTREE AnalyseTypeidExpr( PTREE typeid_expr )
             }
             info = GetWithinOffsetOfVFPtr( class_type, &expr );
             expr = NodeComma( extra, expr );
-            args = NodeArguments( NodeTypeid( class_type ),
+            args = NodeMakeArgList( NodeTypeid( class_type ),
                                   NodeMakeConstantOffset( info->vf_offset ),
                                   expr,
                                   NULL );

--- a/bld/plusplus/c/analtyid.c
+++ b/bld/plusplus/c/analtyid.c
@@ -133,7 +133,7 @@ PTREE AnalyseTypeidExpr( PTREE typeid_expr )
                 NodeFreeDupedExpr( kill );
             }
             info = GetWithinOffsetOfVFPtr( class_type, &expr );
-            expr = NodeComma( extra, expr );
+            expr = NodeMakeComma( extra, expr );
             args = NodeMakeArgList( NodeTypeid( class_type ),
                                   NodeMakeConstantOffset( info->vf_offset ),
                                   expr,

--- a/bld/plusplus/c/analtyid.c
+++ b/bld/plusplus/c/analtyid.c
@@ -135,7 +135,7 @@ PTREE AnalyseTypeidExpr( PTREE typeid_expr )
             info = GetWithinOffsetOfVFPtr( class_type, &expr );
             expr = NodeComma( extra, expr );
             args = NodeArguments( NodeTypeid( class_type ),
-                                  NodeOffset( info->vf_offset ),
+                                  NodeMakeConstantOffset( info->vf_offset ),
                                   expr,
                                   NULL );
             result_expr = RunTimeCall( args, type_info, RTF_GET_TYPEID );

--- a/bld/plusplus/c/analudc.c
+++ b/bld/plusplus/c/analudc.c
@@ -84,7 +84,7 @@ PTREE UdcCall                   // CALL UDC FUNCTION
     node = NodeMakeCallee( result->sym );
     node->u.symcg.result = result;
     node->cgop = CO_NAME_CONVERT;
-    node = NodeDottedFunction( src, node );
+    node = NodeMakeDottedFunction( src, node );
     node = PTreeCopySrcLocation( node, src );
     node = NodeMakeBinary( CO_CALL_NOOVLD, node, NULL );
     node = PTreeCopySrcLocation( node, src );

--- a/bld/plusplus/c/analudc.c
+++ b/bld/plusplus/c/analudc.c
@@ -86,7 +86,7 @@ PTREE UdcCall                   // CALL UDC FUNCTION
     node->cgop = CO_NAME_CONVERT;
     node = NodeDottedFunction( src, node );
     node = PTreeCopySrcLocation( node, src );
-    node = NodeBinary( CO_CALL_NOOVLD, node, NULL );
+    node = NodeMakeBinary( CO_CALL_NOOVLD, node, NULL );
     node = PTreeCopySrcLocation( node, src );
     node = AnalyseCall( node, diagnosis );
     return node;

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -1886,7 +1886,7 @@ static PTREE convertCtor(       // CONVERT CTOR EXPRESSION
                     expr = MembPtrZero( type );
                     break;
                 default:
-                    expr = NodeIntegralConstant( 0, type );
+                    expr = NodeMakeIntegralConstant( 0, type );
                 }
             }
             PTreeExtractLocn( old, &expr->locn );
@@ -3645,7 +3645,7 @@ start_opac_string:
             }
             expr = convertIncDec( new_op, expr, left );
             refed = TypedefModifierRemoveOnly( refed );
-            node = NodeIntegralConstant( 1, refed );
+            node = NodeMakeIntegralConstant( 1, refed );
             *PTreeRefRight( expr ) = node;
             type = expr->type;
           } continue;

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -4136,7 +4136,7 @@ start_opac_string:
                     expr = PTreeErrorNode( throw_exp );
                     break;
                 }
-                expr = RunTimeCall( NodeArgument( expr, throw_exp )
+                expr = RunTimeCall( NodeMakeArgument( expr, throw_exp )
                                   , GetBasicType( TYP_VOID )
                                   , rtcode );
             }

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -1698,7 +1698,7 @@ static PTREE bld_ptr_adj(       // BUILD A POINTER ADJUSTMENT
     if( pted_size == 1 ) {
         return factor;
     }
-    new_node = NodeBinary( CO_TIMES, factor, NodeOffset( pted_size ) );
+    new_node = NodeMakeBinary( CO_TIMES, factor, NodeOffset( pted_size ) );
     new_node->type = factor->type;
     return FoldBinary( new_node );
 }
@@ -1962,7 +1962,7 @@ static PTREE initClass(         // INIT. A CLASS ( INIT OR RETURN )
             break;
           case CNV_IMPOSSIBLE :
             ConversionTypesSet( orig_right, left->type );
-            expr = NodeBinary( CO_CTOR, left, right_comma );
+            expr = NodeMakeBinary( CO_CTOR, left, right_comma );
             expr->locn = *init_locn;
             CtorDiagNoMatch( expr, diagnosis->msg_impossible, &fnov_diag );
             ConversionDiagnoseInf();
@@ -3200,7 +3200,7 @@ start_opac_string:
           case CONV_TO_PTR_DIFF :
             type = TypePointerDiff( type );
             expr->type = type;
-            expr = NodeBinary( CO_DIVIDE
+            expr = NodeMakeBinary( CO_DIVIDE
                               , expr
                               , bld_pted_size( left ) );
             expr = PTreeCopySrcLocation( expr, left );
@@ -4472,7 +4472,7 @@ PTREE AnalyseReturnExpr(    // ANALYSE A RETURN EXPRESSION
     if( expr != NULL ) {
         fun_type = SymFuncReturnType( func );
         right = expr;
-        expr = NodeBinary( CO_RETURN, PTreeType( fun_type ), right );
+        expr = NodeMakeBinary( CO_RETURN, PTreeType( fun_type ), right );
         expr = PTreeCopySrcLocation( expr, right );
         expr = run_traversals( expr );
         expr = NodeDone( expr );

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -4385,7 +4385,7 @@ PTREE AnalyseStmtExpr(      // ANALYZE A STATEMENT EXPRESSION
     if( expr != NULL ) {
         expr = run_traversals( expr );
         warnMeaningfulSideEffect( expr );
-        expr = NodeDone( expr );
+        expr = NodeMakeDone( expr );
     }
     return expr;
 }
@@ -4475,7 +4475,7 @@ PTREE AnalyseReturnExpr(    // ANALYSE A RETURN EXPRESSION
         expr = NodeMakeBinary( CO_RETURN, PTreeType( fun_type ), right );
         expr = PTreeCopySrcLocation( expr, right );
         expr = run_traversals( expr );
-        expr = NodeDone( expr );
+        expr = NodeMakeDone( expr );
         if( FnRetnOpt() ) {
             expr->flags |= PTF_RETN_OPT;
         }

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -1902,7 +1902,7 @@ static PTREE convertCtor(       // CONVERT CTOR EXPRESSION
             expr = CastImplicit( expr, type, CNV_INIT, &diagInit );
 #endif
         } else {
-            PTREE temp = NodeTemporary( type );
+            PTREE temp = NodeMakeTemporary( type );
             expr = generateCtor( temp, expr );
             if( expr->op != PT_ERROR ) {
                 expr = NodeDtorExpr( expr, temp->u.symcg.symbol );

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -1693,7 +1693,7 @@ static PTREE bld_ptr_adj(       // BUILD A POINTER ADJUSTMENT
     target_size_t pted_size;    // - size of ptr object type
 
     ptr_type = ptr->type;
-    factor = NodeConvert( TypePointerDiff( ptr_type ), factor );
+    factor = NodeMakeConversion( TypePointerDiff( ptr_type ), factor );
     pted_size = CgTypeSize( TypePointedAtModified( ptr_type ) );
     if( pted_size == 1 ) {
         return factor;
@@ -3167,9 +3167,9 @@ start_opac_string:
                 break;
             continue;
           case CONV_AA_COMMON :
-            expr->u.subtree[0] = NodeConvert( type
+            expr->u.subtree[0] = NodeMakeConversion( type
                                             , expr->u.subtree[0] );
-            expr->u.subtree[1] = NodeConvert( type
+            expr->u.subtree[1] = NodeMakeConversion( type
                                             , expr->u.subtree[1] );
             left = PTreeOpLeft( expr );
             right = PTreeOpRight( expr );
@@ -4072,7 +4072,7 @@ start_opac_string:
                     type = NodeType( throw_exp );
                 } else if( NULL != FunctionDeclarationType( type ) ) {
                     type = TypeCanonicalThr( type );
-                    throw_exp = NodeConvert( type, throw_exp );
+                    throw_exp = NodeMakeConversion( type, throw_exp );
                     throw_exp->flags &= ~ PTF_LVALUE;
                 }
                 if( BasedPtrType( type ) ) {
@@ -4154,7 +4154,7 @@ start_opac_string:
             warnIntTrunc( right, segid_type, getConstBitsType( segid_type ) );
             left1 = expr->u.subtree[0];
             if( TypeIsBasedPtr( type ) ) {
-                left1 = NodeConvert( TypeSegAddr(), left1 );
+                left1 = NodeMakeConversion( TypeSegAddr(), left1 );
                 expr->u.subtree[0] = left1;
             }
             type = TypeSegOp( left1->type );

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -4068,7 +4068,7 @@ start_opac_string:
                     throw_exp = NodeGetRValue( throw_exp );
                     type = throw_exp->type;
                 } else if( NULL != MemberPtrType( type ) ) {
-                    throw_exp = NodeAssignTemporary( type, throw_exp );
+                    throw_exp = NodeMakeAssignToNewTmp( type, throw_exp );
                     type = NodeType( throw_exp );
                 } else if( NULL != FunctionDeclarationType( type ) ) {
                     type = TypeCanonicalThr( type );
@@ -4110,7 +4110,7 @@ start_opac_string:
                             rtcode = RTF_THROW_ZERO;
                         }
 //                      constant = NodeGetConstantNode( throw_exp );
-                        throw_exp = NodeAssignTemporary( throw_exp->type, throw_exp );
+                        throw_exp = NodeMakeAssignToNewTmp( throw_exp->type, throw_exp );
                         expr = PTreeOpLeft( throw_exp );
                         type = NodeType( expr );
                     }

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -2182,7 +2182,7 @@ static bool analyseAddrOfFunc(  // ANALYSE '&func'
 
     expr = PTreeOp( a_expr );
     addrof = expr;
-    switch( NodeAddrOfFun( addrof, &fnode ) ) {
+    switch( NodeGetOverloadedFnAddr( addrof, &fnode ) ) {
       default  :
         retb = true;
         break;

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -3691,7 +3691,7 @@ start_opac_string:
                 colon = PTreeOpRight( left );
                 opl = PTreeOpLeft( colon );
                 opr = PTreeOpRight( colon );
-                if( NodeIsBitField( opr ) && NodeBitField( opl ) ) {
+                if( NodeIsBitField( opr ) && NodeIsBitField( opl ) ) {
                     expr->type = type;
                     expr = NodeMakeBitQuestAssign( expr );
                     expr->flags |= PTF_SIDE_EFF | PTF_MEANINGFUL;

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -1905,7 +1905,7 @@ static PTREE convertCtor(       // CONVERT CTOR EXPRESSION
             PTREE temp = NodeMakeTemporary( type );
             expr = generateCtor( temp, expr );
             if( expr->op != PT_ERROR ) {
-                expr = NodeDtorExpr( expr, temp->u.symcg.symbol );
+                expr = NodeMarkDtorExpr( expr, temp->u.symcg.symbol );
             }
         }
         break;

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -4076,7 +4076,7 @@ start_opac_string:
                     throw_exp->flags &= ~ PTF_LVALUE;
                 }
                 if( BasedPtrType( type ) ) {
-                    if( ! NodeDerefPtr( &throw_exp ) ) {
+                    if( ! NodeTryDerefPtr( &throw_exp ) ) {
                         expr = throw_exp;
                         break;
                     }
@@ -4165,13 +4165,13 @@ start_opac_string:
             type = expr->type;
             continue;
           case DREF_PTR_LEFT :      // DE-REFERENCE PTR ON LEFT
-          { if( ! NodeDerefPtr( &expr->u.subtree[0] ) )
+          { if( ! NodeTryDerefPtr( &expr->u.subtree[0] ) )
                 break;
             left = PTreeOpLeft( expr );
             type = left->type;
           } continue;
           case DREF_PTR_RIGHT :     // DE-REFERENCE PTR ON RIGHT
-          { if( ! NodeDerefPtr( &expr->u.subtree[1] ) )
+          { if( ! NodeTryDerefPtr( &expr->u.subtree[1] ) )
                 break;
             right = PTreeOpRight( expr );
           } continue;

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -3183,7 +3183,7 @@ start_opac_string:
             continue;
           case CONV_CMP_ZERO_LEFT :
             left = expr->u.subtree[0];
-            left = NodeConvertToBool( left );
+            left = NodeMakeBoolConversion( left );
             expr->u.subtree[0] = left;
             if( left->op != PT_ERROR )
                 continue;
@@ -3191,7 +3191,7 @@ start_opac_string:
             break;
           case CONV_CMP_ZERO_RIGHT :
             right = expr->u.subtree[1];
-            right = NodeConvertToBool( right );
+            right = NodeMakeBoolConversion( right );
             expr->u.subtree[1] = right;
             if( right->op != PT_ERROR )
                 continue;
@@ -4425,7 +4425,7 @@ PTREE AnalyseBoolExpr(      // ANALYZE A BOOLEAN EXPRESSION
             if( 0 == ( expr->flags & PTF_BOOLEAN ) ) {
                 warnBoolAssignment( expr );
             }
-            expr = NodeConvertToBool( expr );
+            expr = NodeMakeBoolConversion( expr );
         }
     }
     return expr;

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -3213,7 +3213,7 @@ start_opac_string:
             }
             continue;
           case CONV_RVALUE_LEFT :
-            left = NodeRvalueLeft( expr );
+            left = NodeSetRValueLeft( expr );
             left->type = BindTemplateClass( left->type, &left->locn, false );
             type = TypedefModifierRemoveOnly( left->type );
             continue;
@@ -3578,7 +3578,7 @@ start_opac_string:
           case RESULT_COMMA :
             warnMeaningfulSideEffect( expr->u.subtree[0] );
             if( NodeIsUnaryOp( expr->u.subtree[0], CO_BITFLD_CONVERT ) ) {
-                left = NodeRvalueLeft( expr );
+                left = NodeSetRValueLeft( expr );
             }
             right = expr->u.subtree[1];
             if( NodeIsUnaryOp( right, CO_BITFLD_CONVERT ) ) {
@@ -3778,7 +3778,7 @@ start_opac_string:
           } break;
           case RESULT_CALL :
             if( NULL == FunctionDeclarationType( type ) ) {
-                left = NodeRvalueLeft( expr );
+                left = NodeSetRValueLeft( expr );
             }
             type = TypedefModifierRemoveOnly( left->type );
             if( type->id == TYP_POINTER ) {
@@ -3945,7 +3945,7 @@ start_opac_string:
             if( expr->flags & PTF_LVALUE )
                 continue;
             NodeRvalueRight( expr );
-            NodeRvalueLeft( expr );
+            NodeSetRValueLeft( expr );
             expr = CastImplicitCommonPtrExpr( expr
                                             , &diagPtrConvCommon
                                             , true );

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -4161,7 +4161,7 @@ start_opac_string:
           } continue;
           case RESULT_SEGNAME :     // __segname( "..." )
             expr = NodeReplace( expr
-                              , NodeSegname( left->u.string->string ) );
+                              , NodeMakeSegname( left->u.string->string ) );
             type = expr->type;
             continue;
           case DREF_PTR_LEFT :      // DE-REFERENCE PTR ON LEFT

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -4000,15 +4000,15 @@ start_opac_string:
           } continue;
           #undef ExtractColonFlags
           case RESULT_COND_OPRS :
-            expr->u.subtree[0] = NodeComma( NodeIc( IC_COND_TRUE )
+            expr->u.subtree[0] = NodeMakeComma( NodeIc( IC_COND_TRUE )
                                           , expr->u.subtree[0] );
-            expr->u.subtree[1] = NodeComma( NodeIc( IC_COND_FALSE )
+            expr->u.subtree[1] = NodeMakeComma( NodeIc( IC_COND_FALSE )
                                           , expr->u.subtree[1] );
             left = expr->u.subtree[0];
             right = expr->u.subtree[1];
             continue;
           case RESULT_COND_OPR :
-            expr->u.subtree[1] = NodeComma( NodeIc( IC_COND_TRUE )
+            expr->u.subtree[1] = NodeMakeComma( NodeIc( IC_COND_TRUE )
                                           , expr->u.subtree[1] );
             continue;
           case RESULT_COND_EXPR :

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -3676,7 +3676,7 @@ start_opac_string:
             continue;
           case RESULT_ASSIGN :
             expr->flags |= PTF_SIDE_EFF | PTF_MEANINGFUL;
-            if( NodeBitField( expr->u.subtree[0] ) )
+            if( NodeIsBitField( expr->u.subtree[0] ) )
                 continue;
             expr->flags |= PTF_LVALUE;
             if( CompFlags.plain_char_promotion ) {
@@ -3691,7 +3691,7 @@ start_opac_string:
                 colon = PTreeOpRight( left );
                 opl = PTreeOpLeft( colon );
                 opr = PTreeOpRight( colon );
-                if( NodeBitField( opr ) && NodeBitField( opl ) ) {
+                if( NodeIsBitField( opr ) && NodeBitField( opl ) ) {
                     expr->type = type;
                     expr = NodeBitQuestAssign( expr );
                     expr->flags |= PTF_SIDE_EFF | PTF_MEANINGFUL;

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -2955,7 +2955,7 @@ start_opac_string:
 #if 0
             ConvertExpr( &expr->u.subtree[0], right->type, CNV_EXPR );
 #else
-            expr->u.subtree[1] = NodeRvalue( expr->u.subtree[1] );
+            expr->u.subtree[1] = NodeGetRValue( expr->u.subtree[1] );
             if( expr->u.subtree[1]->op == PT_ERROR ) {
                 PTreeErrorNode( expr );
                 break;
@@ -4065,7 +4065,7 @@ start_opac_string:
                     expr = throw_exp;
                     break;
                 } else if( NULL != ArrayType( type ) ) {
-                    throw_exp = NodeRvalue( throw_exp );
+                    throw_exp = NodeGetRValue( throw_exp );
                     type = throw_exp->type;
                 } else if( NULL != MemberPtrType( type ) ) {
                     throw_exp = NodeAssignTemporary( type, throw_exp );
@@ -4438,7 +4438,7 @@ PTREE AnalyseValueExpr(     // ANALYZE AN EXPRESSION, MAKE IT A VALUE
     if( expr != NULL ) {
         expr = run_traversals( expr );
         if( expr->op != PT_ERROR ) {
-            expr = NodeRvalue( expr );
+            expr = NodeGetRValue( expr );
         }
     }
     return expr;

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -3693,7 +3693,7 @@ start_opac_string:
                 opr = PTreeOpRight( colon );
                 if( NodeIsBitField( opr ) && NodeBitField( opl ) ) {
                     expr->type = type;
-                    expr = NodeBitQuestAssign( expr );
+                    expr = NodeMakeBitQuestAssign( expr );
                     expr->flags |= PTF_SIDE_EFF | PTF_MEANINGFUL;
                 }
             }

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -1655,7 +1655,7 @@ static bool is_ptr_constant(    // CHECK IF NODE IS TYPED AS PTR TO A CONSTANT
 static PTREE bld_type_size(     // BUILD CONSTANT NODE WITH SIZE OF TYPE
     TYPE type )                 // - type in question
 {
-    return NodeOffset( CgTypeSize( type ) );
+    return NodeMakeConstantOffset( CgTypeSize( type ) );
 }
 
 
@@ -1698,7 +1698,7 @@ static PTREE bld_ptr_adj(       // BUILD A POINTER ADJUSTMENT
     if( pted_size == 1 ) {
         return factor;
     }
-    new_node = NodeMakeBinary( CO_TIMES, factor, NodeOffset( pted_size ) );
+    new_node = NodeMakeBinary( CO_TIMES, factor, NodeMakeConstantOffset( pted_size ) );
     new_node->type = factor->type;
     return FoldBinary( new_node );
 }

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -3883,7 +3883,7 @@ start_opac_string:
                     force_rvalue = true;
                 }
                 if( force_rvalue ) {
-                    left = NodeRvalueExactLeft( expr );
+                    left = NodeSetRValueExactLeft( expr );
                     if( PT_ERROR == left->op )
                         break;
                     type = TypedefModifierRemoveOnly( left->type );

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -2516,7 +2516,7 @@ static bool allowClassCastAsLValue( PTREE *p_expr )
     if( class_type == NULL ) {
         retb = false;
     } else {
-        *p_expr = NodeForceLvalue( *p_expr );
+        *p_expr = NodeForceLValue( *p_expr );
         retb = true;
     }
     return( retb );
@@ -4117,7 +4117,7 @@ start_opac_string:
                     break;
                   case THROBJ_CLASS :
                   case THROBJ_CLASS_VIRT :
-                    throw_exp = NodeForceLvalue( throw_exp );
+                    throw_exp = NodeForceLValue( throw_exp );
                     expr = throw_exp;
                     type = NodeType( expr );
                     DbgVerify( NULL != TypeReference( type )

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -4000,15 +4000,15 @@ start_opac_string:
           } continue;
           #undef ExtractColonFlags
           case RESULT_COND_OPRS :
-            expr->u.subtree[0] = NodeMakeComma( NodeIc( IC_COND_TRUE )
+            expr->u.subtree[0] = NodeMakeComma( NodeMakeIc( IC_COND_TRUE )
                                           , expr->u.subtree[0] );
-            expr->u.subtree[1] = NodeMakeComma( NodeIc( IC_COND_FALSE )
+            expr->u.subtree[1] = NodeMakeComma( NodeMakeIc( IC_COND_FALSE )
                                           , expr->u.subtree[1] );
             left = expr->u.subtree[0];
             right = expr->u.subtree[1];
             continue;
           case RESULT_COND_OPR :
-            expr->u.subtree[1] = NodeMakeComma( NodeIc( IC_COND_TRUE )
+            expr->u.subtree[1] = NodeMakeComma( NodeMakeIc( IC_COND_TRUE )
                                           , expr->u.subtree[1] );
             continue;
           case RESULT_COND_EXPR :

--- a/bld/plusplus/c/callopt.c
+++ b/bld/plusplus/c/callopt.c
@@ -44,7 +44,7 @@ CALL_OPT AnalyseCallOpts        // ANALYSE CALL OPTIMIZATIONS
     CALL_OPT retn;              // - type of return
     PTREE right;                // - bare source operand
 
-    right = *NodeReturnSrc( &src, a_dtor );
+    right = *NodeGetReturnSrc( &src, a_dtor );
     *a_right = right;
     if( type == ClassTypeForType( right->type ) ) {
         if( NodeCallsCtor( right ) ) {

--- a/bld/plusplus/c/callopt.c
+++ b/bld/plusplus/c/callopt.c
@@ -101,7 +101,7 @@ static PTREE doCopySubstitution( // EFFECT COPY SUBSTITUTION
     }
     repl->u.symcg.symbol->flag = 0;
     *a_repl = NodeReplace( *a_repl, tgt );
-    orig = NodeConvertFlags( ClassTypeForType( tgt->type )
+    orig = NodeMakeConversionFlags( ClassTypeForType( tgt->type )
                            , orig
                            , PTF_LVALUE
                            | PTF_MEMORY_EXACT

--- a/bld/plusplus/c/callopt.c
+++ b/bld/plusplus/c/callopt.c
@@ -52,7 +52,7 @@ CALL_OPT AnalyseCallOpts        // ANALYSE CALL OPTIMIZATIONS
         } else if( NodeIsBinaryOp( right, CO_CALL_EXEC )
                 || NodeIsBinaryOp( right, CO_CALL_EXEC_IND ) ) {
             TYPE ftype;         // - function type
-            ftype = TypeFunctionCalled( NodeFuncForCall( right )->type );
+            ftype = TypeFunctionCalled( NodeGetFnForCall( right )->type );
             DbgVerify( ftype != NULL
                      , "AnalyseCLassCallOpts -- impossible parse tree" );
             if( OMR_CLASS_REF == ObjModelFunctionReturn( ftype ) ) {

--- a/bld/plusplus/c/convctl.c
+++ b/bld/plusplus/c/convctl.c
@@ -946,7 +946,7 @@ static PTREE nodeBasedSelfExpr( // FIND EXPR TO BE USED FOR BASED __SELF
 static PTREE findBasedStrSym(   // FIND REFERENCE SYMBOL FOR TF1_BASED_STRING
     TYPE expr_type )            // - type of pointer expression
 {
-    return NodeBasedStr( BasedPtrType( expr_type ) );
+    return NodeMakeBasedStr( BasedPtrType( expr_type ) );
 }
 
 

--- a/bld/plusplus/c/convctl.c
+++ b/bld/plusplus/c/convctl.c
@@ -979,21 +979,21 @@ static PTREE convertFromPcPtr(  // CONVERT SPECIAL TO REGULAR PC PTR
           case PC_PTR_BASED_STRING :
           { PTREE bsym;         // - basing symbol
             bsym = findBasedStrSym( expr->type );
-            expr = NodeBinary( CO_SEG_OP, expr, bsym );
+            expr = NodeMakeBinary( CO_SEG_OP, expr, bsym );
             expr = NodeSetType( expr, tgt_type, PTF_PTR_NONZERO );
           } break;
           case PC_PTR_BASED_SELF :
-            expr = NodeBinary( CO_SEG_OP, expr, bself );
+            expr = NodeMakeBinary( CO_SEG_OP, expr, bself );
             expr = NodeSetType( expr, tgt_type, PTF_PTR_NONZERO );
             break;
           case PC_PTR_BASED_FETCH :
-            expr = NodeBinary( CO_SEG_OP
+            expr = NodeMakeBinary( CO_SEG_OP
                              , expr
                              , NodeRvalue( MakeNodeSymbol( baser ) ) );
             expr = NodeSetType( expr, tgt_type, PTF_PTR_NONZERO );
             break;
           case PC_PTR_BASED_ADD :
-            expr = NodeBinary( CO_PLUS
+            expr = NodeMakeBinary( CO_PLUS
                              , expr
                              , NodeRvalue( MakeNodeSymbol( baser ) ) );
             expr = NodeSetType( expr, tgt_type, PTF_PTR_NONZERO );
@@ -1033,7 +1033,7 @@ static PTREE convertToPcPtr(    // CONVERT REGULAR TO SPECIAL PC PTR
         baser = BasedPtrType( ptr_type )->u.m.base;
         temp = MakeNodeSymbol( baser );
         temp = NodeRvalue( temp );
-        expr = NodeBinary( CO_MINUS, expr, temp );
+        expr = NodeMakeBinary( CO_MINUS, expr, temp );
         expr = NodeSetType( expr, ptr_type, PTF_PTR_NONZERO );
       } break;
     }

--- a/bld/plusplus/c/convctl.c
+++ b/bld/plusplus/c/convctl.c
@@ -1347,7 +1347,7 @@ CNV_RETN CastPtrToPtr           // IMPLICIT/EXPLICIT CAST PTR -> PTR
     PTREE expr;                 // - resultant expression
     PTREE dtor;                 // - dtoring operand
 
-    expr = *NodeReturnSrc( &ctl->expr, &dtor );
+    expr = *NodeGetReturnSrc( &ctl->expr, &dtor );
     if( expr->op == PT_SYMBOL ) {
         expr->u.symcg.symbol->flag |= SF_ADDR_TAKEN;
     }

--- a/bld/plusplus/c/convctl.c
+++ b/bld/plusplus/c/convctl.c
@@ -974,7 +974,7 @@ static PTREE convertFromPcPtr(  // CONVERT SPECIAL TO REGULAR PC PTR
             expr = NodeSetType( expr, ptr_type, PTF_PTR_NONZERO );
             break;
           case PC_PTR_BASED_VOID :
-            expr = NodeConvertFlags( tgt_type, expr, PTF_PTR_NONZERO );
+            expr = NodeMakeConversionFlags( tgt_type, expr, PTF_PTR_NONZERO );
             break;
           case PC_PTR_BASED_STRING :
           { PTREE bsym;         // - basing symbol
@@ -1025,7 +1025,7 @@ static PTREE convertToPcPtr(    // CONVERT REGULAR TO SPECIAL PC PTR
       case PC_PTR_BASED_VOID :
       case PC_PTR_BASED_FETCH :
       case PC_PTR_BASED_STRING :
-        expr = NodeConvertFlags( ptr_type, expr, PTF_PTR_NONZERO );
+        expr = NodeMakeConversionFlags( ptr_type, expr, PTF_PTR_NONZERO );
         break;
       case PC_PTR_BASED_ADD :
       { PTREE temp;             // - temp

--- a/bld/plusplus/c/convctl.c
+++ b/bld/plusplus/c/convctl.c
@@ -970,7 +970,7 @@ static PTREE convertFromPcPtr(  // CONVERT SPECIAL TO REGULAR PC PTR
                              , TC1_NOT_ENUM_CHAR );
         switch( ptr_class ) {
           case PC_PTR_FAR16 :
-            expr = NodeUnary( CO_FAR16_TO_POINTER, expr );
+            expr = NodeMakeUnary( CO_FAR16_TO_POINTER, expr );
             expr = NodeSetType( expr, ptr_type, PTF_PTR_NONZERO );
             break;
           case PC_PTR_BASED_VOID :
@@ -1018,7 +1018,7 @@ static PTREE convertToPcPtr(    // CONVERT REGULAR TO SPECIAL PC PTR
       case PC_PTR_NOT :
         break;
       case PC_PTR_FAR16 :
-        expr = NodeUnary( CO_POINTER_TO_FAR16, expr );
+        expr = NodeMakeUnary( CO_POINTER_TO_FAR16, expr );
         expr = NodeSetType( expr, ptr_type, PTF_PTR_NONZERO );
         break;
       case PC_PTR_BASED_SELF :

--- a/bld/plusplus/c/convctl.c
+++ b/bld/plusplus/c/convctl.c
@@ -487,7 +487,7 @@ void ConvCtlInit                // INITIALIZE CONVCTL
                 ref_type = TypeReference( ctl->tgt.unmod );
                 if( TypeIsConst( ref_type ) ) {
                     PTREE exp;
-                    exp = NodeAssignTemporary( ref_type, ctl->expr->u.subtree[1] );
+                    exp = NodeMakeAssignToNewTmp( ref_type, ctl->expr->u.subtree[1] );
                     ctl->expr->u.subtree[1] = exp;
                 } else {
                     diagnoseError( ctl, ERR_TEMP_AS_NONCONST_REF );

--- a/bld/plusplus/c/convctl.c
+++ b/bld/plusplus/c/convctl.c
@@ -449,7 +449,7 @@ void ConvCtlInit                // INITIALIZE CONVCTL
                     checkSrcForError( ctl );
                 } else if( NodeIsUnaryOp( ctl->expr->u.subtree[1], CO_BITFLD_CONVERT ) ) {
                     if( TypeIsConst( ctl->tgt.unmod->of ) ) {
-                        ctl->expr->u.subtree[1] = NodeRvalue( ctl->expr->u.subtree[1] );
+                        ctl->expr->u.subtree[1] = NodeGetRValue( ctl->expr->u.subtree[1] );
                     } else {
                         ConversionInfDisable();
                         PTreeErrorExpr( ctl->expr->u.subtree[1], ERR_CANT_REFERENCE_A_BIT_FIELD );
@@ -500,7 +500,7 @@ void ConvCtlInit                // INITIALIZE CONVCTL
                     ctl->expr->u.subtree[1]->type = MakePointerTo( ref_type );
                     ctl->expr->u.subtree[1]->flags &= ~PTF_LVALUE;
                 } else {
-                    expr->u.subtree[1] = NodeRvalue( expr->u.subtree[1] );
+                    expr->u.subtree[1] = NodeGetRValue( expr->u.subtree[1] );
                     src = expr->u.subtree[1]->type;
                 }
             }
@@ -989,13 +989,13 @@ static PTREE convertFromPcPtr(  // CONVERT SPECIAL TO REGULAR PC PTR
           case PC_PTR_BASED_FETCH :
             expr = NodeMakeBinary( CO_SEG_OP
                              , expr
-                             , NodeRvalue( MakeNodeSymbol( baser ) ) );
+                             , NodeGetRValue( MakeNodeSymbol( baser ) ) );
             expr = NodeSetType( expr, tgt_type, PTF_PTR_NONZERO );
             break;
           case PC_PTR_BASED_ADD :
             expr = NodeMakeBinary( CO_PLUS
                              , expr
-                             , NodeRvalue( MakeNodeSymbol( baser ) ) );
+                             , NodeGetRValue( MakeNodeSymbol( baser ) ) );
             expr = NodeSetType( expr, tgt_type, PTF_PTR_NONZERO );
             break;
           default :
@@ -1032,7 +1032,7 @@ static PTREE convertToPcPtr(    // CONVERT REGULAR TO SPECIAL PC PTR
         SYMBOL baser;           // - based symbol
         baser = BasedPtrType( ptr_type )->u.m.base;
         temp = MakeNodeSymbol( baser );
-        temp = NodeRvalue( temp );
+        temp = NodeGetRValue( temp );
         expr = NodeMakeBinary( CO_MINUS, expr, temp );
         expr = NodeSetType( expr, ptr_type, PTF_PTR_NONZERO );
       } break;

--- a/bld/plusplus/c/convctl.c
+++ b/bld/plusplus/c/convctl.c
@@ -937,7 +937,7 @@ static PTREE nodeBasedSelfExpr( // FIND EXPR TO BE USED FOR BASED __SELF
     pted = TypePointedAtModified( node_type );
     umod = TypeModExtract( pted, &flags, &baser, TC1_NOT_ENUM_CHAR );
     tgt = TypeRebuildPcPtr( umod, flags, TF1_FAR );
-    expr->u.subtree[0] = NodeConvert( tgt, expr->u.subtree[0] );
+    expr->u.subtree[0] = NodeMakeConversion( tgt, expr->u.subtree[0] );
     expr->u.subtree[0]->flags &= ~ PTF_LVALUE;
     return NodeDupExpr( &expr->u.subtree[0] );
 }
@@ -1313,7 +1313,7 @@ static CNV_RETN pcPtrConvertSrcTgt(// PTR CONVERT SOURCE TO TARGET
 #endif
                 // fall thru
             case 2:       // truncate to __based pointer, except TF1_ADD
-                expr = NodeConvert( tgt_type, expr );
+                expr = NodeMakeConversion( tgt_type, expr );
                 break;
             case 3:       // convert to FAR16
             case 8:       // convert regular to TF1_ADD
@@ -1330,7 +1330,7 @@ static CNV_RETN pcPtrConvertSrcTgt(// PTR CONVERT SOURCE TO TARGET
             case 6:       // convert from FAR16 to __based
             case 9:       // convert TF1_ADD to __based
                 expr = convertFromPcPtr( expr, type_src, bself );
-                expr = NodeConvert( tgt_type, expr );
+                expr = NodeMakeConversion( tgt_type, expr );
                 break;
             }
         }

--- a/bld/plusplus/c/convctl.c
+++ b/bld/plusplus/c/convctl.c
@@ -266,7 +266,7 @@ static void adjustFnAddrPtr     // ADJUST FOR &FUNCTION --> PTR
     PTREE func;                 // - function node ( &class::func )
 
     addrof = PTreeOp( &ctl->expr->u.subtree[1] );
-    switch( NodeAddrOfFun( addrof, &func ) ) {
+    switch( NodeGetOverloadedFnAddr( addrof, &func ) ) {
       case ADDR_FN_ONE_USED :
       case ADDR_FN_ONE :
         func = NodeActualNonOverloaded( func );
@@ -311,7 +311,7 @@ static void adjustFnAddrMembPtr // ADJUST FOR &FUNCTION --> MEMB-PTR
     TYPE mptype;                // - member-ptr type
 
     addrof = PTreeOp( &ctl->expr->u.subtree[1] );
-    switch( NodeAddrOfFun( addrof, &func ) ) {
+    switch( NodeGetOverloadedFnAddr( addrof, &func ) ) {
       case ADDR_FN_ONE_USED :
         if( !CompFlags.extensions_enabled )
             break;

--- a/bld/plusplus/c/convctl.c
+++ b/bld/plusplus/c/convctl.c
@@ -939,7 +939,7 @@ static PTREE nodeBasedSelfExpr( // FIND EXPR TO BE USED FOR BASED __SELF
     tgt = TypeRebuildPcPtr( umod, flags, TF1_FAR );
     expr->u.subtree[0] = NodeMakeConversion( tgt, expr->u.subtree[0] );
     expr->u.subtree[0]->flags &= ~ PTF_LVALUE;
-    return NodeDupExpr( &expr->u.subtree[0] );
+    return NodeMakeExprDuplicate( &expr->u.subtree[0] );
 }
 
 

--- a/bld/plusplus/c/datadtor.c
+++ b/bld/plusplus/c/datadtor.c
@@ -73,7 +73,7 @@ static PTREE addPtIcUnsigned(   // DECORATE TREE WITH PT_IC NODE (unsigned)
     CGINTEROP opcode,           // - opcode
     unsigned value )            // - value
 {
-    return addPtIc( tree, NodeIcUnsigned( opcode, value ) );
+    return addPtIc( tree, NodeMakeIcUnsigned( opcode, value ) );
 }
 
 

--- a/bld/plusplus/c/datainit.c
+++ b/bld/plusplus/c/datainit.c
@@ -325,7 +325,7 @@ static void dataInitEmitAutoAssign( SYMBOL dst, SYMBOL src )
     type = MakeTypeOf( type, GetBasicType( TYP_UCHAR ) );
     node = NodeFetch( refOfSym( type, src ) );
     node = NodeMakeAssignment( refOfSym( type, dst ), node );
-    node = NodeDone( node );
+    node = NodeMakeDone( node );
 
     _dump( "- Auto Assign Expression ------------------------------" );
     _dumpPTree( node );
@@ -1234,7 +1234,7 @@ static void dataInitInvokeCtor( target_size_t start )
         return;
     }
     node = dtorableObjectCtored( currInit->nest, node, true );
-    node = NodeDone( node );
+    node = NodeMakeDone( node );
 
     _dump( "- Invoke Ctor Expression ------------------------------" );
     _dumpPTree( node );
@@ -1304,7 +1304,7 @@ static void dataInitRunTimeCall( target_size_t start, target_size_t size )
             }
             node = RunTimeCall( node, MakeReferenceTo( base_type ), fun_code );
             node = dtorableObjectCtored( currInit->nest, node, true );
-            node = NodeDone( node );
+            node = NodeMakeDone( node );
 
             _dump( "- RunTime Call Expression -----------------------------" );
             _dumpPTree( node );

--- a/bld/plusplus/c/datainit.c
+++ b/bld/plusplus/c/datainit.c
@@ -1293,7 +1293,7 @@ static void dataInitRunTimeCall( target_size_t start, target_size_t size )
             currInit->state = DS_ERROR;
         } else {
             sig = dataInitTypeSigFind( base_type, TSA_DEFAULT_CTOR | TSA_DTOR );
-            node = NodeMakeArgList( NodeTypeSig( sig )
+            node = NodeMakeArgList( NodeMakeTypeSignature( sig )
                                 , NodeMakeConstantOffset( num_elem )
                                 , dataInitPadLeftSide( start )
                                 , NULL );

--- a/bld/plusplus/c/datainit.c
+++ b/bld/plusplus/c/datainit.c
@@ -1293,7 +1293,7 @@ static void dataInitRunTimeCall( target_size_t start, target_size_t size )
             currInit->state = DS_ERROR;
         } else {
             sig = dataInitTypeSigFind( base_type, TSA_DEFAULT_CTOR | TSA_DTOR );
-            node = NodeArguments( NodeTypeSig( sig )
+            node = NodeMakeArgList( NodeTypeSig( sig )
                                 , NodeMakeConstantOffset( num_elem )
                                 , dataInitPadLeftSide( start )
                                 , NULL );

--- a/bld/plusplus/c/datainit.c
+++ b/bld/plusplus/c/datainit.c
@@ -288,7 +288,7 @@ static PTREE dataInitPadLeftSide( target_size_t start )
     type = TypeMergeForMember( type, currInit->base_type );
     tree->type = type;
     tree->flags |= PTF_LVALUE;
-    tree = NodeUnary( CO_INDIRECT, tree );
+    tree = NodeMakeUnary( CO_INDIRECT, tree );
     tree->type = type;
     tree->flags |= PTF_LVALUE;
     return( tree );

--- a/bld/plusplus/c/datainit.c
+++ b/bld/plusplus/c/datainit.c
@@ -695,7 +695,7 @@ static PTREE emitDtorInitExpr(  // EMIT DTOR MARKING FOR AN EXPRESSION
             // end of scope-call optimization
             expr = PtdInitSymEnd( expr, sym );
         }
-        expr = NodeDtorExpr( expr, sym );
+        expr = NodeMarkDtorExpr( expr, sym );
         if( done != NULL ) {
             done->u.subtree[0] = expr;
             expr = done;

--- a/bld/plusplus/c/datainit.c
+++ b/bld/plusplus/c/datainit.c
@@ -298,7 +298,7 @@ static PTREE dataInitPadLeftSide( target_size_t start )
 static PTREE refOfSym( TYPE type, SYMBOL var )
 /********************************************/
 {
-    return NodeConvert( MakeReferenceTo( type ), MakeNodeSymbol( var ) );
+    return NodeMakeConversion( MakeReferenceTo( type ), MakeNodeSymbol( var ) );
 }
 #endif
 

--- a/bld/plusplus/c/datainit.c
+++ b/bld/plusplus/c/datainit.c
@@ -1294,7 +1294,7 @@ static void dataInitRunTimeCall( target_size_t start, target_size_t size )
         } else {
             sig = dataInitTypeSigFind( base_type, TSA_DEFAULT_CTOR | TSA_DTOR );
             node = NodeArguments( NodeTypeSig( sig )
-                                , NodeOffset( num_elem )
+                                , NodeMakeConstantOffset( num_elem )
                                 , dataInitPadLeftSide( start )
                                 , NULL );
             if( TypeHasVirtualBases( base_type ) ) {

--- a/bld/plusplus/c/datainit.c
+++ b/bld/plusplus/c/datainit.c
@@ -324,7 +324,7 @@ static void dataInitEmitAutoAssign( SYMBOL dst, SYMBOL src )
 #if 0
     type = MakeTypeOf( type, GetBasicType( TYP_UCHAR ) );
     node = NodeFetch( refOfSym( type, src ) );
-    node = NodeAssign( refOfSym( type, dst ), node );
+    node = NodeMakeAssignment( refOfSym( type, dst ), node );
     node = NodeDone( node );
 
     _dump( "- Auto Assign Expression ------------------------------" );

--- a/bld/plusplus/c/defarg.c
+++ b/bld/plusplus/c/defarg.c
@@ -315,7 +315,7 @@ bool AddDefaultArgs(            // ADD DEFAULT ARGUMENTS, AS REQ'D
                 PTreeErrorNode( defarg_expr );
                 break;
             }
-            defarg_expr = NodeArg( defarg_expr );
+            defarg_expr = NodeMakeArg( defarg_expr );
             *args = defarg_expr;
             args = &defarg_expr->u.subtree[0]; // used if more than one defarg
             func->flag |= SF_REFERENCED;

--- a/bld/plusplus/c/dupnode.c
+++ b/bld/plusplus/c/dupnode.c
@@ -125,7 +125,7 @@ static PTREE dupPromote(        // PROMOTE A DUPLICATE
     temp->sym_type = type;
     convertToTemp( dup1, temp );
     convertToTemp( dup2, temp );
-    dup = NodeBinary( NULL == TypeReference( type ) ? CO_EQUAL : CO_EQUAL_REF
+    dup = NodeMakeBinary( NULL == TypeReference( type ) ? CO_EQUAL : CO_EQUAL_REF
                     , MakeNodeSymbol( temp )
                     , dup );
     dup->type = type;

--- a/bld/plusplus/c/dyncast.c
+++ b/bld/plusplus/c/dyncast.c
@@ -52,7 +52,7 @@ static PTREE DynamicCastVoid           // DYNAMIC CAST CODE: VOID *
     from = NodeTypeid( ctl->src.pted );
     info = GetWithinOffsetOfVFPtr( ctl->src.pted, &expr );
     expr = NodeArguments( from
-                        , NodeOffset( info->vf_offset )
+                        , NodeMakeConstantOffset( info->vf_offset )
                         , expr
                         , NULL );
     expr = RunTimeCall( expr, ctl->tgt.orig , RTF_DYN_CAST_VOID );
@@ -80,7 +80,7 @@ PTREE DynamicCast               // DYNAMIC CAST CODE
         info = GetWithinOffsetOfVFPtr( ctl->src.pted, &expr );
         expr = NodeArguments( to
                             , from
-                            , NodeOffset( info->vf_offset )
+                            , NodeMakeConstantOffset( info->vf_offset )
                             , expr
                             , NULL );
         DbgAssert( ctl->src.reference == ctl->tgt.reference );

--- a/bld/plusplus/c/dyncast.c
+++ b/bld/plusplus/c/dyncast.c
@@ -51,7 +51,7 @@ static PTREE DynamicCastVoid           // DYNAMIC CAST CODE: VOID *
     expr->locn = locn;
     from = NodeTypeid( ctl->src.pted );
     info = GetWithinOffsetOfVFPtr( ctl->src.pted, &expr );
-    expr = NodeArguments( from
+    expr = NodeMakeArgList( from
                         , NodeMakeConstantOffset( info->vf_offset )
                         , expr
                         , NULL );
@@ -78,7 +78,7 @@ PTREE DynamicCast               // DYNAMIC CAST CODE
         from = NodeTypeid( ctl->src.pted );
         to = NodeTypeid( ctl->tgt.pted );
         info = GetWithinOffsetOfVFPtr( ctl->src.pted, &expr );
-        expr = NodeArguments( to
+        expr = NodeMakeArgList( to
                             , from
                             , NodeMakeConstantOffset( info->vf_offset )
                             , expr

--- a/bld/plusplus/c/except.c
+++ b/bld/plusplus/c/except.c
@@ -383,7 +383,7 @@ PTREE ThrowTypeSig(             // GET THROW ARGUMENT FOR TYPE SIGNATURE
     if( throwCnvFront( type, expr ) ) {
         node = NodeMakeUnary( CO_TYPE_SIG, NULL );
         node->type = type;
-        node = NodeArg( node );
+        node = NodeMakeArg( node );
         node->type = type;
     } else {
         node = NULL;

--- a/bld/plusplus/c/except.c
+++ b/bld/plusplus/c/except.c
@@ -381,7 +381,7 @@ PTREE ThrowTypeSig(             // GET THROW ARGUMENT FOR TYPE SIGNATURE
 
     type = TypeCanonicalThr( type );
     if( throwCnvFront( type, expr ) ) {
-        node = NodeUnary( CO_TYPE_SIG, NULL );
+        node = NodeMakeUnary( CO_TYPE_SIG, NULL );
         node->type = type;
         node = NodeArg( node );
         node->type = type;

--- a/bld/plusplus/c/fnbody.c
+++ b/bld/plusplus/c/fnbody.c
@@ -2230,7 +2230,7 @@ void FunctionBody( DECL_INFO *dinfo )
       case RETN_DFLT_INT :
         if( MainProcedure( func ) ) {
             PTREE expr;
-            expr = AnalyseReturnExpr( func, NodeZero() );
+            expr = AnalyseReturnExpr( func, NodeMakeZeroConstant() );
             IcEmitExpr( expr );
         }
         // drops thru

--- a/bld/plusplus/c/fnovload.c
+++ b/bld/plusplus/c/fnovload.c
@@ -1488,7 +1488,7 @@ static void computeFuncRank( SYMBOL fsym, SYMBOL sym, TYPE *tgt,
     SEARCH_RESULT       *result;
 
     initRankVector( FNC_DEFAULT, &curr_rank, 0 );
-    retn = NodeAddrOfFun( *ptlist, &fn );
+    retn = NodeGetOverloadedFnAddr( *ptlist, &fn );
     DbgAssert( retn != ADDR_FN_NONE );
     src_mptr = false;
     if( fn->flags & PTF_COLON_QUALED ) { // i.e. S::foo not just foo

--- a/bld/plusplus/c/fold.c
+++ b/bld/plusplus/c/fold.c
@@ -575,7 +575,7 @@ static PTREE makeTrueFalse( PTREE expr, PTREE op, int value )
     if( anachronismFound( op ) ) {
         return( expr );
     }
-    node = NodeOffset( value );
+    node = NodeMakeConstantOffset( value );
     node = NodeSetBooleanType( node );
     node = PTreeCopySrcLocation( node, expr );
     NodeFreeDupedExpr( expr );

--- a/bld/plusplus/c/icemit.c
+++ b/bld/plusplus/c/icemit.c
@@ -879,7 +879,7 @@ void IcEmitDtorAutoSym(         // EMIT EXPRESSION TO MARK AUTO AS DTOR'ED
 {
     PTREE node;                 // - expression to be emitted
 
-    node = NodeMarkDtorExpr( NodeIntDummy(), sym );
+    node = NodeMarkDtorExpr( NodeMakeIntDummy(), sym );
     node = PtdDtorScopeType( node, sym->sym_type );
     node = NodeUnaryCopy( CO_TRASH_EXPR, node );
     IcEmitExpr( node );
@@ -891,7 +891,7 @@ void IcEmitDtorStaticSym(       // EMIT EXPRESSION TO MARK STATIC AS DTOR'ED
 {
     PTREE node;                 // - expression to be emitted
 
-    node = NodeMarkDtorExpr( NodeIntDummy(), sym );
+    node = NodeMarkDtorExpr( NodeMakeIntDummy(), sym );
     node = NodeUnaryCopy( CO_TRASH_EXPR, node );
     IcEmitExpr( node );
 }

--- a/bld/plusplus/c/icemit.c
+++ b/bld/plusplus/c/icemit.c
@@ -946,6 +946,6 @@ void EmitAnalysedStmt(          // EMIT ANALYSED STMT (IF IT EXISTS)
     PTREE stmt )                // - the statement
 {
     if( stmt != NULL ) {
-        IcEmitExpr( NodeDone( stmt ) );
+        IcEmitExpr( NodeMakeDone( stmt ) );
     }
 }

--- a/bld/plusplus/c/icemit.c
+++ b/bld/plusplus/c/icemit.c
@@ -879,7 +879,7 @@ void IcEmitDtorAutoSym(         // EMIT EXPRESSION TO MARK AUTO AS DTOR'ED
 {
     PTREE node;                 // - expression to be emitted
 
-    node = NodeDtorExpr( NodeIntDummy(), sym );
+    node = NodeMarkDtorExpr( NodeIntDummy(), sym );
     node = PtdDtorScopeType( node, sym->sym_type );
     node = NodeUnaryCopy( CO_TRASH_EXPR, node );
     IcEmitExpr( node );
@@ -891,7 +891,7 @@ void IcEmitDtorStaticSym(       // EMIT EXPRESSION TO MARK STATIC AS DTOR'ED
 {
     PTREE node;                 // - expression to be emitted
 
-    node = NodeDtorExpr( NodeIntDummy(), sym );
+    node = NodeMarkDtorExpr( NodeIntDummy(), sym );
     node = NodeUnaryCopy( CO_TRASH_EXPR, node );
     IcEmitExpr( node );
 }

--- a/bld/plusplus/c/initref.c
+++ b/bld/plusplus/c/initref.c
@@ -111,7 +111,7 @@ static bool returnsStruct(      // TEST IF STRUCT RETURNED BY CALL
 {
     TYPE func_type;             // - type of function call
 
-    func_type = TypeFunctionCalled( NodeFuncForCall( call )->type );
+    func_type = TypeFunctionCalled( NodeGetFnForCall( call )->type );
 #if 0
     return NULL != StructType( func_type->of );
 #else

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -347,12 +347,12 @@ static PTREE computeNewDelta(   // COMPUTE NEW DELTA
     if( inf->delta_reqd ) {
         delta = ( inf->safe ) ? inf->delta : -inf->delta;
         if( inf->test_reqd ) {
-            node = addOffset( NodeDupExpr( &new_delta ), delta, type );
+            node = addOffset( NodeMakeExprDuplicate( &new_delta ), delta, type );
             node = FoldBinary( node );
             node = NodeMakeBinary( CO_COLON, new_delta, node );
             node->type = type;
             node = NodeMakeBinary( CO_QUESTION
-                             , NodeMakeZeroCompare( NodeDupExpr( new_index ) )
+                             , NodeMakeZeroCompare( NodeMakeExprDuplicate( new_index ) )
                              , node );
             node->type = type;
         } else {
@@ -379,7 +379,7 @@ static PTREE computeNewIndex(   // COMPUTE NEW INDEX
             off_node->type = type;
             if( inf->single_mapping ) {
                 node = NodeMakeBinary( (inf->vb_index == 0 ) ? CO_GT : CO_EQ
-                                 , NodeDupExpr( &new_index )
+                                 , NodeMakeExprDuplicate( &new_index )
                                  , NodeMakeConstantOffset( inf->single_test * TARGET_UINT ) );
                 node = NodeSetBooleanType( node );
                 node = FoldBinary( node );
@@ -916,9 +916,9 @@ static MP_TYPE classifyMpExpr(  // CLASSIFY A MEMBER-POINTER EXPRESSION
             }
         }
         type = MakePointerTo( dereferenceFnType( type_mp->of ) );
-        func = accessOp( NodeDupExpr( &expr ), 0, type );
+        func = accessOp( NodeMakeExprDuplicate( &expr ), 0, type );
         type = memberPtrLayout( &offset_delta, &offset_index );
-        delta = accessOp( NodeDupExpr( &expr ), offset_delta, type );
+        delta = accessOp( NodeMakeExprDuplicate( &expr ), offset_delta, type );
         index = accessOp( expr, offset_index, type );
         expr = makeMembPtrExpr( expr->type, func, delta, index );
         expr->flags |= PTF_LVALUE;
@@ -946,7 +946,7 @@ CNV_RETN MembPtrAssign(         // ASSIGNMENT/INITIALIZATION OF MEMBER POINTER
                          , expr->u.subtree[0]->type
                          , CNV_INIT_COPY );
     if( retn == CNV_OK ) {
-        tgt = NodeDupExpr( &expr->u.subtree[0] );
+        tgt = NodeMakeExprDuplicate( &expr->u.subtree[0] );
         classifyMpExpr( &expr->u.subtree[0] );
         switch( classifyMpExpr( &expr->u.subtree[1] ) ) {
           case MP_CONST :
@@ -1048,11 +1048,11 @@ static PTREE doDereference(     // GENERATE DE-REFERENCING CODE
         expr = expr->u.subtree[0];
         index = NodeGetRValue( expr->u.subtree[1] );
         expr->u.subtree[1] = NULL;
-        temp = accessOp( NodeDupExpr( &lhs )
+        temp = accessOp( NodeMakeExprDuplicate( &lhs )
                        , ScopeVBPtrOffset( scope )
                        , MakePointerTo( type_offset ) );
-        expr = NodeAddToLeft( NodeFetch( NodeDupExpr( &temp ) )
-                        , NodeDupExpr( &index )
+        expr = NodeAddToLeft( NodeFetch( NodeMakeExprDuplicate( &temp ) )
+                        , NodeMakeExprDuplicate( &index )
                         , type_offset );
         expr->flags |= PTF_LVALUE;
         expr = NodeAddToLeft( temp, NodeFetch( expr ), type_cp );

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -60,7 +60,7 @@ typedef enum                    // CLASSIFICATION OF MEMBER-PTR EXPRESSIONS
 static PTREE membPtrTemporary(  // PLACE MEMBER PTR IN TEMPORARY
     PTREE expr )                // - member-ptr expression
 {
-    expr = NodeMakeAssignment( NodeTemporary( expr->type ), expr );
+    expr = NodeMakeAssignment( NodeMakeTemporary( expr->type ), expr );
     expr->flags |= PTF_MEMORY_EXACT;
     return expr;
 }

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -448,7 +448,7 @@ static PTREE makeMembPtrExpr(   // MAKE A MEMBER-PTR EXPRESSION
     PTREE expr;                 // - resultant expression
 
     expr = NodeMakeUnary( CO_MEMPTR_CONST
-                    , NodeArguments( index, delta, func, NULL ) );
+                    , NodeMakeArgList( index, delta, func, NULL ) );
     expr->type = type;
     return expr;
 }

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -273,7 +273,7 @@ static void generateOffsetFunc( // GENERATE CODE FOR OFFSET FUNCTION
     expr = NodeMakeAssignment( MakeNodeSymbol( ret ), expr );
     expr->type = type_ret;
     expr->flags |= PTF_LVALUE;
-    IcEmitExpr( NodeDone( expr ) );
+    IcEmitExpr( NodeMakeDone( expr ) );
     CgFrontReturnSymbol( ret );
     FunctionBodyShutdown( func, &func_fd );
     ScopeEnd( SCOPE_FUNCTION );

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -1066,7 +1066,7 @@ static PTREE doDereference(     // GENERATE DE-REFERENCING CODE
     }
     NodeFreeDupedExpr( expr_root );
     expr = NodeAddToLeft( delta, expr, type_cp );
-    expr = NodeArg( expr );
+    expr = NodeMakeArg( expr );
     func = NodeUnaryCopy( CO_CALL_SETUP_IND, func );
     func->type = type_fn;
     expr = NodeMakeBinary( CO_CALL_EXEC_IND, func, expr );

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -213,7 +213,7 @@ static PTREE accessOp(          // ACCESS AN OPERAND
 {
     PTREE expr;                 // - resultant expression
 
-    expr = NodeBinary( CO_DOT, base, NodeOffset( offset ) );
+    expr = NodeMakeBinary( CO_DOT, base, NodeOffset( offset ) );
     expr->type = type;
     expr->flags |= PTF_LVALUE;
     return expr;
@@ -349,9 +349,9 @@ static PTREE computeNewDelta(   // COMPUTE NEW DELTA
         if( inf->test_reqd ) {
             node = addOffset( NodeDupExpr( &new_delta ), delta, type );
             node = FoldBinary( node );
-            node = NodeBinary( CO_COLON, new_delta, node );
+            node = NodeMakeBinary( CO_COLON, new_delta, node );
             node->type = type;
-            node = NodeBinary( CO_QUESTION
+            node = NodeMakeBinary( CO_QUESTION
                              , NodeCompareToZero( NodeDupExpr( new_index ) )
                              , node );
             node->type = type;
@@ -378,14 +378,14 @@ static PTREE computeNewIndex(   // COMPUTE NEW INDEX
             off_node = NodeOffset( inf->vb_index * TARGET_UINT );
             off_node->type = type;
             if( inf->single_mapping ) {
-                node = NodeBinary( (inf->vb_index == 0 ) ? CO_GT : CO_EQ
+                node = NodeMakeBinary( (inf->vb_index == 0 ) ? CO_GT : CO_EQ
                                  , NodeDupExpr( &new_index )
                                  , NodeOffset( inf->single_test * TARGET_UINT ) );
                 node = NodeSetBooleanType( node );
                 node = FoldBinary( node );
-                new_index = NodeBinary( CO_COLON, off_node, new_index );
+                new_index = NodeMakeBinary( CO_COLON, off_node, new_index );
                 new_index->type = type;
-                new_index = NodeBinary( CO_QUESTION
+                new_index = NodeMakeBinary( CO_QUESTION
                                       , node
                                       , new_index );
                 new_index->type = type;
@@ -396,7 +396,7 @@ static PTREE computeNewIndex(   // COMPUTE NEW INDEX
             }
         } else {
             node = MakeNodeSymbol( inf->mapping );
-            node = NodeBinary( CO_DOT, node, new_index );
+            node = NodeMakeBinary( CO_DOT, node, new_index );
             node->type = type;
             node->flags |= PTF_LVALUE;
             new_index = NodeFetch( node );
@@ -1057,9 +1057,9 @@ static PTREE doDereference(     // GENERATE DE-REFERENCING CODE
         expr->flags |= PTF_LVALUE;
         expr = NodeAddToLeft( temp, NodeFetch( expr ), type_cp );
         expr->flags &= ~ PTF_LVALUE;
-        expr = NodeBinary( CO_COLON, expr, lhs );
+        expr = NodeMakeBinary( CO_COLON, expr, lhs );
         expr->type = type_cp;
-        expr = NodeBinary( CO_QUESTION, NodeCompareToZero( index ), expr );
+        expr = NodeMakeBinary( CO_QUESTION, NodeCompareToZero( index ), expr );
         expr->type = type_cp;
     } else {
         expr = lhs;
@@ -1069,7 +1069,7 @@ static PTREE doDereference(     // GENERATE DE-REFERENCING CODE
     expr = NodeArg( expr );
     func = NodeUnaryCopy( CO_CALL_SETUP_IND, func );
     func->type = type_fn;
-    expr = NodeBinary( CO_CALL_EXEC_IND, func, expr );
+    expr = NodeMakeBinary( CO_CALL_EXEC_IND, func, expr );
     expr->type = type_mp->of;
     expr->flags |= PTF_LVALUE;
     if( FunctionDeclarationType( type_mp->of ) ) {

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -258,13 +258,13 @@ static void generateOffsetFunc( // GENERATE CODE FOR OFFSET FUNCTION
     type_ret = SymFuncReturnType( func );
     ret = SymFunctionReturn();
     if( SymIsThisDataMember( refed ) ) {
-        expr = NodeAddToLeft( NodeThis(), NodeMakeConstantOffset( refed->u.member_offset ), refed->sym_type );
+        expr = NodeAddToLeft( NodeMakeThis(), NodeMakeConstantOffset( refed->u.member_offset ), refed->sym_type );
         expr = NodeFetchReference( expr );
     } else {
         if( SymIsVirtual( refed ) ) {
             VfnReference( refed );
             result = node->u.symcg.result;
-            expr = AccessVirtualFnAddress( NodeThis(), result, refed );
+            expr = AccessVirtualFnAddress( NodeMakeThis(), result, refed );
         } else {
             expr = MakeNodeSymbol( refed );
         }

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -537,10 +537,10 @@ static PTREE storeMembPtrCon(   // STORE MEMBER-PTR CONSTANT
     left = PTreeOpLeft( expr );
     right = PTreeOpRight( expr );
     result = assignMembPtrArg( &left, &right );
-    result = NodeComma( result, assignMembPtrArg( &left, &right ) );
-    result = NodeComma( result, assignMembPtrArg( &left, &right ) );
+    result = NodeMakeComma( result, assignMembPtrArg( &left, &right ) );
+    result = NodeMakeComma( result, assignMembPtrArg( &left, &right ) );
     result = NodeReplace( expr , result );
-    result = NodeComma( result, tgt );
+    result = NodeMakeComma( result, tgt );
     result->flags |= PTF_SIDE_EFF;
     return result;
 }
@@ -1110,7 +1110,7 @@ PTREE MembPtrDereference(       // DO '.*' AND '->*' operations
         ref = &((*ref)->u.subtree[0]);
         right = *ref;
         *ref = NULL;
-        expr->u.subtree[1] = NodeComma( NodePruneTop( expr->u.subtree[1] )
+        expr->u.subtree[1] = NodeMakeComma( NodePruneTop( expr->u.subtree[1] )
                                       , right );
         sym = right->u.symcg.symbol;
         if( expr->cgop == CO_DOT_STAR ) {

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -670,7 +670,7 @@ static CNV_RETN analyseAddrOfNode( // ANALYSE NODE FOR (& item)
             retn = CNV_OK;
         }
     } else if( SymIsFunction( base_item ) ) {
-        if( ADDR_FN_ONE_USED == NodeAddrOfFun( item, &item ) ) {
+        if( ADDR_FN_ONE_USED == NodeGetOverloadedFnAddr( item, &item ) ) {
             item->u.symcg.symbol = ActualNonOverloadedFunc( base_item, item->u.symcg.result );
             retn = CNV_OK;
         } else {
@@ -799,7 +799,7 @@ static bool membPtrAddrOfNode(  // TEST IF (& class::member)
         if( NULL != mbrptr ) {
             return true;
         } else {
-            retn = NodeAddrOfFun( node, &fn );
+            retn = NodeGetOverloadedFnAddr( node, &fn );
             if( (retn != ADDR_FN_NONE )  &&
                 ( (fn->flags & PTF_COLON_QUALED) ||     // S::foo not just foo
                   ( CompFlags.extensions_enabled ) ) ) { // just foo (MFC ext)

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -60,7 +60,7 @@ typedef enum                    // CLASSIFICATION OF MEMBER-PTR EXPRESSIONS
 static PTREE membPtrTemporary(  // PLACE MEMBER PTR IN TEMPORARY
     PTREE expr )                // - member-ptr expression
 {
-    expr = NodeAssign( NodeTemporary( expr->type ), expr );
+    expr = NodeMakeAssignment( NodeTemporary( expr->type ), expr );
     expr->flags |= PTF_MEMORY_EXACT;
     return expr;
 }
@@ -270,7 +270,7 @@ static void generateOffsetFunc( // GENERATE CODE FOR OFFSET FUNCTION
         }
     }
     expr->type = ret->sym_type;
-    expr = NodeAssign( MakeNodeSymbol( ret ), expr );
+    expr = NodeMakeAssignment( MakeNodeSymbol( ret ), expr );
     expr->type = type_ret;
     expr->flags |= PTF_LVALUE;
     IcEmitExpr( NodeDone( expr ) );
@@ -522,7 +522,7 @@ static PTREE assignMembPtrArg(  // ASSIGN A MEMBER-PTR ARGUMENT
     PTREE *a_left,              // - addr[ left operand ]
     PTREE *a_right )            // - addr[ right operand ]
 {
-    return NodeAssign( nextArg( a_left ), NodeGetRValue( nextArg( a_right ) ) );
+    return NodeMakeAssignment( nextArg( a_left ), NodeGetRValue( nextArg( a_right ) ) );
 }
 
 

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -463,7 +463,7 @@ static PTREE makeMembPtrCon(    // MAKE A MEMBER-PTR CONSTANT EXPRESSION
     PTREE deref;                // - expression for dereferencing function
 
     if( func == NULL ) {
-        deref = NodeIntegralConstant( 0, MembPtrDerefFnPtr() );
+        deref = NodeMakeIntegralConstant( 0, MembPtrDerefFnPtr() );
     } else {
         deref = MakeNodeSymbol( func );
     }

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -227,7 +227,7 @@ static PTREE addOffset(         // ADD AN OFFSET TO AN LVALUE
 {
     PTREE expr;                 // - resultant expression
 
-    expr = NodeAddToLeft( field, NodeMakeConstantOffset( offset ), type );
+    expr = NodeMakeLeftAddition( field, NodeMakeConstantOffset( offset ), type );
     expr->flags &= ~ PTF_LVALUE;
     return expr;
 }
@@ -258,7 +258,7 @@ static void generateOffsetFunc( // GENERATE CODE FOR OFFSET FUNCTION
     type_ret = SymFuncReturnType( func );
     ret = SymFunctionReturn();
     if( SymIsThisDataMember( refed ) ) {
-        expr = NodeAddToLeft( NodeMakeThis(), NodeMakeConstantOffset( refed->u.member_offset ), refed->sym_type );
+        expr = NodeMakeLeftAddition( NodeMakeThis(), NodeMakeConstantOffset( refed->u.member_offset ), refed->sym_type );
         expr = NodeFetchReference( expr );
     } else {
         if( SymIsVirtual( refed ) ) {
@@ -1051,11 +1051,11 @@ static PTREE doDereference(     // GENERATE DE-REFERENCING CODE
         temp = accessOp( NodeMakeExprDuplicate( &lhs )
                        , ScopeVBPtrOffset( scope )
                        , MakePointerTo( type_offset ) );
-        expr = NodeAddToLeft( NodeFetch( NodeMakeExprDuplicate( &temp ) )
+        expr = NodeMakeLeftAddition( NodeFetch( NodeMakeExprDuplicate( &temp ) )
                         , NodeMakeExprDuplicate( &index )
                         , type_offset );
         expr->flags |= PTF_LVALUE;
-        expr = NodeAddToLeft( temp, NodeFetch( expr ), type_cp );
+        expr = NodeMakeLeftAddition( temp, NodeFetch( expr ), type_cp );
         expr->flags &= ~ PTF_LVALUE;
         expr = NodeMakeBinary( CO_COLON, expr, lhs );
         expr->type = type_cp;
@@ -1065,7 +1065,7 @@ static PTREE doDereference(     // GENERATE DE-REFERENCING CODE
         expr = lhs;
     }
     NodeFreeDupedExpr( expr_root );
-    expr = NodeAddToLeft( delta, expr, type_cp );
+    expr = NodeMakeLeftAddition( delta, expr, type_cp );
     expr = NodeMakeArg( expr );
     func = NodeUnaryCopy( CO_CALL_SETUP_IND, func );
     func->type = type_fn;

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -213,7 +213,7 @@ static PTREE accessOp(          // ACCESS AN OPERAND
 {
     PTREE expr;                 // - resultant expression
 
-    expr = NodeMakeBinary( CO_DOT, base, NodeOffset( offset ) );
+    expr = NodeMakeBinary( CO_DOT, base, NodeMakeConstantOffset( offset ) );
     expr->type = type;
     expr->flags |= PTF_LVALUE;
     return expr;
@@ -227,7 +227,7 @@ static PTREE addOffset(         // ADD AN OFFSET TO AN LVALUE
 {
     PTREE expr;                 // - resultant expression
 
-    expr = NodeAddToLeft( field, NodeOffset( offset ), type );
+    expr = NodeAddToLeft( field, NodeMakeConstantOffset( offset ), type );
     expr->flags &= ~ PTF_LVALUE;
     return expr;
 }
@@ -258,7 +258,7 @@ static void generateOffsetFunc( // GENERATE CODE FOR OFFSET FUNCTION
     type_ret = SymFuncReturnType( func );
     ret = SymFunctionReturn();
     if( SymIsThisDataMember( refed ) ) {
-        expr = NodeAddToLeft( NodeThis(), NodeOffset( refed->u.member_offset ), refed->sym_type );
+        expr = NodeAddToLeft( NodeThis(), NodeMakeConstantOffset( refed->u.member_offset ), refed->sym_type );
         expr = NodeFetchReference( expr );
     } else {
         if( SymIsVirtual( refed ) ) {
@@ -375,12 +375,12 @@ static PTREE computeNewIndex(   // COMPUTE NEW INDEX
     if( inf->mapping_reqd ) {
         type = TypeTargetSizeT();
         if( inf->mapping == NULL ) {
-            off_node = NodeOffset( inf->vb_index * TARGET_UINT );
+            off_node = NodeMakeConstantOffset( inf->vb_index * TARGET_UINT );
             off_node->type = type;
             if( inf->single_mapping ) {
                 node = NodeMakeBinary( (inf->vb_index == 0 ) ? CO_GT : CO_EQ
                                  , NodeDupExpr( &new_index )
-                                 , NodeOffset( inf->single_test * TARGET_UINT ) );
+                                 , NodeMakeConstantOffset( inf->single_test * TARGET_UINT ) );
                 node = NodeSetBooleanType( node );
                 node = FoldBinary( node );
                 new_index = NodeMakeBinary( CO_COLON, off_node, new_index );
@@ -469,8 +469,8 @@ static PTREE makeMembPtrCon(    // MAKE A MEMBER-PTR CONSTANT EXPRESSION
     }
     return makeMembPtrExpr( type
                           , deref
-                          , NodeOffset( delta )
-                          , NodeOffset( index ) );
+                          , NodeMakeConstantOffset( delta )
+                          , NodeMakeConstantOffset( index ) );
 }
 
 PTREE MembPtrZero(              // MAKE A NULL MEMBER POINTER CONSTANT

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -352,7 +352,7 @@ static PTREE computeNewDelta(   // COMPUTE NEW DELTA
             node = NodeMakeBinary( CO_COLON, new_delta, node );
             node->type = type;
             node = NodeMakeBinary( CO_QUESTION
-                             , NodeCompareToZero( NodeDupExpr( new_index ) )
+                             , NodeMakeZeroCompare( NodeDupExpr( new_index ) )
                              , node );
             node->type = type;
         } else {
@@ -1059,7 +1059,7 @@ static PTREE doDereference(     // GENERATE DE-REFERENCING CODE
         expr->flags &= ~ PTF_LVALUE;
         expr = NodeMakeBinary( CO_COLON, expr, lhs );
         expr->type = type_cp;
-        expr = NodeMakeBinary( CO_QUESTION, NodeCompareToZero( index ), expr );
+        expr = NodeMakeBinary( CO_QUESTION, NodeMakeZeroCompare( index ), expr );
         expr->type = type_cp;
     } else {
         expr = lhs;

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -447,7 +447,7 @@ static PTREE makeMembPtrExpr(   // MAKE A MEMBER-PTR EXPRESSION
 {
     PTREE expr;                 // - resultant expression
 
-    expr = NodeUnary( CO_MEMPTR_CONST
+    expr = NodeMakeUnary( CO_MEMPTR_CONST
                     , NodeArguments( index, delta, func, NULL ) );
     expr->type = type;
     return expr;

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -73,7 +73,7 @@ static PTREE membPtrStoreTemp(  // STORE MEMBER PTR EXPR IN TEMPORARY
 
     a_expr = membPtrTemporary( expr );
     MembPtrAssign( &a_expr );
-    return NodeRvalue( a_expr );
+    return NodeGetRValue( a_expr );
 }
 
 
@@ -419,8 +419,8 @@ static PTREE computeDeltaIndex( // COMPUTE NEW DELTA, INDEX
     original = expr;
     expr = PTreeOpLeft( original );
     expr = expr->u.subtree[0];
-    new_delta = NodeRvalue( expr->u.subtree[1] );
-    new_index = NodeRvalue( expr->u.subtree[0]->u.subtree[1] );
+    new_delta = NodeGetRValue( expr->u.subtree[1] );
+    new_index = NodeGetRValue( expr->u.subtree[0]->u.subtree[1] );
     if( inf->safe ) {
         new_delta = computeNewDelta( new_delta, &new_index, inf );
         new_index = computeNewIndex( new_index, inf );
@@ -522,7 +522,7 @@ static PTREE assignMembPtrArg(  // ASSIGN A MEMBER-PTR ARGUMENT
     PTREE *a_left,              // - addr[ left operand ]
     PTREE *a_right )            // - addr[ right operand ]
 {
-    return NodeAssign( nextArg( a_left ), NodeRvalue( nextArg( a_right ) ) );
+    return NodeAssign( nextArg( a_left ), NodeGetRValue( nextArg( a_right ) ) );
 }
 
 
@@ -1038,15 +1038,15 @@ static PTREE doDereference(     // GENERATE DE-REFERENCING CODE
     *r_rhs = NULL;
     expr = expr_root;
     expr = expr->u.subtree[0];
-    func = NodeRvalue( expr->u.subtree[1] );
+    func = NodeGetRValue( expr->u.subtree[1] );
     expr->u.subtree[1] = NULL;
     expr = expr->u.subtree[0];
-    delta = NodeRvalue( expr->u.subtree[1] );
+    delta = NodeGetRValue( expr->u.subtree[1] );
     expr->u.subtree[1] = NULL;
     type_offset = delta->type;
     if( ScopeHasVirtualBases( scope ) ) {
         expr = expr->u.subtree[0];
-        index = NodeRvalue( expr->u.subtree[1] );
+        index = NodeGetRValue( expr->u.subtree[1] );
         expr->u.subtree[1] = NULL;
         temp = accessOp( NodeDupExpr( &lhs )
                        , ScopeVBPtrOffset( scope )
@@ -1437,9 +1437,9 @@ static PTREE doCompare(         // DO A COMPARISON
                              );
     } else {
         expr->u.subtree[0] = NodeReplace( expr->u.subtree[0]
-                                        , NodeRvalue( left ) );
+                                        , NodeGetRValue( left ) );
         expr->u.subtree[1] = NodeReplace( expr->u.subtree[1]
-                                        , NodeRvalue( right ) );
+                                        , NodeGetRValue( right ) );
     }
     return expr;
 }
@@ -1647,7 +1647,7 @@ PTREE MembPtrFuncArg(           // EXPRESSION FOR FUNCTION ARGUMENT
 //      arg = NodeReplace( arg, MakeNodeSymbol( sym ) );
         arg = NodeReplace( arg, NodeMakeCallee( sym ) );
     }
-    return NodeRvalue( arg );
+    return NodeGetRValue( arg );
 }
 
 

--- a/bld/plusplus/c/opovload.c
+++ b/bld/plusplus/c/opovload.c
@@ -534,7 +534,7 @@ static PTREE transform_naked(   // TRANSFORM TO CALL TO NON-MEMBER FUNCTION
         }
     } else if( cgop == CO_POST_PLUS_PLUS
             || cgop == CO_POST_MINUS_MINUS ) {
-        param = NodeMakeArgument( param, NodeZero() );
+        param = NodeMakeArgument( param, NodeMakeZeroConstant() );
     }
     result = NULL;
     if( olinf->result_nonmem != NULL ) {
@@ -600,7 +600,7 @@ static PTREE transform_member(  // TRANSFORM TO CALL TO MEMBER FUNCTION
         } else {
             if( ( cgop == CO_POST_PLUS_PLUS   )
               ||( cgop == CO_POST_MINUS_MINUS ) ) {
-                param = NodeMakeArg( NodeZero() );
+                param = NodeMakeArg( NodeMakeZeroConstant() );
             } else {
                 param = NULL;
             }
@@ -664,7 +664,7 @@ static PTREE resolve_symbols(   // RESOLVE MULTIPLE OVERLOAD DEFINITIONS
             count = 2;
         }
     } else if( olinf->mask & OPM_POST ) {
-        zero_node = NodeZero();
+        zero_node = NodeMakeZeroConstant();
         setupOVOP( olinf, zero_node, &olinf->right );
         ptlist[1] = olinf->right.operand;
         alist.base.type_list[ 1 ] = olinf->right.node_type;

--- a/bld/plusplus/c/opovload.c
+++ b/bld/plusplus/c/opovload.c
@@ -579,7 +579,7 @@ static PTREE transform_member(  // TRANSFORM TO CALL TO MEMBER FUNCTION
             PTreeErrorExprSym( op, ERR_OPERATOR_ARROW_RETURN_BAD, op_sym );
             return op;
         }
-        caller = NodeDottedFunction( olinf->left.operand
+        caller = NodeMakeDottedFunction( olinf->left.operand
                                    , build_fun_name( olinf->result_mem ) );
         caller = PTreeCopySrcLocation( caller, op );
         caller = NodeMakeBinary( CO_CALL, caller, NULL );
@@ -605,7 +605,7 @@ static PTREE transform_member(  // TRANSFORM TO CALL TO MEMBER FUNCTION
                 param = NULL;
             }
         }
-        caller = NodeDottedFunction( olinf->left.operand
+        caller = NodeMakeDottedFunction( olinf->left.operand
                                    , build_fun_name( olinf->result_mem ) );
         caller = PTreeCopySrcLocation( caller, op );
         op = transform_to_call( op, caller, param );
@@ -637,7 +637,7 @@ static PTREE resolve_symbols(   // RESOLVE MULTIPLE OVERLOAD DEFINITIONS
         oper = PTreeIdSym( fun );
         oper = NodeSymbolNoRef( oper, fun, olinf->result_mem );
         oper->cgop = CO_NAME_DOT;
-        olinf->expr->u.subtree[0] = NodeDottedFunction( olinf->left.operand
+        olinf->expr->u.subtree[0] = NodeMakeDottedFunction( olinf->left.operand
                                                       , oper );
 
         ScopeFreeResult( olinf->result_nonmem );

--- a/bld/plusplus/c/opovload.c
+++ b/bld/plusplus/c/opovload.c
@@ -926,7 +926,7 @@ static bool isBadFun(           // DIAGNOSE IF MEMBER FUNC. OR OVERLOADED
     PTREE node;                 // - node to be examined
 
     node = PTreeOp( &operand );
-    switch( NodeAddrOfFun( node, &fnode ) ) {
+    switch( NodeGetOverloadedFnAddr( node, &fnode ) ) {
       default :
         retb = false;
         break;

--- a/bld/plusplus/c/opovload.c
+++ b/bld/plusplus/c/opovload.c
@@ -582,7 +582,7 @@ static PTREE transform_member(  // TRANSFORM TO CALL TO MEMBER FUNCTION
         caller = NodeDottedFunction( olinf->left.operand
                                    , build_fun_name( olinf->result_mem ) );
         caller = PTreeCopySrcLocation( caller, op );
-        caller = NodeBinary( CO_CALL, caller, NULL );
+        caller = NodeMakeBinary( CO_CALL, caller, NULL );
         caller = PTreeCopySrcLocation( caller, op );
         caller = AnalyseCall( caller, NULL );
         op->u.subtree[0] = caller;

--- a/bld/plusplus/c/opovload.c
+++ b/bld/plusplus/c/opovload.c
@@ -521,7 +521,7 @@ static PTREE transform_naked(   // TRANSFORM TO CALL TO NON-MEMBER FUNCTION
     SEARCH_RESULT *result;
 
     cgop = olinf->expr->cgop;
-    param = NodeArg( olinf->left.operand );
+    param = NodeMakeArg( olinf->left.operand );
     if( olinf->flags & PTO_BINARY ) {
         if( cgop == CO_CALL ) {
             param->u.subtree[0] = olinf->right.operand;
@@ -595,12 +595,12 @@ static PTREE transform_member(  // TRANSFORM TO CALL TO MEMBER FUNCTION
         if( olinf->flags & PTO_BINARY ) {
             param = olinf->right.operand;
             if( cgop != CO_CALL ) {
-                param = NodeArg( param );
+                param = NodeMakeArg( param );
             }
         } else {
             if( ( cgop == CO_POST_PLUS_PLUS   )
               ||( cgop == CO_POST_MINUS_MINUS ) ) {
-                param = NodeArg( NodeZero() );
+                param = NodeMakeArg( NodeZero() );
             } else {
                 param = NULL;
             }

--- a/bld/plusplus/c/opovload.c
+++ b/bld/plusplus/c/opovload.c
@@ -527,14 +527,14 @@ static PTREE transform_naked(   // TRANSFORM TO CALL TO NON-MEMBER FUNCTION
             param->u.subtree[0] = olinf->right.operand;
         } else {
             if( olinf->right.operand != NULL ) {
-                param = NodeArgument( param, olinf->right.operand );
+                param = NodeMakeArgument( param, olinf->right.operand );
             } else {
                 PTreeErrorNode( param );
             }
         }
     } else if( cgop == CO_POST_PLUS_PLUS
             || cgop == CO_POST_MINUS_MINUS ) {
-        param = NodeArgument( param, NodeZero() );
+        param = NodeMakeArgument( param, NodeZero() );
     }
     result = NULL;
     if( olinf->result_nonmem != NULL ) {

--- a/bld/plusplus/c/ptree.c
+++ b/bld/plusplus/c/ptree.c
@@ -1692,7 +1692,7 @@ PTREE PTreeIntrinsicOperator( PTREE expr, CGOP cgop )
     arg1->u.subtree[1] = NULL;
     flags = oper_flags[ cgop ];
     if( flags & PTO_UNARY ) {
-        expr = NodeUnary( cgop, op1 );
+        expr = NodeMakeUnary( cgop, op1 );
     } else {
         arg2 = arg1->u.subtree[0];
         op2 = arg2->u.subtree[1];

--- a/bld/plusplus/c/ptree.c
+++ b/bld/plusplus/c/ptree.c
@@ -1697,7 +1697,7 @@ PTREE PTreeIntrinsicOperator( PTREE expr, CGOP cgop )
         arg2 = arg1->u.subtree[0];
         op2 = arg2->u.subtree[1];
         arg2->u.subtree[1] = NULL;
-        expr = NodeBinary( cgop, op1, op2 );
+        expr = NodeMakeBinary( cgop, op1, op2 );
     }
     expr->type = expr_type;
     PTreeFreeSubtrees( old_expr );

--- a/bld/plusplus/c/scope.c
+++ b/bld/plusplus/c/scope.c
@@ -5759,7 +5759,7 @@ static void emitOffset( target_offset_t offset )
 {
     PTREE expr;
 
-    expr = NodeOffset( offset );
+    expr = NodeMakeConstantOffset( offset );
     DgStoreScalar( expr, 0, expr->type );
     PTreeFreeSubtrees( expr );
 }

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -205,7 +205,7 @@ static PTREE thunkArgList(      // BUILD THUNK ARGUMENT LIST
             expr = NodeFetchReference( expr );
             arg_model = ObjModelArgument( TypeReferenced( arg_type ) );
             if( TypeReference( arg_type ) == NULL && arg_model != OMR_CLASS_REF ) {
-                expr = NodeRvalue( expr );
+                expr = NodeGetRValue( expr );
             }
             list = NodeArgument( list, expr );
         }
@@ -433,7 +433,7 @@ void EmitVfunThunk(             // EMIT THUNK FOR VIRTUAL FUNCTION
     override_class = ScopeClass( SymScope( override_sym ) );
     args = thunkArgList( fn_scope );
     /* make "this" arg */
-    this_arg = NodeRvalue( NodeThis() );
+    this_arg = NodeGetRValue( NodeThis() );
     this_arg = NodeMakeConversion( MakePointerTo( override_class ), this_arg );
     this_arg = NodeArg( this_arg );
     return_type = SymFuncReturnType( override_sym );

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -293,7 +293,7 @@ void RtnGenCallBackGenThunk(    // GENERATE THUNK CODE
             extra_arg = NULL;
         }
         if( SymIsThisMember( orig_sym ) ) {
-            this_arg = NodeArg( NodeThis() );
+            this_arg = NodeMakeArg( NodeThis() );
         } else {
             this_arg = NULL;
         }
@@ -435,7 +435,7 @@ void EmitVfunThunk(             // EMIT THUNK FOR VIRTUAL FUNCTION
     /* make "this" arg */
     this_arg = NodeGetRValue( NodeThis() );
     this_arg = NodeMakeConversion( MakePointerTo( override_class ), this_arg );
-    this_arg = NodeArg( this_arg );
+    this_arg = NodeMakeArg( this_arg );
     return_type = SymFuncReturnType( override_sym );
     return_node = NULL;
     if( OMR_CLASS_REF == ObjModelArgument( return_type ) ) {

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -349,7 +349,7 @@ static PTREE applyReturnThunk(  // GENERATE A RETURN THUNK
         /* only need NULL checks for pointer casts */
         if( ptr_type->id == TYP_POINTER ) {
             if( (ptr_type->flag & TF1_REFERENCE) == 0 ) {
-                dup1 = NodeDupExpr( &expr );
+                dup1 = NodeMakeExprDuplicate( &expr );
             }
         }
     }
@@ -363,7 +363,7 @@ static PTREE applyReturnThunk(  // GENERATE A RETURN THUNK
         expr = NodeAddToLeft( expr, NodeMakeConstantOffset( delta ), ret_type );
     }
     if( dup1 != NULL ) {
-        dup2 = NodeDupExpr( &dup1 );
+        dup2 = NodeMakeExprDuplicate( &dup1 );
         dup1 = NodeMakeZeroCompare( dup1 );
         expr = NodeTestExpr( dup1, expr, dup2 );
     }

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -434,7 +434,7 @@ void EmitVfunThunk(             // EMIT THUNK FOR VIRTUAL FUNCTION
     args = thunkArgList( fn_scope );
     /* make "this" arg */
     this_arg = NodeRvalue( NodeThis() );
-    this_arg = NodeConvert( MakePointerTo( override_class ), this_arg );
+    this_arg = NodeMakeConversion( MakePointerTo( override_class ), this_arg );
     this_arg = NodeArg( this_arg );
     return_type = SymFuncReturnType( override_sym );
     return_node = NULL;

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -360,7 +360,7 @@ static PTREE applyReturnThunk(  // GENERATE A RETURN THUNK
         expr = NodeConvertVirtualPtr( expr, ret_type, vb_offset, vb_index );
     }
     if( delta != 0 ) {
-        expr = NodeAddToLeft( expr, NodeOffset( delta ), ret_type );
+        expr = NodeAddToLeft( expr, NodeMakeConstantOffset( delta ), ret_type );
     }
     if( dup1 != NULL ) {
         dup2 = NodeDupExpr( &dup1 );

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -207,7 +207,7 @@ static PTREE thunkArgList(      // BUILD THUNK ARGUMENT LIST
             if( TypeReference( arg_type ) == NULL && arg_model != OMR_CLASS_REF ) {
                 expr = NodeGetRValue( expr );
             }
-            list = NodeArgument( list, expr );
+            list = NodeMakeArgument( list, expr );
         }
     }
     list = NodeReverseArgs( &count, list );

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -439,7 +439,7 @@ void EmitVfunThunk(             // EMIT THUNK FOR VIRTUAL FUNCTION
     return_type = SymFuncReturnType( override_sym );
     return_node = NULL;
     if( OMR_CLASS_REF == ObjModelArgument( return_type ) ) {
-        return_node = NodeTemporary( return_type );
+        return_node = NodeMakeTemporary( return_type );
     }
     stmt = NodeMakeCall( override_sym, return_type, args );
     stmt = CallArgsArrange( override_sym->sym_type, stmt, args, this_arg, NULL, return_node );

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -444,7 +444,7 @@ void EmitVfunThunk(             // EMIT THUNK FOR VIRTUAL FUNCTION
     stmt = NodeMakeCall( override_sym, return_type, args );
     stmt = CallArgsArrange( override_sym->sym_type, stmt, args, this_arg, NULL, return_node );
     if( return_node != NULL ) {
-        stmt = NodeDtorExpr( stmt, return_node->u.symcg.symbol );
+        stmt = NodeMarkDtorExpr( stmt, return_node->u.symcg.symbol );
         stmt = PtdCtoredExprType( stmt, override_sym, return_type );
     }
     return_sym = SymFunctionReturn();

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -360,7 +360,7 @@ static PTREE applyReturnThunk(  // GENERATE A RETURN THUNK
         expr = NodeConvertVirtualPtr( expr, ret_type, vb_offset, vb_index );
     }
     if( delta != 0 ) {
-        expr = NodeAddToLeft( expr, NodeMakeConstantOffset( delta ), ret_type );
+        expr = NodeMakeLeftAddition( expr, NodeMakeConstantOffset( delta ), ret_type );
     }
     if( dup1 != NULL ) {
         dup2 = NodeMakeExprDuplicate( &dup1 );

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -365,7 +365,7 @@ static PTREE applyReturnThunk(  // GENERATE A RETURN THUNK
     if( dup1 != NULL ) {
         dup2 = NodeMakeExprDuplicate( &dup1 );
         dup1 = NodeMakeZeroCompare( dup1 );
-        expr = NodeTestExpr( dup1, expr, dup2 );
+        expr = NodeMakeTernaryExpr( dup1, expr, dup2 );
     }
     return( expr );
 }

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -364,7 +364,7 @@ static PTREE applyReturnThunk(  // GENERATE A RETURN THUNK
     }
     if( dup1 != NULL ) {
         dup2 = NodeDupExpr( &dup1 );
-        dup1 = NodeCompareToZero( dup1 );
+        dup1 = NodeMakeZeroCompare( dup1 );
         expr = NodeTestExpr( dup1, expr, dup2 );
     }
     return( expr );

--- a/bld/plusplus/c/thunk.c
+++ b/bld/plusplus/c/thunk.c
@@ -293,7 +293,7 @@ void RtnGenCallBackGenThunk(    // GENERATE THUNK CODE
             extra_arg = NULL;
         }
         if( SymIsThisMember( orig_sym ) ) {
-            this_arg = NodeMakeArg( NodeThis() );
+            this_arg = NodeMakeArg( NodeMakeThis() );
         } else {
             this_arg = NULL;
         }
@@ -433,7 +433,7 @@ void EmitVfunThunk(             // EMIT THUNK FOR VIRTUAL FUNCTION
     override_class = ScopeClass( SymScope( override_sym ) );
     args = thunkArgList( fn_scope );
     /* make "this" arg */
-    this_arg = NodeGetRValue( NodeThis() );
+    this_arg = NodeGetRValue( NodeMakeThis() );
     this_arg = NodeMakeConversion( MakePointerTo( override_class ), this_arg );
     this_arg = NodeMakeArg( this_arg );
     return_type = SymFuncReturnType( override_sym );

--- a/bld/plusplus/c/vfun.c
+++ b/bld/plusplus/c/vfun.c
@@ -269,7 +269,7 @@ void VfnReference(              // EMIT VIRTUAL FUNCTION REFERENCE
     fake = NodeMakeBinary( CO_CALL_EXEC_IND, fake, NULL );
     fake->type = SymFuncReturnType( vfun );
     fake->flags |= PTF_MEANINGFUL | PTF_SIDE_EFF;
-    fake = NodeDone( fake );
+    fake = NodeMakeDone( fake );
     IcEmitExpr( fake );
     CgFrontLabdefCs( around );
     CgFrontLabfreeCs( 1 );

--- a/bld/plusplus/c/vfun.c
+++ b/bld/plusplus/c/vfun.c
@@ -158,14 +158,14 @@ static PTREE genVfunCall(       // DIRECTLY GENERATE VFUN CALL
     TYPE vfptr_type;            // - type[ ptr to VF table ]
     TYPE vfn_type;              // - type[ ptr to VF ]
 
-    node = NodeBinary( CO_DOT, node, NodeOffset( vf_offset ) );
+    node = NodeMakeBinary( CO_DOT, node, NodeOffset( vf_offset ) );
     vfptr_type = MakeVFTableFieldType( true );
     node->type = vfptr_type;
     node->flags |= PTF_LVALUE;
     node = PtdExprConst( node );
     node = NodeRvalue( node );
     vfn_type = TypePointedAtModified( vfptr_type );
-    node = NodeBinary( CO_DOT, node, NodeOffset( vf_index * CgMemorySize( vfn_type ) ) );
+    node = NodeMakeBinary( CO_DOT, node, NodeOffset( vf_index * CgMemorySize( vfn_type ) ) );
     node->type = vfn_type;
     node->flags |= PTF_LVALUE;
     node = NodeRvalue( node );
@@ -241,7 +241,7 @@ PTREE VfnDecorateCall(          // DECORATE VIRTUAL CALL
     vfun = SymDefaultBase( vfun );
     sym = NodeMakeCallee( vfun );
     sym->cgop = CO_IGNORE;
-    sym = NodeBinary( CO_VIRT_FUNC, expr, sym );
+    sym = NodeMakeBinary( CO_VIRT_FUNC, expr, sym );
     sym->flags = expr->flags;
     sym->type = expr->type;
     return sym;
@@ -266,7 +266,7 @@ void VfnReference(              // EMIT VIRTUAL FUNCTION REFERENCE
     fake = NodeRvalue( fake );
     fake = NodeUnaryCopy( CO_CALL_SETUP_IND, fake );
     fake = VfnDecorateCall( fake, vfun );
-    fake = NodeBinary( CO_CALL_EXEC_IND, fake, NULL );
+    fake = NodeMakeBinary( CO_CALL_EXEC_IND, fake, NULL );
     fake->type = SymFuncReturnType( vfun );
     fake->flags |= PTF_MEANINGFUL | PTF_SIDE_EFF;
     fake = NodeDone( fake );

--- a/bld/plusplus/c/vfun.c
+++ b/bld/plusplus/c/vfun.c
@@ -193,7 +193,7 @@ static PTREE genVfunIcs(        // GENERATE IC'S FOR CG-GENERATION OF VFUN CALL
 
     expr = NodeMakeCallee( vfun );
     expr->cgop = CO_IGNORE;
-    expr = NodeUnary( CO_CALL_SETUP_VFUN, expr );
+    expr = NodeMakeUnary( CO_CALL_SETUP_VFUN, expr );
     expr->type = vfun->sym_type;
     expr->flags = node->flags;
     expr = PtdVfunAccess( expr, vf_index, vf_offset, baser );

--- a/bld/plusplus/c/vfun.c
+++ b/bld/plusplus/c/vfun.c
@@ -261,7 +261,7 @@ void VfnReference(              // EMIT VIRTUAL FUNCTION REFERENCE
 
     around = CgFrontLabelCs();
     CgFrontGotoNear( IC_LABEL_CS, O_GOTO, around );
-    fake = NodeAssignTemporary( MakePointerTo( vfun->sym_type )
+    fake = NodeMakeAssignToNewTmp( MakePointerTo( vfun->sym_type )
                               , NodeMakeCallee( vfun ) );
     fake = NodeGetRValue( fake );
     fake = NodeUnaryCopy( CO_CALL_SETUP_IND, fake );

--- a/bld/plusplus/c/vfun.c
+++ b/bld/plusplus/c/vfun.c
@@ -198,7 +198,7 @@ static PTREE genVfunIcs(        // GENERATE IC'S FOR CG-GENERATION OF VFUN CALL
     expr->flags = node->flags;
     expr = PtdVfunAccess( expr, vf_index, vf_offset, baser );
     node = NodeUnaryCopy( CO_VFUN_PTR, node );
-    return NodeComma( node, expr );
+    return NodeMakeComma( node, expr );
 }
 
 

--- a/bld/plusplus/c/vfun.c
+++ b/bld/plusplus/c/vfun.c
@@ -163,12 +163,12 @@ static PTREE genVfunCall(       // DIRECTLY GENERATE VFUN CALL
     node->type = vfptr_type;
     node->flags |= PTF_LVALUE;
     node = PtdExprConst( node );
-    node = NodeRvalue( node );
+    node = NodeGetRValue( node );
     vfn_type = TypePointedAtModified( vfptr_type );
     node = NodeMakeBinary( CO_DOT, node, NodeOffset( vf_index * CgMemorySize( vfn_type ) ) );
     node->type = vfn_type;
     node->flags |= PTF_LVALUE;
-    node = NodeRvalue( node );
+    node = NodeGetRValue( node );
     node->type = sym->sym_type;
     return node;
 }
@@ -263,7 +263,7 @@ void VfnReference(              // EMIT VIRTUAL FUNCTION REFERENCE
     CgFrontGotoNear( IC_LABEL_CS, O_GOTO, around );
     fake = NodeAssignTemporary( MakePointerTo( vfun->sym_type )
                               , NodeMakeCallee( vfun ) );
-    fake = NodeRvalue( fake );
+    fake = NodeGetRValue( fake );
     fake = NodeUnaryCopy( CO_CALL_SETUP_IND, fake );
     fake = VfnDecorateCall( fake, vfun );
     fake = NodeMakeBinary( CO_CALL_EXEC_IND, fake, NULL );

--- a/bld/plusplus/c/vfun.c
+++ b/bld/plusplus/c/vfun.c
@@ -158,14 +158,14 @@ static PTREE genVfunCall(       // DIRECTLY GENERATE VFUN CALL
     TYPE vfptr_type;            // - type[ ptr to VF table ]
     TYPE vfn_type;              // - type[ ptr to VF ]
 
-    node = NodeMakeBinary( CO_DOT, node, NodeOffset( vf_offset ) );
+    node = NodeMakeBinary( CO_DOT, node, NodeMakeConstantOffset( vf_offset ) );
     vfptr_type = MakeVFTableFieldType( true );
     node->type = vfptr_type;
     node->flags |= PTF_LVALUE;
     node = PtdExprConst( node );
     node = NodeGetRValue( node );
     vfn_type = TypePointedAtModified( vfptr_type );
-    node = NodeMakeBinary( CO_DOT, node, NodeOffset( vf_index * CgMemorySize( vfn_type ) ) );
+    node = NodeMakeBinary( CO_DOT, node, NodeMakeConstantOffset( vf_index * CgMemorySize( vfn_type ) ) );
     node->type = vfn_type;
     node->flags |= PTF_LVALUE;
     node = NodeGetRValue( node );

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1280,7 +1280,7 @@ PTREE NodeThisCopyLocation(     // MAKE A RVALUE "THIS" NODE WITH LOCATION
 TYPE NodeType(                  // GET TYPE FOR A NODE
     PTREE node )                // - the node
 ;
-PTREE NodeUnary(                // MAKE A UNARY NODE
+PTREE NodeMakeUnary(                // MAKE A UNARY NODE
     CGOP op,                    // - operator
     PTREE expr )                // - operand
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -903,7 +903,7 @@ PTREE NodeMakeAssignment(               // CREATE ASSIGNMENT NODE
     PTREE tgt,                  // - target
     PTREE src )                 // - source
 ;
-PTREE NodeAssignRef(            // CREATE ASSIGNMENT NODE FOR REFERENCE
+PTREE NodeMakeRefAssignment(            // CREATE ASSIGNMENT NODE FOR REFERENCE
     PTREE tgt,                  // - target
     PTREE src )                 // - source
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -958,7 +958,7 @@ CNV_RETN NodeCheckPtrTrunc(     // CHECK FOR POINTER TRUNCATION WARNING
     TYPE tgt,                   // - target type
     TYPE src )                  // - source type
 ;
-PTREE NodeComma(                // MAKE A COMMA PTREE NODE
+PTREE NodeMakeComma(                // MAKE A COMMA PTREE NODE
     PTREE left,                 // - left operand
     PTREE right )               // - right operand
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -899,7 +899,7 @@ PTREE NodeMakeArgList(            // MAKE A LIST OF ARGUMENTS
     PTREE arg,                  // - first arg
     ... )                       // - NULL terminated, in reverse order
 ;
-PTREE NodeAssign(               // CREATE ASSIGNMENT NODE
+PTREE NodeMakeAssignment(               // CREATE ASSIGNMENT NODE
     PTREE tgt,                  // - target
     PTREE src )                 // - source
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1188,7 +1188,7 @@ PTREE NodePruneRight(            // PRUNE RIGHT OPERAND
 PTREE NodePruneTop(             // PRUNE TOP OPERAND
     PTREE expr )                // - expression
 ;
-bool NodePtrNonZero(            // TEST IF A PTR NODE IS ALWAYS NON-ZERO
+bool NodeIsNonNullPtr(            // TEST IF A PTR NODE IS ALWAYS NON-ZERO
     PTREE node )                // - node to be tested
 ;
 bool NodeReferencesTemporary(   // CHECK IF NODE PRODUCES OR IS TEMPORARY

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -962,7 +962,7 @@ PTREE NodeMakeComma(                // MAKE A COMMA PTREE NODE
     PTREE left,                 // - left operand
     PTREE right )               // - right operand
 ;
-PTREE NodeCommaIfSideEffect(    // MAKE A COMMA PTREE NODE (IF LHS HAS side-effects)
+PTREE NodeMakeCommaIfLHSSideEffect(    // MAKE A COMMA PTREE NODE (IF LHS HAS side-effects)
     PTREE left,                 // - left operand
     PTREE right )               // - right operand
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1274,7 +1274,7 @@ PTREE NodeTemporary(            // CREATE TEMPORARY AND NODE FOR IT
 PTREE NodeMakeThis(                 // MAKE A RVALUE "THIS" NODE
     void )
 ;
-PTREE NodeThisCopyLocation(     // MAKE A RVALUE "THIS" NODE WITH LOCATION
+PTREE NodeMakeRVThisAtLoc(     // MAKE A RVALUE "THIS" NODE WITH LOCATION
     PTREE use_locn )            // - node to grab locn from
 ;
 TYPE NodeType(                  // GET TYPE FOR A NODE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -911,7 +911,7 @@ PTREE NodeAssignTemporary(      // ASSIGN NODE TO A TEMPORARY
     TYPE type,                  // - type of temporary
     PTREE expr )                // - the expression to be assigned to temp
 ;
-PTREE NodeAssignTemporaryNode(  // ASSIGN NODE TO A TEMPORARY NODE
+PTREE NodeMakeAssignToTmp(  // ASSIGN NODE TO A TEMPORARY NODE
     TYPE type,                  // - type of temporary
     PTREE expr,                 // - the expression to be assigned to temp
     PTREE temp_node )           // - node for temporary symbol

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1041,7 +1041,7 @@ PTREE NodeDtorExpr(             // MARK FOR DTOR'ING AFTER EXPRESSION
     PTREE expr,                 // - expression computing symbol
     SYMBOL sym )                // - SYMBOL being computed
 ;
-PTREE NodeDupExpr(              // DUPLICATE EXPRESSION
+PTREE NodeMakeExprDuplicate(              // DUPLICATE EXPRESSION
     PTREE *expr )               // - addr( expression )
 ;
 PTREE NodeFetch(                // FETCH A VALUE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1208,7 +1208,7 @@ PTREE NodeReplaceTop(           // REPLACE TOP EXPRESSION WITH ANOTHER
     PTREE old,                  // - expression to be replaced
     PTREE replace )             // - replacement expression
 ;
-PTREE* NodeReturnSrc(           // GET ADDR OF SOURCE OPERAND RETURNED
+PTREE* NodeGetReturnSrc(           // GET ADDR OF SOURCE OPERAND RETURNED
     PTREE* src,                 // - addr[ operand ]
     PTREE* dtor )               // - addr[ CO_DTOR operand ]
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1222,7 +1222,7 @@ PTREE NodeReverseArgs(          // REVERSE CALL ARGUMENTS
 PTREE NodeGetRValue(               // GET RVALUE, IF LVALUE
     PTREE curr )                // - node to be transformed
 ;
-PTREE NodeRvalueExact(          // SET RVALUE (EXACT)
+PTREE NodeSetRValueExact(          // SET RVALUE (EXACT)
     PTREE node )                // - current node
 ;
 PTREE NodeRvalueExactLeft(      // SET RVALUE (EXACT) ON LEFT

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1065,7 +1065,7 @@ void NodeFreeSearchResult(      // FREE SEARCH_RESULT FROM A NODE
 PTREE NodeMakeFromConstSym(         // BUILD CONSTANT NODE FROM CONSTANT SYMBOL
     SYMBOL con )                // - constant symbol
 ;
-PTREE NodeFuncForCall(          // GET FUNCTION NODE FOR CALL
+PTREE NodeGetFnForCall(          // GET FUNCTION NODE FOR CALL
     PTREE call_node )           // - a call node
 ;
 PTREE NodeGetCallExpr(          // POINT AT CALL EXPRESSION

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1191,7 +1191,7 @@ PTREE NodePruneTop(             // PRUNE TOP OPERAND
 bool NodeIsNonNullPtr(            // TEST IF A PTR NODE IS ALWAYS NON-ZERO
     PTREE node )                // - node to be tested
 ;
-bool NodeReferencesTemporary(   // CHECK IF NODE PRODUCES OR IS TEMPORARY
+bool NodeYieldsTemporary(   // CHECK IF NODE PRODUCES OR IS TEMPORARY
     PTREE node )                // - possible temporary
 ;
 PTREE NodeRemoveCasts(          // REMOVE CASTING FROM NODE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1053,7 +1053,7 @@ PTREE NodeFetchClassExact(      // FETCH AS "CLASS_EXACT"
 PTREE NodeFetchReference(       // FETCH A REFERENCE, IF REQ'D
     PTREE expr )                // - expression
 ;
-PTREE NodeForceLvalue           // FORCE EXPRESSION TO BE LVALUE
+PTREE NodeForceLValue           // FORCE EXPRESSION TO BE LVALUE
     ( PTREE expr )              // - expression
 ;
 void NodeFreeDupedExpr(         // FREE AN EXPRESSION WITH DUPLICATES

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -890,7 +890,7 @@ PTREE NodeMakeArgument(             // MAKE AN ARGUMENT NODE
     PTREE left,                 // - left subtree
     PTREE right )               // - right subtree
 ;
-PTREE NodeArgumentExactCtor(    // ADD EXACT CTOR ARG., IF REQUIRED
+PTREE NodeMakeArgCtor(    // ADD EXACT CTOR ARG., IF REQUIRED
     PTREE args,                 // - other arguments
     TYPE type,                  // - type for class
     bool exact )                // - true ==> exact CTORing of classes

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1167,7 +1167,7 @@ bool NodeNonConstRefToTemp(     // CHECK IF TEMP. PASSED AS NON-CONST REF
 PTREE NodeMakeConstantOffset(               // BUILD CONSTANT NODE FOR AN OFFSET
     target_offset_t offset )    // - the offset
 ;
-PTREE NodeTestExpr(             // GENERATE A TERNARY TEST EXPRESSION
+PTREE NodeMakeTernaryExpr(             // GENERATE A TERNARY TEST EXPRESSION
     PTREE b_expr,               // - boolean expression
     PTREE t_expr,               // - true expression
     PTREE f_expr )              // - false expression

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -907,7 +907,7 @@ PTREE NodeMakeRefAssignment(            // CREATE ASSIGNMENT NODE FOR REFERENCE
     PTREE tgt,                  // - target
     PTREE src )                 // - source
 ;
-PTREE NodeAssignTemporary(      // ASSIGN NODE TO A TEMPORARY
+PTREE NodeMakeAssignToNewTmp(      // ASSIGN NODE TO A TEMPORARY
     TYPE type,                  // - type of temporary
     PTREE expr )                // - the expression to be assigned to temp
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -942,7 +942,7 @@ bool NodeCallsCtor(             // DETERMINE IF NODE CALLS CTOR
 PTREE NodeMakeCDtorArg(             // BUILD CONSTANT NODE FOR CDTOR EXTRA ARG
     target_offset_t code )      // - the code
 ;
-PTREE NodeCDtorExtra(           // MAKE A CTOR/DTOR EXTRA PARM NODE
+PTREE NodeMakeCDtorExtraParm(           // MAKE A CTOR/DTOR EXTRA PARM NODE
     void )
 ;
 CNV_RETN NodeCheckCnvPtrVoid(   // CHECK CONVERSION TO 'VOID*'

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1297,7 +1297,7 @@ void NodeWarnPtrTrunc(          // WARN FOR POINTER/REFERENCE TRUNCATION
 void NodeWarnPtrTruncCast(      // WARN FOR CAST POINTER/REFERENCE TRUNCATION
     PTREE node )                // - node for warning
 ;
-PTREE NodeZero                  // BUILD A ZERO NODE
+PTREE NodeMakeZeroConstant                  // BUILD A ZERO NODE
     ( void )
 ;
 PTREE OverloadOperator(         // HANDLE OPERATOR OVERLOADING, IF REQ'D

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -939,7 +939,7 @@ void NodeBuildArgList(          // BUILD ARGUMENT LIST FROM CALLER ARG.S
 bool NodeCallsCtor(             // DETERMINE IF NODE CALLS CTOR
     PTREE node )                // - a call node
 ;
-PTREE NodeCDtorArg(             // BUILD CONSTANT NODE FOR CDTOR EXTRA ARG
+PTREE NodeMakeCDtorArg(             // BUILD CONSTANT NODE FOR CDTOR EXTRA ARG
     target_offset_t code )      // - the code
 ;
 PTREE NodeCDtorExtra(           // MAKE A CTOR/DTOR EXTRA PARM NODE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1164,7 +1164,7 @@ bool NodeNonConstRefToTemp(     // CHECK IF TEMP. PASSED AS NON-CONST REF
     TYPE arg_type,              // - possible non-const reference
     PTREE node )                // - possible temporary
 ;
-PTREE NodeOffset(               // BUILD CONSTANT NODE FOR AN OFFSET
+PTREE NodeMakeConstantOffset(               // BUILD CONSTANT NODE FOR AN OFFSET
     target_offset_t offset )    // - the offset
 ;
 PTREE NodeTestExpr(             // GENERATE A TERNARY TEST EXPRESSION

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1240,7 +1240,7 @@ PTREE NodeRvalueRight(          // SET RVALUE ON RIGHT
 PTREE NodeRvForRefClass         // MAKE RVALUE FOR REF CLASS
     ( PTREE expr )              // - LVALUE ref-class expression
 ;
-PTREE NodeSegname(              // BUILD EXPRESSION FOR __segname
+PTREE NodeMakeSegname(              // BUILD EXPRESSION FOR __segname
     char* segname )             // - name of segment
 ;
 PTREE NodeSetMemoryExact(       // SET PTF_MEMORY_EXACT, IF REQ'D

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1130,7 +1130,7 @@ bool NodeIsZeroConstant(        // TEST IF A ZERO CONSTANT
 bool NodeIsZeroIntConstant(     // TEST IF A ZERO INTEGER CONSTANT
     PTREE node )                // - node
 ;
-PTREE NodeLvExtract             // EXTRACT LVALUE, IF POSSIBLE
+PTREE NodeExtractLValue             // EXTRACT LVALUE, IF POSSIBLE
     ( PTREE expr )              // - expression
 ;
 PTREE NodeLvForRefClass         // MAKE LVALUE FOR REF CLASS

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -883,7 +883,7 @@ addr_func_t NodeAddrOfFun(      // GET PTREE FOR &FUN (FUN IS OVERLOADED)
     PTREE oper,                 // - expression
     PTREE *addr_func )          // - addr[ &function ]
 ;
-PTREE NodeArg(                  // MAKE A SINGLE ARGUMENT NODE
+PTREE NodeMakeArg(                  // MAKE A SINGLE ARGUMENT NODE
     PTREE argval )              // - value for argument
 ;
 PTREE NodeMakeArgument(             // MAKE AN ARGUMENT NODE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1033,7 +1033,7 @@ bool NodeTryDerefPtr(              // DEREFERENCE A POINTER
 PTREE NodeMakeDone(                 // MAKE A NODE-DONE
     PTREE expr )                // - expression
 ;
-PTREE NodeDottedFunction        // BUILD A DOT NODE FOR A FUNCTION
+PTREE NodeMakeDottedFunction        // BUILD A DOT NODE FOR A FUNCTION
     ( PTREE left                // - left operand
     , PTREE right )             // - right operand
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1231,7 +1231,7 @@ PTREE NodeRvalueExactLeft(      // SET RVALUE (EXACT) ON LEFT
 PTREE NodeRvalueExactRight(     // SET RVALUE (EXACT) ON RIGHT
     PTREE node )                // - current node
 ;
-PTREE NodeRvalueLeft(           // SET RVALUE ON LEFT
+PTREE NodeSetRValueLeft(           // SET RVALUE ON LEFT
     PTREE node )                // - current node
 ;
 PTREE NodeRvalueRight(          // SET RVALUE ON RIGHT

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -924,7 +924,7 @@ PTREE NodeMakeBinary(               // MAKE A BINARY NODE
     PTREE left,                 // - left operand
     PTREE right )               // - right operand
 ;
-bool NodeBitField(              // TEST IF NODE IS A BIT FIELD
+bool NodeIsBitField(              // TEST IF NODE IS A BIT FIELD
     PTREE node )                // - the node
 ;
 PTREE NodeBitQuestAssign(       // ASSIGN (expr?bit-fld:bit-fld) = expr

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1037,7 +1037,7 @@ PTREE NodeDottedFunction        // BUILD A DOT NODE FOR A FUNCTION
     ( PTREE left                // - left operand
     , PTREE right )             // - right operand
 ;
-PTREE NodeDtorExpr(             // MARK FOR DTOR'ING AFTER EXPRESSION
+PTREE NodeMarkDtorExpr(             // MARK FOR DTOR'ING AFTER EXPRESSION
     PTREE expr,                 // - expression computing symbol
     SYMBOL sym )                // - SYMBOL being computed
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -980,7 +980,7 @@ PTREE NodeMakeZeroCompare(        // MAKE A COMPARE-TO-ZERO NODE, IF REQ'D
 PTREE NodeMakeBoolConversion(        // MAKE A CONVERT-TO-BOOL NODE, IF REQ'D
     PTREE expr )
 ;
-int NodeConstantValue(          // GET CONSTANT VALUE FOR A NODE
+int NodeGetConstantValue(          // GET CONSTANT VALUE FOR A NODE
     PTREE node )                // - a constant node
 ;
 PTREE NodeMakeConversion(              // MAKE A CONVERSION NODE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1225,7 +1225,7 @@ PTREE NodeGetRValue(               // GET RVALUE, IF LVALUE
 PTREE NodeSetRValueExact(          // SET RVALUE (EXACT)
     PTREE node )                // - current node
 ;
-PTREE NodeRvalueExactLeft(      // SET RVALUE (EXACT) ON LEFT
+PTREE NodeSetRValueExactLeft(      // SET RVALUE (EXACT) ON LEFT
     PTREE node )                // - current node
 ;
 PTREE NodeRvalueExactRight(     // SET RVALUE (EXACT) ON RIGHT

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1219,7 +1219,7 @@ PTREE NodeReverseArgs(          // REVERSE CALL ARGUMENTS
     unsigned *arg_count,        // - # args
     PTREE arg )                 // - start of arg. list (to be reversed)
 ;
-PTREE NodeRvalue(               // GET RVALUE, IF LVALUE
+PTREE NodeGetRValue(               // GET RVALUE, IF LVALUE
     PTREE curr )                // - node to be transformed
 ;
 PTREE NodeRvalueExact(          // SET RVALUE (EXACT)

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1082,7 +1082,7 @@ bool NodeGetIbpSymbol(          // GET BOUND-REFERENCE SYMBOL, IF POSSIBLE
 PTREE NodeIc(                   // ADD A PTREE-IC NODE
     CGINTEROP opcode )          // - opcode
 ;
-PTREE NodeIcUnsigned(           // ADD A PTREE-IC NODE, UNSIGNED OPERAND
+PTREE NodeMakeIcUnsigned(           // ADD A PTREE-IC NODE, UNSIGNED OPERAND
     CGINTEROP opcode,           // - opcode
     unsigned operand )          // - operand
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1023,7 +1023,7 @@ PTREE NodeConvertVirtualPtr(    // EXECUTE A VIRTUAL BASE CAST
     target_offset_t vb_offset,  // - offset of vbptr
     vindex vb_index )           // - index in vbtable
 ;
-PTREE NodeCopyClassObject(      // COPY OBJECT W/O CTOR
+PTREE NodeMakeClassObjectCopy(      // COPY OBJECT W/O CTOR
     PTREE tgt,                  // - target object (LVALUE)
     PTREE src )                 // - source object (RVALUE)
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -916,7 +916,7 @@ PTREE NodeMakeAssignToTmp(  // ASSIGN NODE TO A TEMPORARY NODE
     PTREE expr,                 // - the expression to be assigned to temp
     PTREE temp_node )           // - node for temporary symbol
 ;
-PTREE NodeBasedStr(             // BUILD EXPRESSION FOR TF1_BASED_STRING TYPE
+PTREE NodeMakeBasedStr(             // BUILD EXPRESSION FOR TF1_BASED_STRING TYPE
     TYPE expr_type )            // - TF1_BASED_STRING type
 ;
 PTREE NodeMakeBinary(               // MAKE A BINARY NODE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1268,7 +1268,7 @@ PTREE NodeSymbolNoRef(          // FILL IN NODE FOR A SYMBOL, NO REF. SETTING
     SYMBOL sym,                 // - symbol
     SEARCH_RESULT *result )     // - search result
 ;
-PTREE NodeTemporary(            // CREATE TEMPORARY AND NODE FOR IT
+PTREE NodeMakeTemporary(            // CREATE TEMPORARY AND NODE FOR IT
     TYPE type )                 // - type of temporary
 ;
 PTREE NodeMakeThis(                 // MAKE A RVALUE "THIS" NODE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1086,7 +1086,7 @@ PTREE NodeMakeIcUnsigned(           // ADD A PTREE-IC NODE, UNSIGNED OPERAND
     CGINTEROP opcode,           // - opcode
     unsigned operand )          // - operand
 ;
-PTREE NodeIntDummy              // BUILD A DUMMY INTEGRAL NODE
+PTREE NodeMakeIntDummy              // BUILD A DUMMY INTEGRAL NODE
     ( void )
 ;
 PTREE NodeMakeIntegralConstant      // BUILD AN INTEGRAL NODE FOR A VALUE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1089,7 +1089,7 @@ PTREE NodeIcUnsigned(           // ADD A PTREE-IC NODE, UNSIGNED OPERAND
 PTREE NodeIntDummy              // BUILD A DUMMY INTEGRAL NODE
     ( void )
 ;
-PTREE NodeIntegralConstant      // BUILD AN INTEGRAL NODE FOR A VALUE
+PTREE NodeMakeIntegralConstant      // BUILD AN INTEGRAL NODE FOR A VALUE
     ( int val                   // - value
     , TYPE type )               // - node type (integral,enum,ptr)
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1160,7 +1160,7 @@ PTREE NodeMarkRvalue(           // SET TYPE, FLAGS FOR LVALUE
 PTREE NodeModInitTemporary(     // CREATE TEMP NODE (STATIC IF IN MODULE-INIT)
     TYPE type )                 // - type of temporary
 ;
-bool NodeNonConstRefToTemp(     // CHECK IF TEMP. PASSED AS NON-CONST REF
+bool NodeIsNonConstRefToTemp(     // CHECK IF TEMP. PASSED AS NON-CONST REF
     TYPE arg_type,              // - possible non-const reference
     PTREE node )                // - possible temporary
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -886,7 +886,7 @@ addr_func_t NodeAddrOfFun(      // GET PTREE FOR &FUN (FUN IS OVERLOADED)
 PTREE NodeArg(                  // MAKE A SINGLE ARGUMENT NODE
     PTREE argval )              // - value for argument
 ;
-PTREE NodeArgument(             // MAKE AN ARGUMENT NODE
+PTREE NodeMakeArgument(             // MAKE AN ARGUMENT NODE
     PTREE left,                 // - left subtree
     PTREE right )               // - right subtree
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -895,7 +895,7 @@ PTREE NodeArgumentExactCtor(    // ADD EXACT CTOR ARG., IF REQUIRED
     TYPE type,                  // - type for class
     bool exact )                // - true ==> exact CTORing of classes
 ;
-PTREE NodeArguments(            // MAKE A LIST OF ARGUMENTS
+PTREE NodeMakeArgList(            // MAKE A LIST OF ARGUMENTS
     PTREE arg,                  // - first arg
     ... )                       // - NULL terminated, in reverse order
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -991,7 +991,7 @@ bool NodeConvertArgument(       // CONVERT AN ARGUMENT VALUE
     PTREE *a_expr,              // - addr( argument value )
     TYPE proto )                // - prototype type
 ;
-PTREE NodeConvertFlags(         // MAKE A CONVERSION NODE WITH FLAGS, IF REQ'D
+PTREE NodeMakeConversionFlags(         // MAKE A CONVERSION NODE WITH FLAGS, IF REQ'D
     TYPE type,                  // - type for conversion
     PTREE expr,                 // - expression to be converted
     PTF_FLAG flags )            // - flags to be added

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1475,7 +1475,7 @@ CNV_RETN UserDefCnvToType(      // DO A USER-DEFINED CONVERSION TO A TYPE
     TYPE src,                   // - source type (a class)
     TYPE tgt )                  // - target type
 ;
-PTREE NodeAddToLeft(            // FABRICATE AN ADDITION TO LEFT
+PTREE NodeMakeLeftAddition(            // FABRICATE AN ADDITION TO LEFT
     PTREE left,                 // - left operand
     PTREE right,                // - right operand
     TYPE type )                 // - type of result

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1062,7 +1062,7 @@ void NodeFreeDupedExpr(         // FREE AN EXPRESSION WITH DUPLICATES
 void NodeFreeSearchResult(      // FREE SEARCH_RESULT FROM A NODE
     PTREE node )                // - the node
 ;
-PTREE NodeFromConstSym(         // BUILD CONSTANT NODE FROM CONSTANT SYMBOL
+PTREE NodeMakeFromConstSym(         // BUILD CONSTANT NODE FROM CONSTANT SYMBOL
     SYMBOL con )                // - constant symbol
 ;
 PTREE NodeFuncForCall(          // GET FUNCTION NODE FOR CALL

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -879,7 +879,7 @@ PTREE NodeAddSideEffect(        // ADD A SIDE-EFFECT EXPRESSION
 PTREE NodeActualNonOverloaded(  // POSITION OVER DEFAULT-ARG SYMBOLS
     PTREE node )                // - PT_SYMBOL for function
 ;
-addr_func_t NodeAddrOfFun(      // GET PTREE FOR &FUN (FUN IS OVERLOADED)
+addr_func_t NodeGetOverloadedFnAddr(      // GET PTREE FOR &FUN (FUN IS OVERLOADED)
     PTREE oper,                 // - expression
     PTREE *addr_func )          // - addr[ &function ]
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -927,7 +927,7 @@ PTREE NodeMakeBinary(               // MAKE A BINARY NODE
 bool NodeIsBitField(              // TEST IF NODE IS A BIT FIELD
     PTREE node )                // - the node
 ;
-PTREE NodeBitQuestAssign(       // ASSIGN (expr?bit-fld:bit-fld) = expr
+PTREE NodeMakeBitQuestAssign(       // ASSIGN (expr?bit-fld:bit-fld) = expr
     PTREE expr )                // - the expression
 ;
 void NodeBuildArgList(          // BUILD ARGUMENT LIST FROM CALLER ARG.S

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1079,7 +1079,7 @@ bool NodeGetIbpSymbol(          // GET BOUND-REFERENCE SYMBOL, IF POSSIBLE
     SYMBOL* a_ibp,              // - bound parameter to use
     target_offset_t* a_offset ) // - addr[ offset to basing symbol ]
 ;
-PTREE NodeIc(                   // ADD A PTREE-IC NODE
+PTREE NodeMakeIc(                   // ADD A PTREE-IC NODE
     CGINTEROP opcode )          // - opcode
 ;
 PTREE NodeMakeIcUnsigned(           // ADD A PTREE-IC NODE, UNSIGNED OPERAND

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1271,7 +1271,7 @@ PTREE NodeSymbolNoRef(          // FILL IN NODE FOR A SYMBOL, NO REF. SETTING
 PTREE NodeTemporary(            // CREATE TEMPORARY AND NODE FOR IT
     TYPE type )                 // - type of temporary
 ;
-PTREE NodeThis(                 // MAKE A RVALUE "THIS" NODE
+PTREE NodeMakeThis(                 // MAKE A RVALUE "THIS" NODE
     void )
 ;
 PTREE NodeThisCopyLocation(     // MAKE A RVALUE "THIS" NODE WITH LOCATION

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -323,7 +323,7 @@ PTREE AnalyseValueExpr(         // ANALYZE A EXPRESSION, MAKE IT A VALUE
 target_size_t ArrayTypeNumberItems( // GET ACTUAL NUMBER OF ITEMS FOR AN ARRAY
     TYPE artype )               // - an array type
 ;
-PTREE CallArgumentExactCtor(    // GET EXACT CTOR ARG., IF REQUIRED
+PTREE MakeArgCtorCall(    // GET EXACT CTOR ARG., IF REQUIRED
     TYPE type,                  // - type for class
     bool exact )                // - true ==> exact CTORing of classes
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1027,7 +1027,7 @@ PTREE NodeMakeClassObjectCopy(      // COPY OBJECT W/O CTOR
     PTREE tgt,                  // - target object (LVALUE)
     PTREE src )                 // - source object (RVALUE)
 ;
-bool NodeDerefPtr(              // DEREFERENCE A POINTER
+bool NodeTryDerefPtr(              // DEREFERENCE A POINTER
     PTREE *a_ptr )              // - addr[ ptr operand ]
 ;
 PTREE NodeMakeDone(                 // MAKE A NODE-DONE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1030,7 +1030,7 @@ PTREE NodeCopyClassObject(      // COPY OBJECT W/O CTOR
 bool NodeDerefPtr(              // DEREFERENCE A POINTER
     PTREE *a_ptr )              // - addr[ ptr operand ]
 ;
-PTREE NodeDone(                 // MAKE A NODE-DONE
+PTREE NodeMakeDone(                 // MAKE A NODE-DONE
     PTREE expr )                // - expression
 ;
 PTREE NodeDottedFunction        // BUILD A DOT NODE FOR A FUNCTION

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -977,7 +977,7 @@ PTREE NodeSetType               // SET NODE TYPE, FLAGS
 PTREE NodeMakeZeroCompare(        // MAKE A COMPARE-TO-ZERO NODE, IF REQ'D
     PTREE expr )
 ;
-PTREE NodeConvertToBool(        // MAKE A CONVERT-TO-BOOL NODE, IF REQ'D
+PTREE NodeMakeBoolConversion(        // MAKE A CONVERT-TO-BOOL NODE, IF REQ'D
     PTREE expr )
 ;
 int NodeConstantValue(          // GET CONSTANT VALUE FOR A NODE

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -983,7 +983,7 @@ PTREE NodeConvertToBool(        // MAKE A CONVERT-TO-BOOL NODE, IF REQ'D
 int NodeConstantValue(          // GET CONSTANT VALUE FOR A NODE
     PTREE node )                // - a constant node
 ;
-PTREE NodeConvert(              // MAKE A CONVERSION NODE
+PTREE NodeMakeConversion(              // MAKE A CONVERSION NODE
     TYPE type,                  // - type for conversion
     PTREE expr )                // - expression to be converted
 ;

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -974,7 +974,7 @@ PTREE NodeSetType               // SET NODE TYPE, FLAGS
     , TYPE type                 // - new type for node
     , PTF_FLAG flags )          // - new flags
 ;
-PTREE NodeCompareToZero(        // MAKE A COMPARE-TO-ZERO NODE, IF REQ'D
+PTREE NodeMakeZeroCompare(        // MAKE A COMPARE-TO-ZERO NODE, IF REQ'D
     PTREE expr )
 ;
 PTREE NodeConvertToBool(        // MAKE A CONVERT-TO-BOOL NODE, IF REQ'D

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -919,7 +919,7 @@ PTREE NodeAssignTemporaryNode(  // ASSIGN NODE TO A TEMPORARY NODE
 PTREE NodeBasedStr(             // BUILD EXPRESSION FOR TF1_BASED_STRING TYPE
     TYPE expr_type )            // - TF1_BASED_STRING type
 ;
-PTREE NodeBinary(               // MAKE A BINARY NODE
+PTREE NodeMakeBinary(               // MAKE A BINARY NODE
     CGOP op,                    // - operator
     PTREE left,                 // - left operand
     PTREE right )               // - right operand

--- a/bld/plusplus/h/typesig.h
+++ b/bld/plusplus/h/typesig.h
@@ -66,7 +66,7 @@ typedef enum                    // TYPE_SIG_ACCESS
 
 // PROTOTYPES:
 
-PTREE NodeTypeSig               // MAKE NODE FOR TYPE-SIG ADDRESS
+PTREE NodeMakeTypeSignature               // MAKE NODE FOR TYPE-SIG ADDRESS
     ( TYPE_SIG* sig )           // - type signature
 ;
 PTREE NodeTypeSigArg            // MAKE ARGUMENT NODE FOR TYPE-SIG ADDRESS

--- a/bld/plusplus/h/typesig.h
+++ b/bld/plusplus/h/typesig.h
@@ -69,7 +69,7 @@ typedef enum                    // TYPE_SIG_ACCESS
 PTREE NodeMakeTypeSignature               // MAKE NODE FOR TYPE-SIG ADDRESS
     ( TYPE_SIG* sig )           // - type signature
 ;
-PTREE NodeTypeSigArg            // MAKE ARGUMENT NODE FOR TYPE-SIG ADDRESS
+PTREE NodeMakeTypeSignatureArg            // MAKE ARGUMENT NODE FOR TYPE-SIG ADDRESS
     ( TYPE_SIG* sig )           // - type signature
 ;
 TYPE_SIG *TypeSigFind(          // FIND TYPE SIGNATURE


### PR DESCRIPTION
Most of the functions in analnode.c have inconsistent and ambiguous names, as they use the same naming style for creating nodes (NodeCompareToZero -> creates a comparison to zero node) and for boolean tests (NodeBitField -> checks if node represents a bit field).

This requests attempts to give these functions better and consistent names.