### PR TITLE
[CXX] Fix anonymous namespace

### DIFF
--- a/bld/plusplus/c/scope.c
+++ b/bld/plusplus/c/scope.c
@@ -1880,18 +1880,11 @@ bool ScopeEquivalent( SCOPE scope, scope_type_t scope_type )
 NAME ScopeUnnamedNamespaceName( TOKEN_LOCN *locn )
 /************************************************/
 {
-    NAME ns_name;
-
-    if( !CompFlags.extensions_enabled ) {
-        ns_name = uniqueNameSpaceName;
-        if( ns_name == NULL ) {
-            ns_name = CppNameUniqueNS( locn );
-            uniqueNameSpaceName = ns_name;
-        }
-    } else {
-        ns_name = CppNameUniqueNS( locn );
+    if( uniqueNameSpaceName == NULL ) {
+        uniqueNameSpaceName = CppNameUniqueNS( locn );
     }
-    return( ns_name );
+
+    return( uniqueNameSpaceName );
 }
 
 NAME ScopeNameSpaceName( SCOPE scope )


### PR DESCRIPTION
If extensions were enabled, the compiler would treat every instance of an anonymous namespace in the same translation unit as separate namespaces.

This patch enforces that anonymous namespaces be treated as always reopening the same namespace even when extensions are on.

Closes issue #277 .