### PR TITLE
Added .count() method to std::map

### DIFF
--- a/bld/hdr/watcom/map.mh
+++ b/bld/hdr/watcom/map.mh
@@ -85,6 +85,11 @@ public:
 
     map& operator=( map const & x ){Implementation::operator=( x ); return( *this );}
 
+    size_type count(const key_type& x) const
+    {
+        return Implementation::find(x) == Implementation::end() ? 0 : 1;
+				}
+
     //element access (not in common with set)
     Type& operator[](Key const &);
 


### PR DESCRIPTION
In accordance with the standard I added a .count method for OW's std::map implementation