### PR TITLE
cmac1: Fix buffer overflow during macro expansion

### DIFF
--- a/bld/cc/c/cmac1.c
+++ b/bld/cc/c/cmac1.c
@@ -248,6 +248,7 @@ TOKEN GetMacroToken( void )
     MACRO_TOKEN     *mtok;
     bool            keep_token;
     TOKEN           token;
+    char            c;
 
     for( ; (mtok = TokenList) != NULL; ) {
         if( (token = mtok->token) != T_NULL ) {
@@ -265,10 +266,11 @@ TOKEN GetMacroToken( void )
         token = T_NULL;
         Buffer[0] = '\0';
     } else {
-        /* size of Buffer is OK, token data was processed in Buffer before */
-        while( (Buffer[TokenLen] = mtok->data[TokenLen]) != '\0' ) {
-            TokenLen++;
+        while( (c = mtok->data[TokenLen]) != '\0' ) {
+            WriteBufferChar(c);
         }
+        WriteBufferNullChar();
+
         keep_token = false;
         switch( token ) {
         case T_SAVED_ID:


### PR DESCRIPTION
As I figured out while compiling MicroPython with Open Watcom, the comment here "size of Buffer is OK" is a lie, as I noticed wcc segfault.

Unfortunately, I wasn't able to derive a minimal example which replicates it, but here are steps you can use to reproduce the bug using the same source I was (this assumes you have WATCOM and related environment variables set correctly):

    $ git clone https://github.com/micropython/micropython
    $ cd micropython
    $ git checkout 4e4c28bf27ff4a9e1a2ce5b6fffa641d9a332507
    $ mkdir ports/dos
    $ cd ports/dos
    $ wcc -bt==dos -I. -I../.. -Ibuild \
          -DMICROPY_ROM_TEXT_COMPRESSION=1 -DNO_QSTR -pl -0 -zq \
          -fr ../../py/objdict.c
    ~> Segmentation fault

Using GDB and some hardware watchpoints, I was able to deduce the segfault was caused by the scanbuf (a.k.a., the "Buffer" global variable) overflowing and corrupting the following MCB, and it was being happening at the code I modified in this commit.

This changes that code to instead using WriteBufferChar and WriteBufferNullChar, which will bounds check Buffer and re-alloc when required.