### PR TITLE
Fixes to get OSX build working

### DIFF
--- a/bld/cg/intel/i86/osxx64/makefile
+++ b/bld/cg/intel/i86/osxx64/makefile
@@ -1,6 +1,6 @@
 #pmake: build target_i86 i86 intel os_osx cpu_x64
 
-host_os  = linux
+host_os  = osx
 host_cpu = x64
 
 !include ../mif/master.mif

--- a/bld/ncurses/master.mif
+++ b/bld/ncurses/master.mif
@@ -6,6 +6,11 @@ ncurses_autodepends = .AUTODEPEND
 !include defrule.mif
 !include deftarg.mif
 
+!ifeq host_os osx
+# To work around duplicate inlined symbols, e.g. __sputc
+c_flags += -std=gnu89
+!endif
+
 .c: ../c
 
 ncurses_objs = &

--- a/bld/plusplus/master.mif
+++ b/bld/plusplus/master.mif
@@ -101,10 +101,12 @@ extra_c_flags_maindrv  = -Dwpp_drv -DDLL_NAME=$(dllname)
 
 !ifndef bootstrap
 !ifneq host_os linux
+!ifneq host_os osx
 # Using -os generates ENTER/LEAVE and Linux is too brain damaged
 # to handle ENTER instructions properly. Since GCC doesn't generate
 # ENTER, this is supposed to be a "feature".
 extra_c_flags_cmdlnany = -os
+!endif
 !endif
 extra_c_flags_cscan_386 = -4r
 extra_c_flags_cscan    = $(extra_c_flags_cscan_$(host_cpu))

--- a/bld/setupgui/c/setupinf.c
+++ b/bld/setupgui/c/setupinf.c
@@ -33,7 +33,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#if !defined(__OSX__)
 #include <malloc.h>
+#endif
 #include <stdarg.h>
 #include <ctype.h>
 #ifdef __UNIX__

--- a/bld/setupgui/c/utils.c
+++ b/bld/setupgui/c/utils.c
@@ -33,7 +33,9 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#if !defined(__OSX__)
 #include <malloc.h>
+#endif
 #include <ctype.h>
 #include <setjmp.h>
 #include <limits.h>

--- a/bld/setupgui/master.mif
+++ b/bld/setupgui/master.mif
@@ -54,9 +54,9 @@ objs +=             &
     dopatch.obj
 !endif
 
-#                     i_dos i_linux i_nt i_os2 i_win i_wini86 i_win386
-#=====================================================================
-!inject setupio.obj   i_dos i_linux i_nt i_os2                i_win386
+#                     i_dos i_linux i_nt i_os2 i_win i_wini86 i_win386 i_osx
+#===========================================================================
+!inject setupio.obj   i_dos i_linux i_nt i_os2                i_win386 i_osx
 !inject setupiod.obj                                 i_wini86
 !inject os2util.obj                      i_os2
 !inject winutil.obj                 i_nt i_os2 i_win
@@ -78,6 +78,7 @@ objs += loadfind.obj
 
 libs_dos   = $(gui_lib) $(ui_lib) $(wres_lib)
 libs_linux = $(gui_lib) $(ui_lib) $(wres_lib)
+libs_osx   = $(gui_lib) $(ui_lib) $(wres_lib)
 libs_nt    = $(gui_lib) $(ui_lib) $(wres_lib)
 libs_os2   = $(gui_lib) $(ui_lib) $(wres_lib)
 
@@ -85,12 +86,14 @@ libs_os2   = $(gui_lib) $(ui_lib) $(wres_lib)
 
 libs_dos    += ../ziplib/osi386/ziplib.lib
 libs_linux  += ../ziplib/linux$(host_cpu)/ziplib.lib
+libs_osx    += ../ziplib/osx$(host_cpu)/ziplib.lib
 libs_nt     += ../ziplib/osi$(host_cpu)/ziplib.lib
 libs_os2    += ../ziplib/osi386/ziplib.lib
 libs_win386 += ../ziplib/osi386/ziplib.lib
 
 libs_dos    += ../zlib/osi386/zlib.lib
 libs_linux  += ../zlib/osi$(host_cpu)/zlib.lib
+libs_osx    += ../zlib/osi$(host_cpu)/zlib.lib
 libs_nt     += ../zlib/osi$(host_cpu)/zlib.lib
 libs_os2    += ../zlib/osi386/zlib.lib
 libs_win386 += ../zlib/osi386/zlib.lib
@@ -149,6 +152,8 @@ dep_res1 = ../h/setup.h gui.rc
 !else ifeq host_os dos
 dep_res1 = ../h/setup.h gui.rc
 !else ifeq host_os linux
+dep_res1 = ../h/setup.h gui.rc
+!else ifeq host_os osx
 dep_res1 = ../h/setup.h gui.rc
 !else
 dep_res1 = ../h/setup.h setup.ico disk.ico gui.rc

--- a/bld/vi/c/fcbdmp.c
+++ b/bld/vi/c/fcbdmp.c
@@ -32,7 +32,9 @@
 
 #include "vi.h"
 #include "win.h"
+#if !defined(__OSX__)
 #include <malloc.h>
+#endif
 
 #if !defined( NDEBUG ) && !defined( __WIN__ )
 

--- a/bld/vi/ctags/taglist.c
+++ b/bld/vi/ctags/taglist.c
@@ -34,7 +34,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#if !defined(__OSX__)
 #include <malloc.h>
+#endif
 #include "ctags.h"
 
 #define isWSorCtrlZ(x)  (isspace( x ) || (x == 0x1A))

--- a/bld/wl/exe2bin/osxx64/makefile
+++ b/bld/wl/exe2bin/osxx64/makefile
@@ -1,6 +1,6 @@
 #pmake: build os_osx cpu_x64
 
-host_os  = linux
+host_os  = osx
 host_cpu = x64
 
 !include ../master.mif

--- a/bld/wl/fcenable/c/fcenable.c
+++ b/bld/wl/fcenable/c/fcenable.c
@@ -33,7 +33,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#if !defined(__OSX__)
 #include <malloc.h>
+#endif
 #include <setjmp.h>
 #if defined( __WATCOMC__ ) || !defined( __UNIX__ )
 #include <process.h>

--- a/bld/wl/fcenable/c/mem.c
+++ b/bld/wl/fcenable/c/mem.c
@@ -30,7 +30,9 @@
 
 
 #include <stdlib.h>
+#if !defined(__OSX__)
 #include <malloc.h>
+#endif
 #include "fcenable.h"
 
 #ifdef TRMEM

--- a/bld/wl/ms2wlink/c/keyword.c
+++ b/bld/wl/ms2wlink/c/keyword.c
@@ -32,7 +32,9 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
+#if !defined(__OSX__)
 #include <malloc.h>
+#endif
 #include "ms2wlink.h"
 #include "command.h"
 

--- a/bld/wl/ms2wlink/c/parsems.c
+++ b/bld/wl/ms2wlink/c/parsems.c
@@ -31,7 +31,9 @@
 
 #include <string.h>
 #include <ctype.h>
+#if !defined(__OSX__)
 #include <malloc.h>
+#endif
 #if defined( __WATCOMC__ ) || !defined( __UNIX__ )
 #include <process.h>
 #endif

--- a/bld/wl/ms2wlink/c/utils.c
+++ b/bld/wl/ms2wlink/c/utils.c
@@ -30,7 +30,9 @@
 
 #include <stdlib.h>
 #include <string.h>
+#if !defined(__OSX__)
 #include <malloc.h>
+#endif
 #include <setjmp.h>
 #include "wio.h"
 #include "ms2wlink.h"

--- a/bld/wtouch/touch.c
+++ b/bld/wtouch/touch.c
@@ -463,7 +463,7 @@ static void doTouch( void )
         }
         _splitpath2( item, sp_buf, &drive, &dir, NULL, NULL );
         number_of_successful_touches = 0;
-#ifdef __LINUX__
+#if defined(__LINUX__) || defined(__OSX__)
         strcpy( full_name, item );
         ndir = NULL;
         number_of_successful_touches += doTouchFile( full_name, ndir, &stamp );


### PR DESCRIPTION
* `malloc.h` was being included in various files but it doesn't exist on OSX. `stdlib.h` should be included for `malloc` and `free` etc, but in Watcom I believe `malloc.h` is required so I've #ifdeffed this out for OSX.

* There was an issue building `ncurses` - I was getting duplicate symbols (`__sputc` and others). It seems to be similar to [this](https://bugzilla.mozilla.org/show_bug.cgi?format=default&id=917526) issue. It's not completely clear what's going on here but using `-std=gnu89` fixes the issue.

The other fixes are all just small things where on OSX it's using similar settings to Linux.