### PR TITLE
Add support for FM TOWNS's version of Phar Lap

### DIFF
--- a/bld/clib/mbyte/c/getltdos.c
+++ b/bld/clib/mbyte/c/getltdos.c
@@ -117,7 +117,16 @@ unsigned short __far *dos_get_dbcs_lead_table( void )
         segregs.ds = _FP_SEG( &pblock );
         intdosx( &regs, &regs, &segregs );
         if( regs.x.cflag == 0 && pblock.real_eax.b.l == 0 ) {
-            if( pblock.real_ds != 0xFFFF ) {    /* weird OS/2 value */
+            if( pblock.real_ds == 0xFFFF ) {    /* weird OS/2 value */
+                return( NULL );
+            } else if( pblock.real_ds == 0 && regs.w.si == 0) {
+                /* Because EXTENDER_RM2PM forces the segment value, without this
+                 * a NULL check on the result of this function would never detect it
+                 * so long as this DOS call doesn't fail.
+                 * At least FM TOWNS returns success but DS:SI=0:0 (which is bogus memory).
+                 */
+                return( NULL );
+            } else {
                 return( EXTENDER_RM2PM( pblock.real_ds, regs.w.si ) );
             }
         }

--- a/bld/clib/startup/a/cstrt386.asm
+++ b/bld/clib/startup/a/cstrt386.asm
@@ -202,9 +202,17 @@ ENV_SEG equ     2ch
         shr     eax,16                  ; get top 16 bits of eax
         cmp     ax,'DX'                 ; if top 16 bits = "DX"
         jne     not_pharlap             ; then its pharlap
+        ;cmp    ebx,'12aJ'              ; - if ebx (version number) is 12aJ
+        cmp     ebx,4A613231h           ; - if ebx (version number) is 12aJ
+        jne     normal_pharlap          ; - then this is FM TOWNS's pharlap version (1.2aJ)
+        mov     al,X_PHARLAP_V2         ; -   behaves closest to Pharlap V2?
+        mov     ah,XS_PHARLAP_FMTOWNS   ; -   mark the subtype for checking as needed
+        jmp short pharlap_general       ; -   act like normal pharlap otherwise
+normal_pharlap:
         sub     bl,'0'                  ; - save major version number
         mov     al,bl                   ; - (was in ascii)
         mov     ah,XS_NONE              ; - extender subtype
+pharlap_general:
         push    eax                     ; - save version number
         mov     es,_psp                 ; - point to PSP
         mov     ebx,es:[5Ch]            ; - get highest addr used

--- a/bld/watcom/h/extender.h
+++ b/bld/watcom/h/extender.h
@@ -51,12 +51,15 @@
 /*
  * Values for '_ExtenderSubtype'
  */
+#define DOSX_PHARLAP_NORMAL         0
+#define DOSX_PHARLAP_FMTOWNS        1
 #define DOSX_RATIONAL_ZEROBASE      0
 #define DOSX_RATIONAL_NONZEROBASE   1  /* Only in DOS4G Pro */
 
 #define _IsOS386()               ( _Extender == DOSX_ERGO )
 #define _IsRational()            ( _Extender == DOSX_RATIONAL )
 #define _IsPharLap()             ( _Extender >= DOSX_PHAR_V2 && _Extender <= DOSX_PHAR_V8 )
+#define _IsPharLapFMTOWNS()      ( _IsPharLap() && _ExtenderSubtype == DOSX_PHARLAP_FMTOWNS )
 #define _IsCodeBuilder()         ( _Extender == DOSX_INTEL )
 #define _IsWin386()              ( _Extender == DOSX_WIN386 )
 #define _IsRationalNonZeroBase() ( _Extender == DOSX_RATIONAL && _ExtenderSubtype == DOSX_RATIONAL_NONZEROBASE )

--- a/bld/watcom/h/extender.inc
+++ b/bld/watcom/h/extender.inc
@@ -49,5 +49,6 @@ X_WIN386                equ     10      ; Watcom Win386
 ;       386 DOS Extender Equates for __ExtenderSubtype variable
 ;
 XS_NONE                 equ     0
+XS_PHARLAP_FMTOWNS      equ     1
 XS_RATIONAL_ZEROBASE    equ     0
 XS_RATIONAL_NONZEROBASE equ     1


### PR DESCRIPTION
The Fujitsu FM TOWNS computer series uses Phar Lap for nearly all software built for it. However, this seems to be an older version than what is currently supported, and so the version check in the startup code was failing to properly handle it.

Additionally, the INT 21h,AH=63h DOS call behaves differently than was expected, causing crashes in initialization.

I haven't done particularly extensive testing of the rest of clib or the functions that use the extender, but I'm able to at least print a hello world now. If I encounter more issues I'll make follow up PRs.