### PR TITLE
Fixed bug where dosbox would fail to run due to path not being expanded.

### DIFF
--- a/build/mif/wgmlcmd.mif
+++ b/build/mif/wgmlcmd.mif
@@ -61,24 +61,24 @@ use_dosemu = dosemu
 
 !else ifeq bld_os bsd
 
-WGMLCMD = dosbox -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e $(src_dir)" -c "d:$(dosemu_wgml_batch)" -noconsole
-GENDEVCMD = dosbox -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e .." -c "d:$(dosemu_gendev_batch)" -noconsole
+WGMLCMD = $(dosbox) -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e $(src_dir)" -c "d:$(dosemu_wgml_batch)" -noconsole
+GENDEVCMD = $(dosbox) -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e .." -c "d:$(dosemu_gendev_batch)" -noconsole
 use_dosemu = dosbox
 # only DOSBOX use upper cased file name
 wgml_ucase=1
 
 !else ifeq bld_os haiku
 
-WGMLCMD = dosbox -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e $(src_dir)" -c "d:$(dosemu_wgml_batch)" -noconsole
-GENDEVCMD = dosbox -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e .." -c "d:$(dosemu_gendev_batch)" -noconsole
+WGMLCMD = $(dosbox) -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e $(src_dir)" -c "d:$(dosemu_wgml_batch)" -noconsole
+GENDEVCMD = $(dosbox) -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e .." -c "d:$(dosemu_gendev_batch)" -noconsole
 use_dosemu = dosbox
 # only DOSBOX use upper cased file name
 wgml_ucase=1
 
 !else ifeq bld_os osx
 
-WGMLCMD = dosbox -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e $(src_dir)" -c "d:$(dosemu_wgml_batch)" -noconsole
-GENDEVCMD = dosbox -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e .." -c "d:$(dosemu_gendev_batch)" -noconsole
+WGMLCMD = $(dosbox) -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e $(src_dir)" -c "d:$(dosemu_wgml_batch)" -noconsole
+GENDEVCMD = $(dosbox) -noautoexec -c "mount c $(docs_dir)" -c "mount d ." -c "mount e .." -c "d:$(dosemu_gendev_batch)" -noconsole
 use_dosemu = dosbox
 # only DOSBOX use upper cased file name
 wgml_ucase=1


### PR DESCRIPTION
dosbox was failing on macOS (and probably haiku and bsd) unless the dosbox binary was in the current path. This was due to the macro not being expanded in the build file.