### PR TITLE
[wcl/owcc] Quote filenames with @ symbols

### DIFF
--- a/bld/wcl/c/clcommon.c
+++ b/bld/wcl/c/clcommon.c
@@ -445,7 +445,7 @@ char *DoQuoted( char *buffer, const char *name, char quote_char )
 
     p = buffer;
     if( name != NULL ) {
-        quotes = ( strchr( name, ' ' ) != NULL );
+        quotes = ( strpbrk( name, " @" ) != NULL );
         if( quotes )
             *p++ = quote_char;
         while( (*p = *name) != '\0' ) {


### PR DESCRIPTION
This patch ensures that filenames and strings in general that contain the `@` symbol are quoted, allowing files with that symbol in the name to be compiled successfully. Without it, WLINK misinterprets the names.