### PR TITLE
Fixed uniutil build error on Unix (including macOS).

### DIFF
--- a/bld/wipfc/Makefile.am
+++ b/bld/wipfc/Makefile.am
@@ -15,7 +15,7 @@ wipfc_SOURCES = cpp/main.cpp cpp/compiler.cpp cpp/document.cpp cpp/env.cpp \
         cpp/hn.cpp cpp/hpn.cpp cpp/i1.cpp cpp/i2.cpp cpp/icmd.cpp cpp/isyn.cpp \
         cpp/lines.cpp cpp/link.cpp cpp/lm.cpp cpp/lp.cpp cpp/note.cpp cpp/nt.cpp \
         cpp/ol.cpp cpp/p.cpp cpp/parml.cpp cpp/pbutton.cpp cpp/rm.cpp cpp/sl.cpp \
-        cpp/table.cpp cpp/title.cpp cpp/ul.cpp cpp/warning.cpp cpp/xmp.cpp
+        cpp/table.cpp cpp/title.cpp cpp/ul.cpp cpp/warning.cpp cpp/xmp.cpp cpp/uniutil.cpp
 noinst_HEADERS = cpp/compiler.hpp cpp/document.hpp cpp/env.hpp cpp/ipfbuff.hpp \
         cpp/ipffile.hpp cpp/lexer.hpp \
         cpp/bitmap.hpp cpp/btmpblk.hpp cpp/cecmd.hpp cpp/cell.hpp cpp/ctrlbtn.hpp \

--- a/bld/wipfc/Makefile.in
+++ b/bld/wipfc/Makefile.in
@@ -73,7 +73,7 @@ am_wipfc_OBJECTS = main.$(OBJEXT) compiler.$(OBJEXT) \
 	lp.$(OBJEXT) note.$(OBJEXT) nt.$(OBJEXT) ol.$(OBJEXT) \
 	p.$(OBJEXT) parml.$(OBJEXT) pbutton.$(OBJEXT) rm.$(OBJEXT) \
 	sl.$(OBJEXT) table.$(OBJEXT) title.$(OBJEXT) ul.$(OBJEXT) \
-	warning.$(OBJEXT) xmp.$(OBJEXT)
+	warning.$(OBJEXT) xmp.$(OBJEXT) uniutil.$(OBJEXT)
 wipfc_OBJECTS = $(am_wipfc_OBJECTS)
 wipfc_LDADD = $(LDADD)
 DEFAULT_INCLUDES = -I.@am__isrc@
@@ -190,7 +190,6 @@ sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
 sysconfdir = @sysconfdir@
 target_alias = @target_alias@
-top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 wipfc_SOURCES = cpp/main.cpp cpp/compiler.cpp cpp/document.cpp cpp/env.cpp \
@@ -208,7 +207,7 @@ wipfc_SOURCES = cpp/main.cpp cpp/compiler.cpp cpp/document.cpp cpp/env.cpp \
         cpp/hn.cpp cpp/hpn.cpp cpp/i1.cpp cpp/i2.cpp cpp/icmd.cpp cpp/isyn.cpp \
         cpp/lines.cpp cpp/link.cpp cpp/lm.cpp cpp/lp.cpp cpp/note.cpp cpp/nt.cpp \
         cpp/ol.cpp cpp/p.cpp cpp/parml.cpp cpp/pbutton.cpp cpp/rm.cpp cpp/sl.cpp \
-        cpp/table.cpp cpp/title.cpp cpp/ul.cpp cpp/warning.cpp cpp/xmp.cpp
+        cpp/table.cpp cpp/title.cpp cpp/ul.cpp cpp/warning.cpp cpp/xmp.cpp cpp/uniutil.cpp
 
 noinst_HEADERS = cpp/compiler.hpp cpp/document.hpp cpp/env.hpp cpp/ipfbuff.hpp \
         cpp/ipffile.hpp cpp/lexer.hpp \
@@ -280,7 +279,7 @@ config.h: stamp-h1
 stamp-h1: $(srcdir)/config.h.in $(top_builddir)/config.status
 	@rm -f stamp-h1
 	cd $(top_builddir) && $(SHELL) ./config.status config.h
-$(srcdir)/config.h.in:  $(am__configure_deps)
+$(srcdir)/config.h.in:  $(am__configure_deps) 
 	cd $(top_srcdir) && $(AUTOHEADER)
 	rm -f stamp-h1
 	touch $@
@@ -310,7 +309,7 @@ uninstall-binPROGRAMS:
 
 clean-binPROGRAMS:
 	-test -z "$(bin_PROGRAMS)" || rm -f $(bin_PROGRAMS)
-wipfc$(EXEEXT): $(wipfc_OBJECTS) $(wipfc_DEPENDENCIES)
+wipfc$(EXEEXT): $(wipfc_OBJECTS) $(wipfc_DEPENDENCIES) 
 	@rm -f wipfc$(EXEEXT)
 	$(CXXLINK) $(wipfc_OBJECTS) $(wipfc_LDADD) $(LIBS)
 
@@ -394,6 +393,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/toc.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/tocref.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ul.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/uniutil.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/warning.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/whtspc.Po@am__quote@
@@ -1534,6 +1534,20 @@ xmp.obj: cpp/xmp.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	source='cpp/xmp.cpp' object='xmp.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o xmp.obj `if test -f 'cpp/xmp.cpp'; then $(CYGPATH_W) 'cpp/xmp.cpp'; else $(CYGPATH_W) '$(srcdir)/cpp/xmp.cpp'; fi`
+
+uniutil.o: cpp/uniutil.cpp
+@am__fastdepCXX_TRUE@	$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT uniutil.o -MD -MP -MF $(DEPDIR)/uniutil.Tpo -c -o uniutil.o `test -f 'cpp/uniutil.cpp' || echo '$(srcdir)/'`cpp/uniutil.cpp
+@am__fastdepCXX_TRUE@	mv -f $(DEPDIR)/uniutil.Tpo $(DEPDIR)/uniutil.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	source='cpp/uniutil.cpp' object='uniutil.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o uniutil.o `test -f 'cpp/uniutil.cpp' || echo '$(srcdir)/'`cpp/uniutil.cpp
+
+uniutil.obj: cpp/uniutil.cpp
+@am__fastdepCXX_TRUE@	$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT uniutil.obj -MD -MP -MF $(DEPDIR)/uniutil.Tpo -c -o uniutil.obj `if test -f 'cpp/uniutil.cpp'; then $(CYGPATH_W) 'cpp/uniutil.cpp'; else $(CYGPATH_W) '$(srcdir)/cpp/uniutil.cpp'; fi`
+@am__fastdepCXX_TRUE@	mv -f $(DEPDIR)/uniutil.Tpo $(DEPDIR)/uniutil.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	source='cpp/uniutil.cpp' object='uniutil.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o uniutil.obj `if test -f 'cpp/uniutil.cpp'; then $(CYGPATH_W) 'cpp/uniutil.cpp'; else $(CYGPATH_W) '$(srcdir)/cpp/uniutil.cpp'; fi`
 install-dist_wipfcDATA: $(dist_wipfc_DATA)
 	@$(NORMAL_INSTALL)
 	test -z "$(wipfcdir)" || $(MKDIR_P) "$(DESTDIR)$(wipfcdir)"

--- a/bld/wipfc/cpp/uniutil.cpp
+++ b/bld/wipfc/cpp/uniutil.cpp
@@ -35,6 +35,7 @@
 #include <string>
 #if defined( __UNIX__ ) || defined( __APPLE__ )
     #include <unistd.h>
+    #include <limits.h>
 #else
     #include <mbctype.h>
 #endif


### PR DESCRIPTION
The build was failing on macOS (and probably other Unixes) because the new file had not been added to the makefile. I added it and re-ran automake to generate the `Makefile.in` (which also removed `top_build_prefix`, I'm not sure why - I guess it's no longer used?).

I also had to include `limits.h` for MB_LEN_MAX.