### PR TITLE
cc: Fix a parsing bug in IndexOp()

### DIFF
--- a/bld/cc/c/cexpr.c
+++ b/bld/cc/c/cexpr.c
@@ -1800,8 +1800,9 @@ static TREEPTR IndexOp( TREEPTR tree, TREEPTR index_expr )
 {
     TYPEPTR     typ;
 
-    if( tree->op.opr == OPR_ERROR )
-        return( tree );
+    if (tree->op.opr == OPR_ERROR)
+        goto ret;
+
     typ = tree->u.expr_type;
     SKIP_TYPEDEFS( typ );
     if( typ->decl_type == TYPE_ARRAY ) {
@@ -1821,6 +1822,8 @@ static TREEPTR IndexOp( TREEPTR tree, TREEPTR index_expr )
             tree = ErrorNode( tree );
         }
     }
+
+ret:
     MustRecog( T_RIGHT_BRACKET );
     return( tree );
 }


### PR DESCRIPTION
IndexOp() was not consuming T_RIGHT_BRACKET when given a tree rooted in
an error node, thus causing the compiler to spin.