### PR TITLE
Include the *.cnv files in the wipfc rel target

### DIFF
--- a/bld/wipfc/builder.ctl
+++ b/bld/wipfc/builder.ctl
@@ -29,6 +29,7 @@ set PROJDIR=<CWD>
 #============================
     <CPCMD> helper/*.nls          <OWRELROOT>/wipfc/
     <CPCMD> helper/*.txt          <OWRELROOT>/wipfc/
+    <CPCMD> helper/*.cnv          <OWRELROOT>/wipfc/
 
     <CCCMD> dos386/wipfc.exe      <OWRELROOT>/binw/
     <CCCMD> os2386/wipfc.exe      <OWRELROOT>/binp/


### PR DESCRIPTION
The *.cnv files used by wipfc were not being copied to rel directory by the rel target.