### PR TITLE
fix `'#pragma' is not recognized...` error when using `setvars.bat`

### DIFF
--- a/cmnvars.bat
+++ b/cmnvars.bat
@@ -59,7 +59,8 @@ goto toolsver
 :no_intel
 :toolsver
 if not exist getversi.bat goto no_toolsver
-call getversi.bat
+if not "%OS%" == "Windows_NT" call getversi.bat
+if "%OS%" == "Windows_NT" for /f "tokens=1,*" %%G in (getversi.bat) do if /i "%%G"=="set" set %%H
 del getversi.*
 :no_toolsver
 


### PR DESCRIPTION
Using `setvars.bat` causes spurious warning/error text when using OpenWatcom as compiler/host for builds...

```shell
C:>setvars.bat
'#pragma' is not recognized as an internal or external command,
operable program or batch file.
'#pragma' is not recognized as an internal or external command,
operable program or batch file.
Open Watcom build environment (WATCOM version=1300, CYEAR=2020)
```

This commit fixes that by only executing the "set ..." lines within 'getversi.bat' (though only on Windows NT+ machines).
