### PR TITLE
Autodetect appropriate toolchain

### DIFF
--- a/setvars.sh
+++ b/setvars.sh
@@ -15,9 +15,22 @@
 
 export OWROOT=$(realpath `pwd`)
 
-# Set this entry to identify your toolchain used by build process
-# supported values are WATCOM GCC CLANG
-export OWTOOLS=GCC
+# Automatically try to determine appropriate toolchain
+
+case `uname` in
+	FreeBSD)
+		# FreeBSD does not ship with GCC anymore by default so needs clang
+		export OWTOOLS=CLANG
+		;;
+	Darwin)
+		# Darwin/macOS does not ship with GCC anymore so needs clang.
+		export OWTOOLS=CLANG
+		;;
+	*)
+		export OWTOOLS=GCC
+		;;
+esac
+
 
 # Build control related variables
 ##################################


### PR DESCRIPTION
The Unix-based build script assumes GCC to build Open Watcom. However,
some operating systems (notably FreeBSD and Darwin/macOS) do not ship
with GCC anymore, resulting in the build failing.

This commit adds a rudimentary form of auto-detection based on the
host's `uname` value to determine a suitable default toolchain.