### PR TITLE
fix including both time.h and sys/time.h for os/2

### DIFF
--- a/bld/hdr/deps.mif
+++ b/bld/hdr/deps.mif
@@ -316,7 +316,6 @@ sys/socket.h    : sys/socket.mh $(owhdr) $(cplus) $(packlnxk) ../incdir.sp ../un
 
 sys/_lfndos.h   : dos/sys/_lfndos.mh $(owhdrcnt)
 sys/stat.h      : sys/stat.mh $(sys_stat_deps)
-sys/time.h      : sys/time.mh $(sys_time_deps)
 
 !else ifeq system linux
 

--- a/bld/hdr/files.dat
+++ b/bld/hdr/files.dat
@@ -75,7 +75,6 @@ usr="wsample.h"
 [ DEFAULT type="s" dir="h/sys" where="c jc f77 jf77 ac" cond="dostarg wintarg os2targ wnttarg nlmtarg | | | |" ]
 usr="locking.h"
 usr="stat.h"
-usr="time.h"
 usr="timeb.h"
 usr="types.h"
 usr="utime.h"

--- a/bld/hdr/hfiles.mif
+++ b/bld/hdr/hfiles.mif
@@ -227,7 +227,7 @@
 !inject sys/sysmips.h                    hlnx
 !inject sys/term.h                            hqnx
 !inject sys/termio.h                          hqnx
-!inject sys/time.h                  hdos hlnx hqnx hrdos
+!inject sys/time.h                       hlnx hqnx hrdos
 !inject sys/timeb.h                 hdos hlnx hqnx hrdos
 !inject sys/timers.h                          hqnx
 !inject sys/times.h                      hlnx hqnx

--- a/bld/hdr/timespec.sp
+++ b/bld/hdr/timespec.sp
@@ -1,7 +1,34 @@
 #ifndef _TIMESPEC_DEFINED
  #define _TIMESPEC_DEFINED
+:segment DOS | IBMTOOLKIT
+:segment DOS
+
+#ifdef __OS2__
+:endsegment
+:include pshpack4.sp
+ struct timespec {
+   union {
+     __w_time_t tv_sec;
+     __w_time_t ts_sec;
+   };
+   union {
+     long       tv_nsec;
+     long       ts_nsec;
+   };
+ };
+:include poppack.sp
+:segment DOS
+#else
+:endsegment
+:endsegment
+:segment !IBMTOOLKIT
  struct timespec {
      __w_time_t tv_sec;
      long       tv_nsec;
  };
+:endsegment
+:segment DOS
+#endif
+
+:endsegment
 #endif /* _TIMESPEC_DEFINED */

--- a/bld/hdr/watcom/signal.mh
+++ b/bld/hdr/watcom/signal.mh
@@ -68,7 +68,9 @@ using std::raise;
 :include uid_t.sp
 :include pid_t.sp
 :segment LINUX
+:include extc99po.sp
 :include timespec.sp
+:include extepi.sp
 :include pthread1.sp
 :endsegment
 

--- a/bld/hdr/watcom/time.mh
+++ b/bld/hdr/watcom/time.mh
@@ -140,12 +140,7 @@ using std::time;
 :keep DECLARE_STRUCT
 :include tm.sp
 :remove DECLARE_STRUCT
-:segment DOS
-
-:include extc99.sp
-:include timespec.sp
-:include extepi.sp
-:elsesegment LINUX | QNX
+:segment DOS | LINUX | QNX
 
 :include extc99po.sp
 :include timespec.sp

--- a/bld/os2api/incl.mif
+++ b/bld/os2api/incl.mif
@@ -25,7 +25,7 @@ wsplice_extra_opts =
 !else
 wsplice_extra_opts = -d"depends.dep"
 !endif
-wsplice_opts = $(wsplice_extra_opts) -i"$(hdr_dir)" $[@ $@
+wsplice_opts = $(wsplice_extra_opts) -kIBMTOOLKIT -i"$(hdr_dir)" $[@ $@
 
 .EXTENSIONS : .sp .mh .sp1
 


### PR DESCRIPTION
correct timespec structure for OS/2 to use POSIX and old BSD definition (used by IBM toolkit)
don't create sys/time.h header file for DOS-like targets
for OS/2 it is created as part of IBM toolkit in bld/os2api project