### PR TITLE
cc: Convert function designators when they're operands of sizeof

### DIFF
--- a/bld/cc/c/cexpr.c
+++ b/bld/cc/c/cexpr.c
@@ -1318,8 +1318,13 @@ static TREEPTR GetExpr( void )
                 break;
             case TC_SIZEOF:
                 typ = tree->u.expr_type;
-                FreeExprTree( tree );
-                if( typ != NULL ) {
+                if (typ && typ->decl_type == TYPE_FUNCTION) {
+                    tree = AddrOp(tree);
+                    typ = tree->u.expr_type;
+                }
+
+                FreeExprTree(tree);
+                if (typ) {
                     tree = SizeofOp( typ );
                 } else {
                     tree = UIntLeaf( 1 ); //error use this as default


### PR DESCRIPTION
ANSI C §3.2.2.1 requires that function designators be converted to
an expression of type ``pointer to function returning type`` when a
function designator is an operand of sizeof (or unary &.)