### PR TITLE
cc: Fix a parsing bug related to misuse of a typedef

### DIFF
--- a/bld/cc/c/cexpr.c
+++ b/bld/cc/c/cexpr.c
@@ -415,6 +415,7 @@ static TREEPTR SymLeaf( void )
             }
             if( sym.attribs.stg_class == SC_TYPEDEF ) {
                 CErr2p( ERR_CANT_USE_TYPEDEF_AS_VAR, Buffer );
+                NextToken();
                 return( IntLeaf( 0 ) );
             }
         }


### PR DESCRIPTION
In SymLeaf() if we have a symbol that happens to be a typedef, SymLeaf()
fails to grab the next token. Thus, upon return to Statement(), the
compiler gets stuck in an infinite loop hoping for T_RIGHT_PAREN to
magically transform into T_SEMI_COLON.