### PR TITLE
cc: Fix a bug when a block has 'else' without 'if'

### DIFF
--- a/bld/cc/c/cstmt.c
+++ b/bld/cc/c/cstmt.c
@@ -626,6 +626,12 @@ static void ElseStmt( void )
 
     SrcLoc = TokenLoc;
     NextToken();
+
+    if (BlockStack->block_type != T_IF) {
+        CErr1(ERR_ELSE_WITHOUT_IF);
+        return;
+    }
+
     BlockStack->block_type = T_ELSE;
     if_label = BlockStack->break_label;
     if( DeadCode == 0 ) {
@@ -1253,6 +1259,9 @@ void Statement( void )
                 break;
             }
             declaration_allowed = false;
+            continue;
+        case T_ELSE:
+            ElseStmt();
             continue;
         case T_WHILE:
             NewLoop();

--- a/bld/cc/gml/cerrs.gml
+++ b/bld/cc/gml/cerrs.gml
@@ -2195,6 +2195,15 @@ void foo( int a )
 }
 .eerrbad
 .
+:MSGSYM. ERR_ELSE_WITHOUT_IF
+:MSGTXT. 'else' without 'if'
+:MSGJTXT. 「else」に「if」がありません
+.np
+The
+.kw else
+must follow
+.kw if
+.
 :eMSGGRP. Errs
 :cmt -------------------------------------------------------------------
 :MSGGRP. Info


### PR DESCRIPTION
Statement() didn't check for T_ELSE, thus it spins looking for
T_SEMI_COLON, never reaching the end of the statement.