### PR TITLE
Fix issue with trap file loader used in dos version of wd

### DIFF
--- a/bld/dig/c/dsx/trpld.c
+++ b/bld/dig/c/dsx/trpld.c
@@ -411,7 +411,7 @@ static char *ReadInTrap( FILE *fp )
         return( TC_ERR_OUT_OF_DOS_MEMORY );
     }
     DIGLoader( Seek )( fp, hdrsize, DIG_ORG );
-    if( DIGLoader( Read )( fp, (void *)DPMIGetSegmentBaseAddress( TrapMem.pm ), imagesize ) != imagesize ) {
+    if( DIGLoader( Read )( fp, (void *)DPMIGetSegmentBaseAddress( TrapMem.pm ), imagesize )) {
         return( TC_ERR_CANT_LOAD_TRAP );
     }
     DIGLoader( Seek )( fp, hdr.reloc_offset, DIG_ORG );


### PR DESCRIPTION
The DIGLoader( Read ) function is already checking the size of
the read bytes and returning true or false. Comparing the return
value with imagesize will fail even if the file was loaded correctly.