### PR TITLE
Do not parse AR environment variable when wlib is in ar mode

### DIFF
--- a/bld/nwlib/c/cmdline.c
+++ b/bld/nwlib/c/cmdline.c
@@ -700,7 +700,7 @@ void ProcessCmdLine( char *argv[] )
         Options.ar = true;
     }
     if( Options.ar ) {
-        env = WlibGetEnv( "AR" );
+        env = NULL;
     } else {
         env = WlibGetEnv( "WLIB" );
     }


### PR DESCRIPTION
Remove a single request for the AR environment variable in wlib because it is commonly used in Makefiles as the command to call "ar" as opposed to a method for passing arguments.