### PR TITLE
Replaced raw conversion to bool with implicit cast

### DIFF
--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -4425,7 +4425,7 @@ PTREE AnalyseBoolExpr(      // ANALYZE A BOOLEAN EXPRESSION
             if( 0 == ( expr->flags & PTF_BOOLEAN ) ) {
                 warnBoolAssignment( expr );
             }
-            expr = NodeConvertToBool( expr );
+            expr = CastImplicit( expr, GetBasicType( TYP_BOOL ), CNV_EXPR, &diagInit);
         }
     }
     return expr;


### PR DESCRIPTION
This is useful to diagnose some implicit conversions to bool in the future, other than being the semantically correct thing to do.