### PR TITLE
bld/wasm/c/direct.c: missing proto for func heap

### DIFF
--- a/bld/wasm/c/direct.c
+++ b/bld/wasm/c/direct.c
@@ -424,6 +424,7 @@ static bool get_watcom_argument_string( char *buffer, int size, int *parm_number
 }
 
 #ifdef DEBUG_OUT
+void heap( char *func ) ;
 void heap( char *func ) // for debugging only
 /*********************/
 {


### PR DESCRIPTION
defined only if debug flag set