### PR TITLE
fix heapwalk

### DIFF
--- a/bld/clib/heap/c/heapwalk.c
+++ b/bld/clib/heap/c/heapwalk.c
@@ -114,7 +114,7 @@ int __HeapWalk( struct _heapinfo *entry, __segment seg, __segment one_heap )
             if( frl_next <= frl )
                 return( _HEAPBADNODE );
             frl = frl_next;
-            if( HEAP( seg )->heaplen != 0 && frl->len > HEAP( seg )->heaplen ) {
+            if( HEAP( seg )->heaplen != 0 && (tag)frl > HEAP( seg )->heaplen ) {
                 return( _HEAPBADNODE );
             }
         }


### PR DESCRIPTION
fix for issue https://github.com/open-watcom/open-watcom-v2/issues/356
after [this refactoring](https://github.com/open-watcom/open-watcom-v2/commit/fdfd118c51044a854e39473818857205968f5525#diff-4e91dde9823d0cc23f586c06080d4b45L133) comparison is done with Ien field instead of pointer itself 

