### PR TITLE
Fixes a bug where PATH variables were not quoted.

### DIFF
--- a/cmnvars.sh
+++ b/cmnvars.sh
@@ -28,11 +28,11 @@ export OWDISTRDIR=$OWROOT/distrib
 # Set environment variables
 # Set up default path information variable
 if [ -z "$OWDEFPATH" ]; then
-    export OWDEFPATH=$PATH:
+    export OWDEFPATH="$PATH":
     if [ -n "$INCLUDE" ]; then export OWDEFINCLUDE=$INCLUDE; fi
     if [ -n "$WATCOM" ]; then export OWDEFWATCOM=$WATCOM; fi
 fi
-export PATH=$OWBINDIR:$OWROOT/build:$OWDEFPATH
+export PATH="$OWBINDIR:$OWROOT/build:$OWDEFPATH"
 if [ -n "$OWDEFINCLUDE" ]; then export INCLUDE=$OWDEFINCLUDE; fi
 if [ -n "$OWDEFWATCOM" ]; then export WATCOM=$OWDEFWATCOM; fi
 


### PR DESCRIPTION
PATH variables weren't quoted properly, which caused the build scripts to fail when e.g. PATH contains a space. This typically does not occur on Linux, however, WSL tends to export Windows environment variables as well, introducing spaces.

This PR fixes this issue.