### PR TITLE
comment out debugging code in wv that won't compile

### DIFF
--- a/bld/wv/c/dbgwintr.c
+++ b/bld/wv/c/dbgwintr.c
@@ -31,6 +31,10 @@
 
 
 #ifndef NDEBUG
+
+#if defined( NEVERdEFINED )
+//20181107@1523-WOI: COMMENTED OUT TO GET CLEAN COMPILE WHEN DEBUG=1.  NONE OF THIS STUFF WILL COMPILE, AND IT IS CLEARLY NOT NEEDED FOR PRODUCTION SINCE IT IS ONLY DEFINED WHEN DEBUG=1
+
 #include <ctype.h>
 #include "dbgdefn.h"
 #include "dbgdata.h"
@@ -178,5 +182,7 @@ void ProcInternal( void )
         InternalJmpTab[cmd]();
     }
 }
+
+#endif
 
 #endif

--- a/bld/wv/h/_dbgcmd.h
+++ b/bld/wv/h/_dbgcmd.h
@@ -68,6 +68,10 @@ pick(   CMD_SKIP,       ProcSkip,        "SKip\0" )
 pick(   CMD_RECORD,     ProcRecord,      "RECord\0" )
 pick(   CMD_ASSIGN,     ProcAssign,      "ASsign\0" )
 pick(   CMD_MODIFY,     ProcModify,      "MOdify\0" )
+
+#if defined( NEVERdEFINED )
+//20181107@1547-WOI: COMMENTED THIS OUT TO GET CLEAN BUILD OF wv WHEN DEBUG=1
 #ifndef NDEBUG
 pick(   CMD_INTERNAL,   ProcInternal,    "XX\0" )
+#endif
 #endif


### PR DESCRIPTION
The code that is now commented out unconditionally was previously commented out unless debug=1.  It won't compile.  With these changes, wv can be built using "builder build OWDEBUGBUILD=1".

Testing:  I can now run wdw wdw [program] and step into debugger code.
Regression testing:  After building with debug=0, I released to my IPDOS (tm) craftwork environment and used it to do a full build of IPDOS and to then test that build by running it in production.