### PR TITLE
Actually Implemented -mstack-size Flag in owcc

### DIFF
--- a/bld/wcl/c/owcc.c
+++ b/bld/wcl/c/owcc.c
@@ -855,6 +855,11 @@ static  int  ParseArgs( int argc, char **argv )
                 wcc_option = 0;
                 break;
             }
+            if( strncmp( "stack-size=", Word, 11) == 0 ) {
+                MemFree( StackSize );
+                StackSize = MemStrDup( Word + 11 );
+                wcc_option = 0;
+            }
             wcc_option = 0;     /* dont' pass on unknown options */
             break;
         case 'z':


### PR DESCRIPTION
The documentation and command-line help both say that the flag *-mstack-size* should work for the *owcc* POSIX wrapper.  However, it doesn't appear to have ever been implemented.  This small change adds support for the flag as the documentation and command-line help both say it should.
