### PR TITLE
Fix a buffer overflow in rc

### DIFF
--- a/bld/rc/rc/c/scan2.c
+++ b/bld/rc/rc/c/scan2.c
@@ -185,7 +185,7 @@ static YYTOKENTYPE scanDFA( ScanValue *value )
     VarString           *newstring; /* a new value */
     YYTOKENTYPE         token;
 #ifdef SCANDEBUG
-    char                debugstring[10];
+    char                debugstring[21];
 #endif
     char                *stringFromFile;
     int                 i;

--- a/bld/rc/rc/c/scanw.c
+++ b/bld/rc/rc/c/scanw.c
@@ -185,7 +185,7 @@ static YYTOKENTYPE ScanDFA( ScanValue * value )
     VarString           *newstring; /* a new value */
     YYTOKENTYPE         token;
 #ifdef SCANDEBUG
-    char                debugstring[10];
+    char                debugstring[21];
 #endif
     char                *stringFromFile;
     int                 i;


### PR DESCRIPTION
Increase the debug string length so it can hold the maximum signed long value.

When lexing certain numbers (such as WS_POPUP which is #defined to 0x80000000L), the resulting string gets too big and overflows the debugstring buffer.

Fix this by making the array 21 characters long, which is enough to represent the longest possible 64-bit number (-9223372036854775808), including the null character.

(This fixes the rc crash mentioned in https://github.com/open-watcom/open-watcom-v2/issues/284)