### PR TITLE
[CXX11] Added nullptr

### DIFF
--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -2005,27 +2005,31 @@ static void allocClassDestination//ALLOCATE DESTINATION WHEN CLASS
     }
 }
 
-
+//TODO: fix nullptr values
 static uint_8 constTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
-//         a           c           m       g
-//         r   e       l   f   v           e
-//     e   i   n   p   a   u   o   p   .   n
-//     r   t   u   t   s   n   i   t   .   e
-//     r   h   m   r   s   c   d   r   .   r
+//                                             n
+//                                             u
+//         a           c           m       g   l
+//         r   e       l   f   v           e   l
+//     e   i   n   p   a   u   o   p   .   n   p
+//     r   t   u   t   s   n   i   t   .   e   t
+//     r   h   m   r   s   c   d   r   .   r   r
+
 //                                               target operand
 //                                               --------------
-    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0  // error
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // arithmetic
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // enumeration
-    ,  1,  3,  3,  5,  3,  3,  3,  3,  0,  0  // pointer
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // class
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // function
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // void
-    ,  1,  4,  4,  4,  4,  4,  4,  6,  0,  0  // member pointer
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // arithmetic
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // enumeration
+    ,  1,  3,  3,  5,  3,  3,  3,  3,  0,  0,  0  // pointer
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // class
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // function
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // void
+    ,  1,  4,  4,  4,  4,  4,  4,  6,  0,  0,  0  // member pointer
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // nullptr
     };
 
 //  0 - impossible
@@ -2097,27 +2101,30 @@ PTREE CastConst                 // CONST_CASTE< TYPE >( EXPR )
     return doCastResult( &ctl, result );
 }
 
-
+//TODO: fix nullptr values
 static uint_8 reintTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
-//         a           c           m       g
-//         r   e       l   f   v           e
-//     e   i   n   p   a   u   o   p   .   n
-//     r   t   u   t   s   n   i   t   .   e
-//     r   h   m   r   s   c   d   r   .   r
+//                                             n
+//                                             u
+//         a           c           m       g   l
+//         r   e       l   f   v           e   l
+//     e   i   n   p   a   u   o   p   .   n   p
+//     r   t   u   t   s   n   i   t   .   e   t
+//     r   h   m   r   s   c   d   r   .   r   r
 //                                               target operand
 //                                               --------------
-    {  1,  1,  1,  1,  1,  1,  1,  1,  1,  1  // error
-    ,  1,  4,  4,  3,  4,  4,  4,  4,  0,  0  // arithmetic
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // enumeration
-    ,  1,  5,  7,  6,  7,  7,  7,  7,  0,  0  // pointer
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // class
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // function
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // void
-    ,  1,  9,  9,  9,  9,  9,  9,  8,  0,  0  // member pointer
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    {  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1  // error
+    ,  1,  4,  4,  3,  4,  4,  4,  4,  0,  0,  0  // arithmetic
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // enumeration
+    ,  1,  5,  7,  6,  7,  7,  7,  7,  0,  0,  0  // pointer
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // class
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // function
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // void
+    ,  1,  9,  9,  9,  9,  9,  9,  8,  0,  0,  0  // member pointer
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
     };
 
 //  0 - impossible
@@ -2198,26 +2205,31 @@ PTREE CastReint                 // REINTERPRET_CASTE< TYPE >( EXPR )
     return doCastResult( &ctl, result );
 }
 
+
+//TODO: fix nullptr values
 static uint_8 staticTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
-//         a           c           m       g
-//         r   e       l   f   v           e
-//     e   i   n   p   a   u   o   p   .   n
-//     r   t   u   t   s   n   i   t   .   e
-//     r   h   m   r   s   c   d   r   .   r
+//                                             n
+//                                             u
+//         a           c           m       g   l
+//         r   e       l   f   v           e   l
+//     e   i   n   p   a   u   o   p   .   n   p
+//     r   t   u   t   s   n   i   t   .   e   t
+//     r   h   m   r   s   c   d   r   .   r   r
 //                                               target operand
 //                                               --------------
-    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0  // error
-    ,  1,  4,  4,  3,  0,  3,  3,  3,  0,  0  // arithmetic
-    ,  1, 14,  4,  3,  0,  3,  3,  3,  0,  0  // enumeration
-    ,  1,  7,  7, 11,  0,  5,  3,  3,  0,  0  // pointer
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // class
-    ,  1,  2,  2,  2,  0,  2,  2,  2,  0,  0  // function
-    ,  1,  6,  6,  6,  0,  6,  6,  6,  0,  0  // void
-    ,  1, 10, 10,  3,  0,  3,  3, 13,  0,  0  // member pointer
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error
+    ,  1,  4,  4,  3,  0,  3,  3,  3,  0,  0,  0  // arithmetic
+    ,  1, 14,  4,  3,  0,  3,  3,  3,  0,  0,  0  // enumeration
+    ,  1,  7,  7, 11,  0,  5,  3,  3,  0,  0,  0  // pointer
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // class
+    ,  1,  2,  2,  2,  0,  2,  2,  2,  0,  0,  0  // function
+    ,  1,  6,  6,  6,  0,  6,  6,  6,  0,  0,  0  // void
+    ,  1, 10, 10,  3,  0,  3,  3, 13,  0,  0,  0  // member pointer
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // nullptr
     };
 
 //  0 - impossible
@@ -2347,27 +2359,30 @@ PTREE CastStatic                // STATIC_CASTE< TYPE >( EXPR )
     return doCastResult( &ctl, result );
 }
 
-
+//TODO: fix nullptr values
 static uint_8 dynamicTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
-//         a           c           m       g
-//         r   e       l   f   v           e
-//     e   i   n   p   a   u   o   p   .   n
-//     r   t   u   t   s   n   i   t   .   e
-//     r   h   m   r   s   c   d   r   .   r
+//                                             n
+//                                             u
+//         a           c           m       g   l
+//         r   e       l   f   v           e   l
+//     e   i   n   p   a   u   o   p   .   n   p
+//     r   t   u   t   s   n   i   t   .   e   t
+//     r   h   m   r   s   c   d   r   .   r   r
 //                                               target operand
 //                                               --------------
-    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0  // error
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // arithmetic
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // enumeration
-    ,  1,  3,  3,  4,  3,  3,  3,  3,  0,  0  // pointer
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // class
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // function
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // void
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0  // member pointer
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // arithmetic
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // enumeration
+    ,  1,  3,  3,  4,  3,  3,  3,  3,  0,  0,  0  // pointer
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // class
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // function
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // void
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // member pointer
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // nullptr
     };
 
 //  0 - impossible
@@ -2462,27 +2477,30 @@ PTREE CastDynamic               // DYNAMIC_CASTE< TYPE >( EXPR )
     return doCastResult( &ctl, result );
 }
 
-
+//TODO: fix nullptr values
 static uint_8 explicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
-//         a           c           m       g
-//         r   e       l   f   v           e
-//     e   i   n   p   a   u   o   p   .   n
-//     r   t   u   t   s   n   i   t   .   e
-//     r   h   m   r   s   c   d   r   .   r
+//                                             n
+//                                             u
+//         a           c           m       g   l
+//         r   e       l   f   v           e   l
+//     e   i   n   p   a   u   o   p   .   n   p
+//     r   t   u   t   s   n   i   t   .   e   t
+//     r   h   m   r   s   c   d   r   .   r   r
 //                                               target operand
 //                                               --------------
-    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0  // error
-    ,  1, 11, 12,  4,  0,  0,  3,  3,  0,  0  // arithmetic
-    ,  1, 12, 12,  4,  0,  0,  3,  3,  0,  0  // enumeration
-    ,  1,  6,  7,  5,  0,  0,  3,  3,  0,  0  // pointer
-    ,  1,  0,  0,  0,  0,  0,  3,  0,  0,  0  // class
-    ,  1,  2,  2,  2,  0,  2,  2,  2,  0,  0  // function
-    ,  1, 13, 13, 13, 13,  0, 13, 13,  0,  0  // void
-    ,  1, 10, 10,  3,  0,  0,  3, 14,  0,  0  // member pointer
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error
+    ,  1, 11, 12,  4,  0,  0,  3,  3,  0,  0,  0  // arithmetic
+    ,  1, 12, 12,  4,  0,  0,  3,  3,  0,  0,  0  // enumeration
+    ,  1,  6,  7,  5,  0,  0,  3,  3,  0,  0,  0  // pointer
+    ,  1,  0,  0,  0,  0,  0,  3,  0,  0,  0,  0  // class
+    ,  1,  2,  2,  2,  0,  2,  2,  2,  0,  0,  0  // function
+    ,  1, 13, 13, 13, 13,  0, 13, 13,  0,  0,  0  // void
+    ,  1, 10, 10,  3,  0,  0,  3, 14,  0,  0,  0  // member pointer
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // nullptr
     };
 
 //  0 - impossible
@@ -2615,13 +2633,13 @@ PTREE CastExplicit              // EXPLICIT CASTE: ( TYPE )( EXPR )
 static uint_8 implicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
-//         a           c           m       g   n
-//         r   e       l   f   v           e   u
-//     e   i   n   p   a   u   o   p   .   n   l
-//     r   t   u   t   s   n   i   t   .   e   l
-//     r   h   m   r   s   c   d   r   .   r   p
-//                                             t
-//                                             r
+//                                             n
+//                                             u
+//         a           c           m       g   l
+//         r   e       l   f   v           e   l
+//     e   i   n   p   a   u   o   p   .   n   p
+//     r   t   u   t   s   n   i   t   .   e   t
+//     r   h   m   r   s   c   d   r   .   r   r
 //                                               target operand
 //                                               --------------
     {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -2018,7 +2018,12 @@ static void allocClassDestination//ALLOCATE DESTINATION WHEN CLASS
     }
 }
 
-//TODO: fix nullptr values
+/**
+ * This table represents the various possible combinations for
+ * const_cast<target operand>(source operand)
+ *
+ * \Return an integer specifying the type of conversion to be performed (or error).
+ */
 static uint_8 constTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
@@ -2029,20 +2034,19 @@ static uint_8 constTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //     e   i   n   p   a   u   o   p   .   n   p
 //     r   t   u   t   s   n   i   t   .   e   t
 //     r   h   m   r   s   c   d   r   .   r   r
-
 //                                               target operand
 //                                               --------------
-    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // arithmetic
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // enumeration
-    ,  1,  3,  3,  5,  3,  3,  3,  3,  0,  0,  0  // pointer
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // class
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // function
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // void
-    ,  1,  4,  4,  4,  4,  4,  4,  6,  0,  0,  0  // member pointer
+    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  1  // error
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // arithmetic
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // enumeration
+    ,  1,  3,  3,  5,  3,  3,  3,  3,  0,  0,  3  // pointer
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // class
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // function
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // void
+    ,  1,  4,  4,  4,  4,  4,  4,  6,  0,  0,  4  // member pointer
     ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
     ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // nullptr
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // nullptr
     };
 
 //  0 - impossible
@@ -2054,7 +2058,7 @@ static uint_8 constTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //  6 - const_cast<memb-ptr>( memb-ptr )
 
 
-PTREE CastConst                 // CONST_CASTE< TYPE >( EXPR )
+PTREE CastConst                 // CONST_CAST< TYPE >( EXPR )
     ( PTREE expr )              // - cast expression
 {
     CONVCTL ctl;                // - conversion control
@@ -2074,7 +2078,7 @@ PTREE CastConst                 // CONST_CASTE< TYPE >( EXPR )
         }
     } else switch( constTable[ ctl.tgt.kind ][ ctl.src.kind ] ) {
       case  0 : // impossible
-        DbgVerify( 0, "ReintCast -- bad selection" );
+        DbgVerify( 0, "ConstCast -- bad selection" );
         result = DIAG_IMPOSSIBLE;
         break;
       case  1 : // an operand is error
@@ -2114,7 +2118,12 @@ PTREE CastConst                 // CONST_CASTE< TYPE >( EXPR )
     return doCastResult( &ctl, result );
 }
 
-//TODO: fix nullptr values
+/**
+ * This table represents the various possible combinations for
+ * reinterpret_cast<target operand>(source operand)
+ *
+ * \Return an integer specifying the type of conversion to be performed (or error).
+ */
 static uint_8 reintTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
@@ -2129,15 +2138,15 @@ static uint_8 reintTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //                                               --------------
     {  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1  // error
     ,  1,  4,  4,  3,  4,  4,  4,  4,  0,  0,  0  // arithmetic
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // enumeration
-    ,  1,  5,  7,  6,  7,  7,  7,  7,  0,  0,  0  // pointer
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // class
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // function
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // void
-    ,  1,  9,  9,  9,  9,  9,  9,  8,  0,  0,  0  // member pointer
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // enumeration
+    ,  1,  5,  7,  6,  7,  7,  7,  7,  0,  0,  7  // pointer
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // class
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // function
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // void
+    ,  1,  9,  9,  9,  9,  9,  9,  8,  0,  0,  9  // member pointer
     ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
     ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // nullptr
     };
 
 //  0 - impossible
@@ -2152,7 +2161,7 @@ static uint_8 reintTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //  9 - source expression cannot be converted to memb-ptr type
 
 
-PTREE CastReint                 // REINTERPRET_CASTE< TYPE >( EXPR )
+PTREE CastReint                 // REINTERPRET_CAST< TYPE >( EXPR )
     ( PTREE expr )              // - cast expression
 {
     CONVCTL ctl;                // - conversion control
@@ -2219,7 +2228,12 @@ PTREE CastReint                 // REINTERPRET_CASTE< TYPE >( EXPR )
 }
 
 
-//TODO: fix nullptr values
+/**
+ * This table represents the various possible combinations for
+ * static_cast<target operand>(source operand)
+ *
+ * \Return an integer specifying the type of conversion to be performed (or error).
+ */
 static uint_8 staticTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
@@ -2232,17 +2246,17 @@ static uint_8 staticTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //     r   h   m   r   s   c   d   r   .   r   r
 //                                               target operand
 //                                               --------------
-    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error
-    ,  1,  4,  4,  3,  0,  3,  3,  3,  0,  0,  0  // arithmetic
-    ,  1, 14,  4,  3,  0,  3,  3,  3,  0,  0,  0  // enumeration
-    ,  1,  7,  7, 11,  0,  5,  3,  3,  0,  0,  0  // pointer
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // class
-    ,  1,  2,  2,  2,  0,  2,  2,  2,  0,  0,  0  // function
-    ,  1,  6,  6,  6,  0,  6,  6,  6,  0,  0,  0  // void
-    ,  1, 10, 10,  3,  0,  3,  3, 13,  0,  0,  0  // member pointer
+    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  1  // error
+    ,  1,  4,  4,  3,  0,  3,  3,  3,  0,  0,  3  // arithmetic
+    ,  1, 14,  4,  3,  0,  3,  3,  3,  0,  0,  3  // enumeration
+    ,  1,  7,  7, 11,  0,  5,  3,  3,  0,  0, 16  // pointer
+    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  3  // class
+    ,  1,  2,  2,  2,  0,  2,  2,  2,  0,  0,  3  // function
+    ,  1,  6,  6,  6,  0,  6,  6,  6,  0,  0,  3  // void
+    ,  1, 10, 10,  3,  0,  3,  3, 13,  0,  0, 16  // member pointer
     ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
     ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // nullptr
+    ,  1, 15,  3,  3,  3,  3,  3,  3,  0,  0,  4  // nullptr
     };
 
 //  0 - impossible
@@ -2257,9 +2271,11 @@ static uint_8 staticTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 // 11 - ptr -> ptr
 // 13 - mptr -> mptr
 // 14 - integral -> enum
+// 15 - zero -> nullptr
+// 16 - nullptr -> ptr, mptr
 
 
-PTREE CastStatic                // STATIC_CASTE< TYPE >( EXPR )
+PTREE CastStatic                // STATIC_CAST< TYPE >( EXPR )
     ( PTREE expr )              // - cast expression
 {
     CONVCTL ctl;                // - conversion control
@@ -2288,7 +2304,7 @@ PTREE CastStatic                // STATIC_CASTE< TYPE >( EXPR )
         }
         switch( jump ) {
           case  0 : // impossible
-            DbgVerify( 0, "ReintCast -- bad selection" );
+            DbgVerify( 0, "StaticCast -- bad selection" );
             result = DIAG_IMPOSSIBLE;
             break;
           case  1 : // an operand is error
@@ -2366,13 +2382,27 @@ PTREE CastStatic                // STATIC_CASTE< TYPE >( EXPR )
                 result = CAST_DO_CGCONV;
             }
             break;
+          case 15: // zero -> nullptr
+            if( zeroSrc( &ctl ) ) {
+                result = CAST_ZERO_TO_NULLPTR;
+            }
+            break;
+          case 16: // nullptr -> ptr, mptr
+            result = CAST_NULLPTR_TO_PTR;
+            break;
         }
         break;
     }
     return doCastResult( &ctl, result );
 }
 
-//TODO: fix nullptr values
+
+/**
+ * This table represents the various possible combinations for
+ * dynamic_cast<target operand>(source operand)
+ *
+ * \Return an integer specifying the type of conversion to be performed (or error).
+ */
 static uint_8 dynamicTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
@@ -2385,17 +2415,17 @@ static uint_8 dynamicTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //     r   h   m   r   s   c   d   r   .   r   r
 //                                               target operand
 //                                               --------------
-    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // arithmetic
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // enumeration
-    ,  1,  3,  3,  4,  3,  3,  3,  3,  0,  0,  0  // pointer
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // class
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // function
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // void
-    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  0  // member pointer
+    {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  1  // error
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // arithmetic
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // enumeration
+    ,  1,  3,  3,  4,  3,  3,  3,  3,  0,  0,  3  // pointer
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // class
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // function
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // void
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // member pointer
     ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
     ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // nullptr
+    ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  2  // nullptr
     };
 
 //  0 - impossible
@@ -2405,7 +2435,7 @@ static uint_8 dynamicTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //  4 - ptr->ptr (or ref->ref )
 
 
-PTREE CastDynamic               // DYNAMIC_CASTE< TYPE >( EXPR )
+PTREE CastDynamic               // DYNAMIC_CAST< TYPE >( EXPR )
     ( PTREE expr )              // - cast expression
 {
     CONVCTL ctl;                // - conversion control
@@ -2490,7 +2520,13 @@ PTREE CastDynamic               // DYNAMIC_CASTE< TYPE >( EXPR )
     return doCastResult( &ctl, result );
 }
 
-//TODO: fix nullptr values
+
+/**
+ * This table represents the various possible combinations for
+ * (target operand)(source operand)
+ *
+ * \Return an integer specifying the type of conversion to be performed (or error).
+ */
 static uint_8 explicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
@@ -2506,14 +2542,14 @@ static uint_8 explicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
     {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error
     ,  1, 11, 12,  4,  0,  0,  3,  3,  0,  0,  0  // arithmetic
     ,  1, 12, 12,  4,  0,  0,  3,  3,  0,  0,  0  // enumeration
-    ,  1,  6,  7,  5,  0,  0,  3,  3,  0,  0,  0  // pointer
+    ,  1,  6,  7,  5,  0,  0,  3,  3,  0,  0, 15  // pointer
     ,  1,  0,  0,  0,  0,  0,  3,  0,  0,  0,  0  // class
     ,  1,  2,  2,  2,  0,  2,  2,  2,  0,  0,  0  // function
     ,  1, 13, 13, 13, 13,  0, 13, 13,  0,  0,  0  // void
-    ,  1, 10, 10,  3,  0,  0,  3, 14,  0,  0,  0  // member pointer
+    ,  1, 10, 10,  3,  0,  0,  3, 14,  0,  0, 15  // member pointer
     ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // ellipsis
     ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // generic
-    ,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0  // nullptr
+    ,  1, 16,  3,  3,  3,  3,  3,  3,  0,  0, 12  // nullptr
     };
 
 //  0 - impossible
@@ -2526,13 +2562,15 @@ static uint_8 explicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //  7 - enum -> ptr
 // 10 - zero to memb-ptr
 // 11 - arith -> arith
-// 12 - enum -> arith, arith -> enum, enum->enum
+// 12 - enum -> arith, arith -> enum, enum->enum, nullptr->nullptr
 // 13 - ??? -> void
 // 14 - membptr -> membptr
+// 15 - nullptr -> ptr, mptr
+// 16 - zero -> nullptr
 // 99 - do old conversion for now
 
 
-PTREE CastExplicit              // EXPLICIT CASTE: ( TYPE )( EXPR )
+PTREE CastExplicit              // EXPLICIT CAST: ( TYPE )( EXPR )
     ( PTREE expr )              // - cast expression
 {
     CONVCTL ctl;                // - conversion control
@@ -2636,7 +2674,7 @@ PTREE CastExplicit              // EXPLICIT CASTE: ( TYPE )( EXPR )
     return forceToDestination( &ctl );
 }
 
-//TODO: The nullptr values need to be tuned.
+
 /**
  * This table represents the various possible combinations for implicit conversions between
  * types.
@@ -2658,14 +2696,14 @@ static uint_8 implicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
     {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error
     ,  1, 11, 13,  4,  0,  3,  2,  4,  0,  0,  4  // arithmetic
     ,  1,  7, 12,  3,  0,  3,  2,  3,  0,  0,  1  // enumeration
-    ,  1,  6,  6,  5,  0,  0,  2,  3,  0,  0,  15 // pointer
+    ,  1,  6,  6,  5,  0,  0,  2,  3,  0,  0, 15  // pointer
     ,  1,  0,  0,  0,  0,  0,  2,  0,  0,  0,  1  // class
     ,  1,  3,  3,  3,  0,  3,  2,  3,  0,  0,  1  // function
     ,  1,  2,  2,  2,  2,  2,  2,  2,  0,  0,  1  // void
-    ,  1, 10, 10,  3,  0,  3,  2, 14,  0,  0,  15 // member pointer
+    ,  1, 10, 10,  3,  0,  3,  2, 14,  0,  0, 15  // member pointer
     ,  1,  0,  0,  0,  0,  0,  2,  0,  0,  0,  1  // ellipsis
     ,  1,  0,  0,  0,  0,  0,  2,  0,  0,  0,  1  // generic
-    ,  1, 16,  2,  2,  0,  0,  2,  2,  0,  0,  0  // nullptr
+    ,  1, 16,  2,  2,  0,  0,  2,  2,  0,  0, 17  // nullptr
     };
 
 //  0 - impossible
@@ -2683,6 +2721,7 @@ static uint_8 implicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 // 14 - membptr -> membptr
 // 15 - nullptr -> ptr, membptr
 // 16 - arith -> nullptr (only zero constant is ok)
+// 17 - nullptr -> nullptr
 // 99 - do old conversion for now
 
 
@@ -2815,7 +2854,7 @@ static PTREE doCastImplicit     // DO AN IMPLICIT CAST
         switch( jump ) {
           default :
           case  0 : // impossible
-            DbgVerify( 0, "ExplictCast -- bad selection" );
+            DbgVerify( 0, "ImplicitCast -- bad selection" );
             result = DIAG_IMPOSSIBLE;
             break;
           case  1 : // an operand is error
@@ -2890,6 +2929,9 @@ static PTREE doCastImplicit     // DO AN IMPLICIT CAST
             } else {
                 result = DIAG_CAST_ILLEGAL;
             }
+            break;
+          case 17: // nullptr -> nullptr
+            result = CAST_DO_CGCONV;
             break;
         }
     }

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -1342,6 +1342,11 @@ static PTREE convertToBool          // CONVERT TO BOOL
     ( CONVCTL* ctl )                // - cast info
 {
     stripOffCastOrig( ctl );
+
+    if( ctl->src.kind == RKD_NULLPTR && ctl->clscls_implicit ) {
+        ConvCtlWarning( ctl, WARN_IMPLICIT_NULLPTR_TO_BOOL );
+    }
+
     return NodeConvertToBool( ctl->expr );
 }
 
@@ -2880,11 +2885,10 @@ static PTREE doCastImplicit     // DO AN IMPLICIT CAST
             result = CAST_NULLPTR_TO_PTR;
             break;
           case 16 : // zero -> nullptr
-            result = DIAG_CAST_ILLEGAL;
             if( zeroSrc( &ctl ) ) {
-                if( !ConvCtlWarning( &ctl, WARN_IMPLICIT_NULLPTR_TO_BOOL ) ) {
-                    result = CAST_ZERO_TO_NULLPTR;
-                }
+                result = CAST_ZERO_TO_NULLPTR;
+            } else {
+                result = DIAG_CAST_ILLEGAL;
             }
             break;
         }

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -2605,6 +2605,7 @@ PTREE CastExplicit              // EXPLICIT CASTE: ( TYPE )( EXPR )
     return forceToDestination( &ctl );
 }
 
+//TODO: The nullptr values need to be tuned.
 /**
  * This table represents the various possible combinations for implicit conversions between
  * types.

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -2625,7 +2625,7 @@ static uint_8 implicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //                                               target operand
 //                                               --------------
     {  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  0  // error
-    ,  1, 11, 13,  4,  0,  3,  2,  4,  0,  0,  1  // arithmetic
+    ,  1, 11, 13,  4,  0,  3,  2,  4,  0,  0,  4  // arithmetic
     ,  1,  7, 12,  3,  0,  3,  2,  3,  0,  0,  1  // enumeration
     ,  1,  6,  6,  5,  0,  0,  2,  3,  0,  0,  15 // pointer
     ,  1,  0,  0,  0,  0,  0,  2,  0,  0,  0,  1  // class
@@ -2634,14 +2634,14 @@ static uint_8 implicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
     ,  1, 10, 10,  3,  0,  3,  2, 14,  0,  0,  15 // member pointer
     ,  1,  0,  0,  0,  0,  0,  2,  0,  0,  0,  1  // ellipsis
     ,  1,  0,  0,  0,  0,  0,  2,  0,  0,  0,  1  // generic
-    ,  1,  2,  2,  2,  0,  0,  2,  2,  0,  0,  0  // nullptr
+    ,  1,  6,  2,  2,  0,  0,  2,  2,  0,  0,  0  // nullptr
     };
 
 //  0 - impossible
 //  1 - one operand error ==> reduce to error node
 //  2 - bad explicit-cast type
 //  3 - bad expression for explicit cast
-//  4 - memb-ptr,ptr to arith (only bool is ok)
+//  4 - memb-ptr, ptr, nullptr to arith (only bool is ok)
 //  5 - ptr to ptr
 //  6 - arith, enum -> ptr
 //  7 - arith -> enum

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -2878,6 +2878,7 @@ static PTREE doCastImplicit     // DO AN IMPLICIT CAST
             break;
           case 15 :
             result = CAST_NULLPTR_TO_PTR;
+            break;
           case 16 : // zero -> nullptr
             if( zeroSrc( &ctl ) ) {
                 result = CAST_ZERO_TO_NULLPTR;

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -2880,10 +2880,11 @@ static PTREE doCastImplicit     // DO AN IMPLICIT CAST
             result = CAST_NULLPTR_TO_PTR;
             break;
           case 16 : // zero -> nullptr
+            result = DIAG_CAST_ILLEGAL;
             if( zeroSrc( &ctl ) ) {
-                result = CAST_ZERO_TO_NULLPTR;
-            } else {
-                result = DIAG_CAST_ILLEGAL;
+                if( !ConvCtlWarning( &ctl, WARN_IMPLICIT_NULLPTR_TO_BOOL ) ) {
+                    result = CAST_ZERO_TO_NULLPTR;
+                }
             }
             break;
         }

--- a/bld/plusplus/c/analcast.c
+++ b/bld/plusplus/c/analcast.c
@@ -2605,7 +2605,12 @@ PTREE CastExplicit              // EXPLICIT CASTE: ( TYPE )( EXPR )
     return forceToDestination( &ctl );
 }
 
-
+/**
+ * This table represents the various possible combinations for implicit conversions between
+ * types.
+ *
+ * \Return an integer specifying the type of conversion to be performed (or error).
+ */
 static uint_8 implicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
@@ -2628,7 +2633,7 @@ static uint_8 implicitTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
     ,  1, 10, 10,  3,  0,  3,  2, 14,  0,  0,  15 // member pointer
     ,  1,  0,  0,  0,  0,  0,  2,  0,  0,  0,  1  // ellipsis
     ,  1,  0,  0,  0,  0,  0,  2,  0,  0,  0,  1  // generic
-    ,  1,  0,  0,  0,  0,  0,  2,  0,  0,  0,  1  // nullptr
+    ,  1,  2,  2,  2,  0,  0,  2,  2,  0,  0,  0  // nullptr
     };
 
 //  0 - impossible

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -799,6 +799,22 @@ bool NodeIsZeroIntConstant(     // TEST IF A ZERO INTEGER CONSTANT
     return( retb );
 }
 
+/**
+ * Test if node is nullptr
+ */
+bool NodeIsNullptr( PTREE node )
+{
+    INT_CONSTANT icon;
+
+    if( nodeGetConstant( node, &icon ) ) {
+        if( icon.type->id == TYP_NULLPTR ) {
+            return( true );
+        } 
+    }
+    
+    return( false );
+}
+
 
 PTREE NodeFromConstSym(         // BUILD CONSTANT NODE FROM CONSTANT SYMBOL
     SYMBOL con )                // - constant symbol

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -804,15 +804,11 @@ bool NodeIsZeroIntConstant(     // TEST IF A ZERO INTEGER CONSTANT
  */
 bool NodeIsNullptr( PTREE node )
 {
-    INT_CONSTANT icon;
-
-    if( nodeGetConstant( node, &icon ) ) {
-        if( icon.type->id == TYP_NULLPTR ) {
-            return( true );
-        } 
+    if( node == NULL ) {
+        return( false );
     }
     
-    return( false );
+    return ( node->op == PT_PTR_CONSTANT );
 }
 
 

--- a/bld/plusplus/c/analnode.c
+++ b/bld/plusplus/c/analnode.c
@@ -217,6 +217,7 @@ PTREE NodePruneTop(             // PRUNE TOP OPERAND NODE
           case PT_ERROR :
           case PT_STRING_CONSTANT :
           case PT_INT_CONSTANT :
+          case PT_PTR_CONSTANT :
           case PT_FLOATING_CONSTANT :
           case PT_TYPE :
           case PT_ID :

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -1799,6 +1799,10 @@ static unsigned classify_operand( // CLASSIFY OPERAND AS PTR, ARITH, OTHER
                     retn = OPCL_OTHER;
                 }
                 break;
+              // While nullptr is not a pointer, is should act like so on most occasions.
+              case PT_PTR_CONSTANT :
+                retn = OPCL_PTR;
+                break;
               default :
                 retn = OPCL_OTHER;
                 break;

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -2975,7 +2975,7 @@ start_opac_string:
               &&( 0 != TypeIsBasedPtr( type ) ) ) {
                 continue;
             }
-            if( ! NodeIsZeroIntConstant( right ) ) {
+            if( !( NodeIsZeroIntConstant( right ) || NodeIsNullptr( right ) ) ) {
                 exprError( right, ERR_NOT_PTR_OR_ZERO );
                 break;
             }

--- a/bld/plusplus/c/analyse.c
+++ b/bld/plusplus/c/analyse.c
@@ -1799,9 +1799,10 @@ static unsigned classify_operand( // CLASSIFY OPERAND AS PTR, ARITH, OTHER
                     retn = OPCL_OTHER;
                 }
                 break;
-              // While nullptr is not a pointer, is should act like so on most occasions.
+              // While nullptr is neither a pointer nor an arithmetic type,
+              // it should act like 0 on most occasions.
               case PT_PTR_CONSTANT :
-                retn = OPCL_PTR;
+                retn = OPCL_ARITH;
                 break;
               default :
                 retn = OPCL_OTHER;

--- a/bld/plusplus/c/cgtype.c
+++ b/bld/plusplus/c/cgtype.c
@@ -324,6 +324,11 @@ static target_size_t cgSize(    // COMPUTE SIZE OF A TYPE
       case TYP_LONG_DOUBLE :
         size = TARGET_LONG_DOUBLE;
         break;
+
+      /* sizeof(nullptr) == sizeof(void *) */
+      case TYP_NULLPTR :
+        size = CgDataPtrSize();
+        break;
       case TYP_POINTER :
         if( ( ! ref_as_ptr ) && ( type->flag & TF1_REFERENCE ) ) {
             size = cgSize( type->of, false );

--- a/bld/plusplus/c/dgfront.c
+++ b/bld/plusplus/c/dgfront.c
@@ -106,6 +106,10 @@ static bool DgStoreScalarValue( TYPE type, PTREE expr, target_size_t offset )
         CgFrontDataPtr( IC_DATA_FLT, ConPoolFloatAdd( expr ) );
         retb = ( BFSign( expr->u.floating_constant ) == 0 );
         break;
+    case PT_PTR_CONSTANT:
+        CgFrontDataPtr( IC_DATA_INT, 0 );
+        retb = true;
+        break;
     case PT_INT_CONSTANT:
         if( NULL == Integral64Type( expr->type ) ) {
             CgFrontDataInt( IC_DATA_INT, expr->u.int_constant );
@@ -125,7 +129,7 @@ static bool DgStoreScalarValue( TYPE type, PTREE expr, target_size_t offset )
         CgFrontDataPtr( IC_DATA_PTR_SYM, expr->u.symcg.symbol );
         break;
     default:
-        CFatal( "dgfront.c unexpected pointer data in DgStorePointer" );
+        CFatal( "dgfront.c unexpected pointer data in DgStoreScalarValue" );
         break;
     }
     return( retb );

--- a/bld/plusplus/c/fmttype.c
+++ b/bld/plusplus/c/fmttype.c
@@ -547,6 +547,9 @@ void FormatFunctionType( TYPE type, VBUF *pprefix, VBUF *psuffix, int num_def,
             case TYP_VOID:
                 VbufConcStr( pprefix, typeName[top->type->id] );
                 break;
+            case TYP_NULLPTR:
+                VbufConcStr( pprefix, "decltype(nullptr) " );
+                break;
             case TYP_GENERIC:
                 VbufConcChr( pprefix, '?' );
                 VbufConcDecimal( pprefix, top->type->u.g.index );

--- a/bld/plusplus/c/fnovrank.c
+++ b/bld/plusplus/c/fnovrank.c
@@ -1326,27 +1326,30 @@ static void rankArithEnumToArith(   // RANK: Arith, Enum --> Arith
     }
 }
 
-
+//TODO: fix nullptr values
 static uint_8 rkdTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //      source operand
 //      --------------
-//         a           c           m       g
-//         r   e       l   f   v           e
-//     e   i   n   p   a   u   o   p   .   n
-//     r   t   u   t   s   n   i   t   .   e
-//     r   h   m   r   s   c   d   r   .   r
+//                                             n
+//                                             u
+//         a           c           m       g   l
+//         r   e       l   f   v           e   l
+//     e   i   n   p   a   u   o   p   .   n   p
+//     r   t   u   t   s   n   i   t   .   e   t
+//     r   h   m   r   s   c   d   r   .   r   r
 //                                               target operand
 //                                               --------------
-    {  1,  1,  1,  1,  1,  1,  1,  1,  1,  1  // error
-    ,  1, 10, 10, 14, 12,  1,  1,  0,  2,  0  // arithmetic
-    ,  1,  1,  3,  1, 18,  1,  1,  1,  2,  0  // enumeration
-    ,  1,  7,  7,  8, 17,  5,  1, 19,  2, 19  // pointer
-    ,  1, 16, 16, 15, 11, 16,  1, 15,  2, 15  // class
-    ,  1,  1,  1,  6, 18,  4,  1,  0,  2,  0  // function
-    ,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1  // void
-    ,  1,  7,  7,  1, 17, 19,  1,  9,  2, 19  // member pointer
-    ,  1,  2,  2,  2,  2,  2,  1,  2,  3,  2  // ellipsis
-    ,  1,  0,  0,  0, 18,  0,  1,  0,  2,  0  // generic
+    {  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0  // error
+    ,  1, 10, 10, 14, 12,  1,  1,  0,  2,  0,  0  // arithmetic
+    ,  1,  1,  3,  1, 18,  1,  1,  1,  2,  0,  0  // enumeration
+    ,  1,  7,  7,  8, 17,  5,  1, 19,  2, 19,  0  // pointer
+    ,  1, 16, 16, 15, 11, 16,  1, 15,  2, 15,  0  // class
+    ,  1,  1,  1,  6, 18,  4,  1,  0,  2,  0,  0  // function
+    ,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0  // void
+    ,  1,  7,  7,  1, 17, 19,  1,  9,  2, 19,  0  // member pointer
+    ,  1,  2,  2,  2,  2,  2,  1,  2,  3,  2,  0  // ellipsis
+    ,  1,  0,  0,  0, 18,  0,  1,  0,  2,  0,  0  // generic
+    ,  1,  0,  0,  0, 18,  0,  1,  0,  2,  0,  0  // nullptr
     };
 
 #if 0

--- a/bld/plusplus/c/fnovrank.c
+++ b/bld/plusplus/c/fnovrank.c
@@ -283,7 +283,7 @@ TYPE *CompareWP13332(
     return( better );
 }
 
-static bool fromConstZero( FNOV_CONV *conv )
+static bool fromZeroConstOrNull( FNOV_CONV *conv )
 /******************************************/
 {
     PTREE *pnode;
@@ -294,13 +294,17 @@ static bool fromConstZero( FNOV_CONV *conv )
         return( false );
     }
     node = *pnode;
-    if( node != NULL && NodeIsZeroIntConstant( node ) ) {
-        /* we don't want 0's that are cast to pointer types here */
-        if( IntegralType( conv->wsrc.basic ) ) {
-            conv->rank->rank = OV_RANK_STD_CONV;
-            conv->rank->u.no_ud.standard++;
-            return true;
-        }
+    if( node == NULL ) {
+        return false;
+    }
+
+    if( NodeIsNullptr( node )
+        /* we don't want 0's that are cast to pointer types */
+        || ( NodeIsZeroIntConstant( node ) && IntegralType( conv->wsrc.basic ) ) ) {
+
+        conv->rank->rank = OV_RANK_STD_CONV;
+        conv->rank->u.no_ud.standard++;
+        return true;
     }
     return false;
 }
@@ -552,7 +556,7 @@ static bool toPtrRank( FNOV_CONV *conv )
         tgt_final = conv->wtgt.final;
         // check for NULL to pointer
         if( ( src_basic->id != TYP_POINTER )
-          && fromConstZero( conv ) ) {
+          && fromZeroConstOrNull( conv ) ) {
             retb = true;
         // check for src pointer to void *
         } else if( rankPtrToVoid( conv ) ) {
@@ -595,7 +599,7 @@ static bool toMbrPtrFromMbrPtrRank( FNOV_CONV *conv )
         conv->rank->u.no_ud.not_exact = 1;
         retb = true;
     // check for NULL to member pointer
-    } else if( fromConstZero( conv ) ) {
+    } else if( fromZeroConstOrNull( conv ) ) {
         retb = true;
     // check for src MEMBER FUNCTION to tgt POINTER to MEMBER FUNCTION
     } else {
@@ -628,7 +632,7 @@ static bool toMbrPtrRank( FNOV_CONV *conv )
     tgt_basic = conv->wtgt.basic;
     if( tgt_basic->id == TYP_MEMBER_POINTER ) {
         src_basic = conv->wsrc.basic;
-        if( fromConstZero( conv ) ) {
+        if( fromZeroConstOrNull( conv ) ) {
             retb = true;
         // check for src MEMBER FUNCTION to tgt POINTER to MEMBER FUNCTION
         } else if( src_basic->id == TYP_FUNCTION ) {
@@ -1021,7 +1025,7 @@ static void clstoClsRank( FNOV_CONV *conv )
 static void rankFuncToPtr(          // RANK: FUNCTION --> PTR
     FNOV_CONV *conv )               // - conversion information
 {
-    if( fromConstZero( conv )
+    if( fromZeroConstOrNull( conv )
      || rankPtrToVoid( conv ) ) {
         // all done
     } else if( conv->wtgt.final->id == TYP_FUNCTION ) {
@@ -1090,7 +1094,7 @@ static void rankPtrToPtr(           // RANK: PTR --> PTR
         }
         if( retb )
             return;
-        if( ! fromConstZero( conv )
+        if( ! fromZeroConstOrNull( conv )
          && ! rankPtrToVoid( conv ) ) {
             // if the pointees are the same, okey dokey
             // if the pointees are different, check for class derivations
@@ -1339,41 +1343,18 @@ static uint_8 rkdTable[RKD_MAX][RKD_MAX] = // ranking-combinations table
 //     r   h   m   r   s   c   d   r   .   r   r
 //                                               target operand
 //                                               --------------
-    {  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0  // error
-    ,  1, 10, 10, 14, 12,  1,  1,  0,  2,  0,  0  // arithmetic
-    ,  1,  1,  3,  1, 18,  1,  1,  1,  2,  0,  0  // enumeration
-    ,  1,  7,  7,  8, 17,  5,  1, 19,  2, 19,  0  // pointer
-    ,  1, 16, 16, 15, 11, 16,  1, 15,  2, 15,  0  // class
-    ,  1,  1,  1,  6, 18,  4,  1,  0,  2,  0,  0  // function
-    ,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0  // void
-    ,  1,  7,  7,  1, 17, 19,  1,  9,  2, 19,  0  // member pointer
-    ,  1,  2,  2,  2,  2,  2,  1,  2,  3,  2,  0  // ellipsis
+    {  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1  // error
+    ,  1, 10, 10, 14, 12,  1,  1,  0,  2,  0,  1  // arithmetic
+    ,  1,  1,  3,  1, 18,  1,  1,  1,  2,  0,  1  // enumeration
+    ,  1,  7,  7,  8, 17,  5,  1, 19,  2, 19,  7  // pointer
+    ,  1, 16, 16, 15, 11, 16,  1, 15,  2, 15, 16  // class
+    ,  1,  1,  1,  6, 18,  4,  1,  0,  2,  0,  1  // function
+    ,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1  // void
+    ,  1,  7,  7,  1, 17, 19,  1,  9,  2, 19,  7  // member pointer
+    ,  1,  2,  2,  2,  2,  2,  1,  2,  3,  2,  2  // ellipsis
     ,  1,  0,  0,  0, 18,  0,  1,  0,  2,  0,  0  // generic
-    ,  1,  0,  0,  0, 18,  0,  1,  0,  2,  0,  0  // nullptr
+    ,  1,  7,  1,  1,  1,  1,  1,  1,  1,  0,  7  // nullptr
     };
-
-#if 0
-
-Argument ranking combinations (stl)
-
-//               a                 c                 m           g
-//               r     e           l     f     v                 e
-//         e     i     n     p     a     u     o     p     .     n
-//         r     t     u     t     s     n     i     t     .     e
-//         r     h     m     r     s     c     d     r     .     r
-
-   0:      0     0     0     0     0     0     0     0     0     0
-   1:      0  5282    94  5841 15111  2088     0     0     0     3
-   2:      0     0     0     0     0     0     0     0     0     0
-   3:      0   837     8  5020  4759  1218     0     0     0     0
-   4:      0   301     0  1585 14968     0     0     0     0     0
-   5:      0     0     0     0     0     0     0     0     0     0
-   6:      0     0     0     0     0     0     0     0     0     0
-   7:      0     0     0     2   415     0     0     0     0     0
-   8:      0     0     0     0     0     0     0     0     0     0
-   9:      0    12     0   193   524     0     0     0     0   680
-
-#endif
 
 // values:
 //  0 ==> do a general check
@@ -1383,7 +1364,7 @@ Argument ranking combinations (stl)
 //  4 ==> result determined by functionsIdentical
 //  5 ==> rank func to ptr.
 //  6 ==> rank ptr to func.
-//  7 ==> OV_RANK_NO_MATCH unless src is 0 constant
+//  7 ==> OV_RANK_NO_MATCH unless src is 0 constant or nullptr
 //  8 ==> ptr to ptr
 //  9 ==> m.ptr to m.ptr
 // 10 ==> ( arith, enum ) --> arith
@@ -1440,7 +1421,7 @@ void FNOV_ARG_RANK( TYPE src, TYPE tgt, PTREE *pt, FNOV_RANK *rank )
     rkd_index = rkdTable[ rkd_tgt ][ rkd_src ];
     switch( rkd_index ) {
       case 7 :
-        if( fromConstZero( &conv ) ) return;
+        if( fromZeroConstOrNull( &conv ) ) return;
         // drops thru
       case 1 :
         conv.rank->rank = OV_RANK_NO_MATCH;

--- a/bld/plusplus/c/fold.c
+++ b/bld/plusplus/c/fold.c
@@ -183,13 +183,19 @@ bool Zero64                     // TEST IF 64-BITTER IS ZERO
     return( test->u._32[0] == 0 && test->u._32[1] == 0 );
 }
 
-
-static bool zeroConstant(       // TEST IF NODE IS ZERO CONSTANT
-    PTREE expr )                // - the expression
+/**
+ * Check if node is or evaluates to a zero constant for folding purposes.
+ *
+ * \param expr The expression to be analyzed.
+ */
+static bool zeroConstant( PTREE expr )
 {
     PTREE orig;
 
     switch( expr->op ) {
+    // For boolean folding purposes, nullptr evaluates to zero (false).
+    case PT_PTR_CONSTANT:
+        return( true );
     case PT_INT_CONSTANT:
         if( NULL == Integral64Type( expr->type ) ) {
             return( expr->u.int_constant == 0 );
@@ -209,13 +215,19 @@ static bool zeroConstant(       // TEST IF NODE IS ZERO CONSTANT
     return( false );
 }
 
-
-static bool nonZeroExpr(        // TEST IF NODE IS NON-ZERO EXPRESSION
-    PTREE expr )                // - the expression
+/**
+ * Check if expression evaluates to a non-zero value.
+ *
+ * \param expr The expression to be evaluated.
+ */
+static bool nonZeroExpr( PTREE expr )
 {
     PTREE orig;
 
     switch( expr->op ) {
+    // For boolean folding purposes, nullptr evaluates to zero.
+    case PT_PTR_CONSTANT:
+        return( false );
     case PT_INT_CONSTANT:
     case PT_FLOATING_CONSTANT:
         return ! zeroConstant( expr );

--- a/bld/plusplus/c/icemit.c
+++ b/bld/plusplus/c/icemit.c
@@ -480,6 +480,13 @@ static PTREE emitNode(          // EMIT A PTREE NODE
         PtdGenBefore( expr->decor );
     }
     switch( expr->op ) {
+      // By now, nullptr should effectively equate to zero.
+      // Note that a nullptr node should only reach this point if we are trying
+      // to codegen a decltype(nullptr) variable. Otherwise, the node should
+      // have been converted to the appropriate pointer type.
+      case PT_PTR_CONSTANT:
+        generate_expr_instr( expr, 0, IC_LEAF_CONST_INT );
+        break;
       case PT_INT_CONSTANT:
         if( expr->cgop != CO_IGNORE ) {
             if( NULL == Integral64Type( expr->type ) ) {

--- a/bld/plusplus/c/membptr.c
+++ b/bld/plusplus/c/membptr.c
@@ -896,7 +896,7 @@ static MP_TYPE classifyMpExpr(  // CLASSIFY A MEMBER-POINTER EXPRESSION
                 retn = MP_EXPR;
             }
         }
-    } else if( NodeIsZeroConstant( expr ) ) {
+    } else if( NodeIsZeroConstant( expr ) || NodeIsNullptr( expr ) ) {
         replace = MembPtrZero( TypeGetCache( TYPC_VOID_MEMBER_PTR ) );
         *a_expr = NodeReplaceTop( *a_expr, replace );
         retn = MP_ZERO;

--- a/bld/plusplus/c/ptree.c
+++ b/bld/plusplus/c/ptree.c
@@ -396,6 +396,15 @@ static PTREE allocConstant( uint_8 op, type_id id )
     return new_tree;
 }
 
+/**
+ * Create a nullptr node.
+ */
+PTREE PTreeNullptrConstant( void )
+/******************************/
+{
+    return( PTreeIntConstant( 0, TYP_NULLPTR ) );
+}
+
 
 PTREE PTreeBoolConstant( int v )
 /******************************/

--- a/bld/plusplus/c/ptree.c
+++ b/bld/plusplus/c/ptree.c
@@ -402,7 +402,12 @@ static PTREE allocConstant( uint_8 op, type_id id )
 PTREE PTreeNullptrConstant( void )
 /******************************/
 {
-    return( PTreeIntConstant( 0, TYP_NULLPTR ) );
+    PTREE nullptr_tree;
+
+    nullptr_tree = allocConstant( PT_PTR_CONSTANT, TYP_NULLPTR );
+
+
+    return( nullptr_tree );
 }
 
 

--- a/bld/plusplus/c/ptree.c
+++ b/bld/plusplus/c/ptree.c
@@ -1499,6 +1499,7 @@ static PTREE linker_constant_tree_node( PTREE expr )
         break;
     case PT_TYPE:
         break;
+    case PT_PTR_CONSTANT:
     case PT_STRING_CONSTANT:
     case PT_FLOATING_CONSTANT:
         if( linkerConstantSymbolNode != NULL ) {

--- a/bld/plusplus/c/scope.c
+++ b/bld/plusplus/c/scope.c
@@ -828,6 +828,7 @@ static void scopeInit(          // SCOPES INITIALIZATION
     if( !CompFlags.enable_std0x ) {
         KwDisable( T_STATIC_ASSERT );
         KwDisable( T_DECLTYPE );
+        KwDisable( T_NULLPTR );
     }
     ExtraRptRegisterCtr( &syms_defined, "symbols defined" );
     ExtraRptRegisterCtr( &scopes_alloced, "scopes allocated" );
@@ -858,6 +859,7 @@ static void scopeFini(          // SCOPES COMPLETION
     if( !CompFlags.enable_std0x ) {
         KwEnable( T_STATIC_ASSERT );
         KwEnable( T_DECLTYPE );
+        KwEnable( T_NULLPTR );
     }
     CarveDestroy( carveSYM_REGION );
     CarveDestroy( carveUSING_NS );

--- a/bld/plusplus/c/type.c
+++ b/bld/plusplus/c/type.c
@@ -8368,6 +8368,7 @@ static void initBasicTypes( void )
         TYP_LONG_DOUBLE,
         TYP_VOID,
         TYP_DOT_DOT_DOT,
+        TYP_NULLPTR,
         TYP_MAX
     };
 

--- a/bld/plusplus/c/type.c
+++ b/bld/plusplus/c/type.c
@@ -1843,6 +1843,7 @@ TYPE AlignmentType( TYPE typ )
         case TYP_ARRAY:
             typ = typ->of;
             break;
+        case TYP_NULLPTR:
         case TYP_POINTER:
         case TYP_MEMBER_POINTER:
             return( GetBasicType( TYP_UINT ) );

--- a/bld/plusplus/c/typerank.c
+++ b/bld/plusplus/c/typerank.c
@@ -85,6 +85,13 @@ RKD RkdForTypeId(       // GET RKD FOR TYPE ID
       case TYP_TYPENAME :
         retn = RKD_GENERIC;
         break;
+        
+      /*
+       * N4296: [2.13.7.1] "std::nullptr_t is a distinct type that is neither a pointer type nor a pointer to member type".
+       */
+      case TYP_NULLPTR :
+        retn = RKD_NULLPTR;
+        break;
       DbgDefault( "invalid RKD detected" );
     }
     return retn;

--- a/bld/plusplus/c/yydriver.c
+++ b/bld/plusplus/c/yydriver.c
@@ -959,6 +959,10 @@ static YYTOKENTYPE specialAngleBracket( PARSE_STACK *state, YYTOKENTYPE token )
     return( token );
 }
 
+/**
+ * Generate the tree node for the current token
+ * and return its type as a YYTOKENTYPE.
+ */
 static YYTOKENTYPE yylex( PARSE_STACK *state )
 /********************************************/
 {
@@ -1084,11 +1088,14 @@ static YYTOKENTYPE yylex( PARSE_STACK *state )
         yylval.tree = PTreeBoolConstant( 1 );
         setLocation( yylval.tree, &yylocation );
         break;
-    /* TEST ONLY. REMOVE */
-    case T_NULLPTR:
     case T_FALSE:
         token = Y_FALSE;
         yylval.tree = PTreeBoolConstant( 0 );
+        setLocation( yylval.tree, &yylocation );
+        break;
+    case T_NULLPTR:
+        token = Y_NULLPTR;
+        yylval.tree = PTreeNullptrConstant();
         setLocation( yylval.tree, &yylocation );
         break;
     default:

--- a/bld/plusplus/c/yydriver.c
+++ b/bld/plusplus/c/yydriver.c
@@ -1084,6 +1084,8 @@ static YYTOKENTYPE yylex( PARSE_STACK *state )
         yylval.tree = PTreeBoolConstant( 1 );
         setLocation( yylval.tree, &yylocation );
         break;
+    /* TEST ONLY. REMOVE */
+    case T_NULLPTR:
     case T_FALSE:
         token = Y_FALSE;
         yylval.tree = PTreeBoolConstant( 0 );

--- a/bld/plusplus/gml/messages.gml
+++ b/bld/plusplus/gml/messages.gml
@@ -12214,7 +12214,7 @@ When C++11 is enabled, the
 can no longer appear as a storage specifier.
 
 :MSGSYM. WARN_IMPLICIT_NULLPTR_TO_BOOL
-:MSGTXT. Implicit conversion from 'decltype(nullptr)'' to 'bool'.
+:MSGTXT. Implicit conversion from 'decltype(nullptr)' to 'bool'.
 :MSGJTXT.
 :WARNING. 1
 When C++11 is enabled, an implicit conversion from std::nullptr_t

--- a/bld/plusplus/gml/messages.gml
+++ b/bld/plusplus/gml/messages.gml
@@ -12212,3 +12212,10 @@ since there was no character after it (i.e., "-p#@" ).
 When C++11 is enabled, the
 .kw auto
 can no longer appear as a storage specifier.
+
+:MSGSYM. WARN_IMPLICIT_NULLPTR_TO_BOOL
+:MSGTXT. Implicit conversion from 'decltype(nullptr)'' to 'bool'.
+:MSGJTXT.
+:WARNING. 1
+When C++11 is enabled, an implicit conversion from std::nullptr_t
+to bool is suspicious.

--- a/bld/plusplus/h/cgfront.h
+++ b/bld/plusplus/h/cgfront.h
@@ -1139,6 +1139,9 @@ bool NodeIsZeroConstant(        // TEST IF A ZERO CONSTANT
 bool NodeIsZeroIntConstant(     // TEST IF A ZERO INTEGER CONSTANT
     PTREE node )                // - node
 ;
+bool NodeIsNullptr(             // TEST IF NULLPTR
+    PTREE node )                // - node
+;
 PTREE NodeLvExtract             // EXTRACT LVALUE, IF POSSIBLE
     ( PTREE expr )              // - expression
 ;

--- a/bld/plusplus/h/ic.h
+++ b/bld/plusplus/h/ic.h
@@ -24,8 +24,7 @@
 *
 *  ========================================================================
 *
-* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
-*               DESCRIBE IT HERE!
+* Description:  Definition of X-macros for intermediate code.
 *
 ****************************************************************************/
 

--- a/bld/plusplus/h/ptree.h
+++ b/bld/plusplus/h/ptree.h
@@ -227,6 +227,7 @@ extern PTREE PTreeAssign( PTREE to, PTREE from );
 extern PTREE PTreeAssignReloc( PTREE to, PTREE from, RELOC_LIST *reloc_list );
 extern PTREE PTreeFree( PTREE );
 extern void PTreeFreeSubtrees( PTREE );
+extern PTREE PTreeNullptrConstant( void )
 extern PTREE PTreeBoolConstant( int );
 extern PTREE PTreeIntConstant( int, type_id );
 extern PTREE PTreeInt64Constant( signed_64, type_id );

--- a/bld/plusplus/h/ptree.h
+++ b/bld/plusplus/h/ptree.h
@@ -227,7 +227,7 @@ extern PTREE PTreeAssign( PTREE to, PTREE from );
 extern PTREE PTreeAssignReloc( PTREE to, PTREE from, RELOC_LIST *reloc_list );
 extern PTREE PTreeFree( PTREE );
 extern void PTreeFreeSubtrees( PTREE );
-extern PTREE PTreeNullptrConstant( void )
+extern PTREE PTreeNullptrConstant( void );
 extern PTREE PTreeBoolConstant( int );
 extern PTREE PTreeIntConstant( int, type_id );
 extern PTREE PTreeInt64Constant( signed_64, type_id );

--- a/bld/plusplus/h/ptreeop.h
+++ b/bld/plusplus/h/ptreeop.h
@@ -24,8 +24,8 @@
 *
 *  ========================================================================
 *
-* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
-*               DESCRIBE IT HERE!
+* Description: XMACRO for the various PTREE operators.
+*
 *
 ****************************************************************************/
 
@@ -38,6 +38,7 @@
 {   PTOP( PT_NULL               , PTS_NULL                      )
 ,   PTOP( PT_STRING_CONSTANT    , PTS_NULL                      )
 ,   PTOP( PT_INT_CONSTANT       , PTS_NULL                      )
+,   PTOP( PT_PTR_CONSTANT       , PTS_NULL                      )
 ,   PTOP( PT_FLOATING_CONSTANT  , PTS_NULL                      )
 ,   PTOP( PT_TYPE               , PTS_NULL                      )
 ,   PTOP( PT_ID                 , PTS_NULL                      )

--- a/bld/plusplus/h/symtype.h
+++ b/bld/plusplus/h/symtype.h
@@ -256,6 +256,7 @@ typedef enum {
     TYP_GENERIC         = 0x1c,
     TYP_TYPENAME        = 0x1d,
     TYP_FREE            = 0x1e,
+    TYP_NULLPTR         = 0x1f,
     TYP_MAX,
 
     TYP_FIRST_VALID     = TYP_BOOL,

--- a/bld/plusplus/h/typerank.h
+++ b/bld/plusplus/h/typerank.h
@@ -43,7 +43,8 @@
 , dfnRKD( RKD_VOID      )   \
 , dfnRKD( RKD_MEMBPTR   )   \
 , dfnRKD( RKD_ELLIPSIS  )   \
-, dfnRKD( RKD_GENERIC   )
+, dfnRKD( RKD_GENERIC   )   \
+, dfnRKD( RKD_NULLPTR   )
 
 #define dfnRKD(a) a
 typedef enum                    // RKD -- kind of ranking for a type

--- a/bld/plusplus/hash/plusplus.key
+++ b/bld/plusplus/hash/plusplus.key
@@ -31,6 +31,7 @@ int		TC_A?
 long		TC_A?
 mutable		TC_A?
 namespace	TC_A?
+nullptr 	TC_A? # C++ 0x
 new		TC_A?
 operator	TC_A?
 private		TC_A?

--- a/bld/plusplus/y/plusplus.y
+++ b/bld/plusplus/y/plusplus.y
@@ -142,6 +142,7 @@ Modified        By              Reason
 %token Y_LONG
 %token Y_MUTABLE
 %token Y_NAMESPACE
+%token Y_NULLPTR
 %token Y_NEW
 %token Y_OPERATOR
 %token Y_PRIVATE
@@ -229,6 +230,7 @@ Modified        By              Reason
 %token <tree> Y_TYPE_NAME
 %token <tree> Y_TEMPLATE_NAME
 %token <tree> Y_NAMESPACE_NAME
+%token <tree> Y_NULLPTR
 %token <tree> Y_CONSTANT
 %token <tree> Y_TRUE
 %token <tree> Y_FALSE
@@ -426,6 +428,7 @@ Modified        By              Reason
 
 %type <tree> identifier
 %type <tree> boolean-literal
+%type <tree> pointer-literal
 %type <tree> new-keyword
 %type <tree> delete-keyword
 %type <tree> declarator-id
@@ -710,6 +713,7 @@ literal
     : Y_CONSTANT /* integer-literal character-literal floating-literal */
     | string-literal
     | boolean-literal
+    | pointer-literal
     ;
 
 string-literal
@@ -721,6 +725,10 @@ string-literal
 boolean-literal
     : Y_TRUE
     | Y_FALSE
+    ;
+
+pointer-literal
+    : Y_NULLPTR
     ;
 
 


### PR DESCRIPTION
This patch implements nullptr support in the compiler with the -za0x flag.
There are two main parts to be completed:
->implicit conversions to bool (relies on #341 to be finished)
->function overloading on std::nullptr_t