### PR TITLE
Support wlib's ar mode when the executable is named 'owar'

### DIFF
--- a/bld/nwlib/c/cmdline.c
+++ b/bld/nwlib/c/cmdline.c
@@ -41,10 +41,6 @@
 #include "clibint.h"
 #endif
 
-
-#define AR_MODE_ENV  "WLIB$AR"
-#define AR_MODE_ENV2 "WLIB_AR"
-
 #define eatwhite( c ) while( *(c) != '\0' && isspace( *(unsigned char *)(c) ) ) ++(c);
 #define notwhite( c ) ( (c) != '\0' && !isspace( (unsigned char)(c) ) )
 
@@ -695,12 +691,12 @@ void ProcessCmdLine( char *argv[] )
     operation   ar_mode;
 
     fname = MakeFName( _cmdname( buffer ) );
-    if( FNCMP( fname, "ar" ) == 0 || WlibGetEnv( AR_MODE_ENV ) != NULL ||
+    if( FNCMP( fname, WLIB_AR_MODE_FN ) == 0 || WlibGetEnv( AR_MODE_ENV ) != NULL ||
         WlibGetEnv( AR_MODE_ENV2 ) != NULL ) {
         Options.ar = true;
     }
     if( Options.ar ) {
-        env = WlibGetEnv( "AR" );
+        env = WlibGetEnv( "OWAR" );
     } else {
         env = WlibGetEnv( "WLIB" );
     }

--- a/bld/nwlib/c/ideentry.c
+++ b/bld/nwlib/c/ideentry.c
@@ -248,7 +248,7 @@ void Usage( void )
         MsgGet( str++, buff );
         if( Options.ar ) {
             str_last = MSG_USAGE_AR_BASE + MSG_USAGE_AR_COUNT;
-            ConsoleMessage( buff, "ar" );
+            ConsoleMessage( buff, WLIB_AR_MODE_FN );
         } else {
             str_last = MSG_USAGE_WLIB_BASE + MSG_USAGE_WLIB_COUNT;
 #ifdef BOOTSTRAP

--- a/bld/nwlib/c/maindrv.c
+++ b/bld/nwlib/c/maindrv.c
@@ -44,8 +44,8 @@
 #include "clibext.h"
 #include "clibint.h"
 
-
-#define AR_MODE_ENV "WLIB$AR"
+/* Needed for environment variable def'n */
+#include "wlibar.h"
 
 #ifndef DLL_NAME
   #error DLL_NAME must be given with -d switch when DLL Driver
@@ -86,8 +86,8 @@ int main( int argc, char *argv[] )  // MAIN-LINE FOR DLL DRIVER
     } else {
         ++p;
     }
-    if( stricmp( p, "ar.exe" ) == 0 ) {
-        putenv( AR_MODE_ENV "=ON" );
+    if( stricmp( p, WLIB_AR_MODE_FN ".exe" ) == 0 ) {
+        putenv( AR_MODE_ENV2 "=ON" );
     }
     retcode = IdeDrvExecDLL( &info, cmd_line );
     free( cmd_line );

--- a/bld/nwlib/h/wlib.h
+++ b/bld/nwlib/h/wlib.h
@@ -72,6 +72,7 @@
 #include "exeflat.h"
 #include "exepe.h"
 #include "exenov.h"
+#include "wlibar.h"
 
 #define Round(x,s)      (((x) + (s) - 1) & ~((s) - 1))
 #define Round2(x)       Round((x),2)

--- a/bld/nwlib/h/wlibar.h
+++ b/bld/nwlib/h/wlibar.h
@@ -2,7 +2,7 @@
 *
 *                            Open Watcom Project
 *
-*    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
+* Copyright (c) 2020 The Open Watcom Contributors. All Rights Reserved.
 *
 *  ========================================================================
 *
@@ -24,14 +24,11 @@
 *
 *  ========================================================================
 *
-* Description:  Library manager command line processing.
+* Description:  Librarian constants for enabling POSIX ar compatability.
 *
 ****************************************************************************/
 
-extern void InitCmdLine( void );
-extern void ProcessCmdLine( char *argv[] );
-extern void FiniCmdLine( void );
+#define AR_MODE_ENV  "WLIB$AR"
+#define AR_MODE_ENV2 "WLIB_AR"
 
-extern lib_cmd      *CmdList;
-extern options_def  Options;
-
+#define WLIB_AR_MODE_FN "owar"


### PR DESCRIPTION
To work similar to *owcc*, the librarian will now switch to ar (POSIX) mode when the filename is *owar*.  The librarian will read options from the environment variable *OWAR* when in this mode, effectively fixing #631 while maintaining consistency with other tools.

Additionally, ar mode will be properly enabled even when the librarian is named *owar.exe*.

The name *owar* has been placed in a new header that also contains consistent environment variable definitions.