### PR TITLE
fix dwarf LEB128 reading routines

### DIFF
--- a/bld/dwarf/dr/c/drdecnam.c
+++ b/bld/dwarf/dr/c/drdecnam.c
@@ -101,21 +101,6 @@ typedef struct {
     List_T func_elg;    /* elg for function parms " )" */
 } BrokenName_T;
 
-static BrokenName_T Empty_Broken_Name = {
-    { NULL, NULL, LIST_TAIL },     /* dec_plg */
-    { NULL, NULL, LIST_HEAD },     /* type_plg */
-    { NULL, NULL, LIST_HEAD },     /* type_bas */
-    { NULL, NULL, LIST_HEAD },     /* type_ptr */
-    { NULL, NULL, LIST_TAIL },     /* type_elg */
-    { NULL, NULL, LIST_TAIL },     /* type_inh */
-    { NULL, NULL, LIST_HEAD },     /* var_plg */
-    { NULL, NULL, LIST_HEAD },     /* var_bas */
-    { NULL, NULL, LIST_HEAD },     /* var_elg */
-    { NULL, NULL, LIST_TAIL },     /* func_plg */
-    { NULL, NULL, LIST_TAIL },     /* func_bas */
-    { NULL, NULL, LIST_TAIL }      /* func_elg*/
-};
-
 /*
  * this structure holds the current location
  */
@@ -266,6 +251,21 @@ static const char *LBLClass =               "Class";
 static const char *LBLCommonBlock =         "Common Block";
 static const char *LBLVariable =            "Variable";
 static const char *LBLParameter =           "Parameter";
+
+static BrokenName_T Empty_Broken_Name = {
+    { NULL, NULL, LIST_TAIL },     /* dec_plg */
+    { NULL, NULL, LIST_HEAD },     /* type_plg */
+    { NULL, NULL, LIST_HEAD },     /* type_bas */
+    { NULL, NULL, LIST_HEAD },     /* type_ptr */
+    { NULL, NULL, LIST_TAIL },     /* type_elg */
+    { NULL, NULL, LIST_TAIL },     /* type_inh */
+    { NULL, NULL, LIST_HEAD },     /* var_plg */
+    { NULL, NULL, LIST_HEAD },     /* var_bas */
+    { NULL, NULL, LIST_HEAD },     /* var_elg */
+    { NULL, NULL, LIST_TAIL },     /* func_plg */
+    { NULL, NULL, LIST_TAIL },     /* func_bas */
+    { NULL, NULL, LIST_TAIL }      /* func_elg*/
+};
 
 void DRDecorateLabel( drmem_hdl die, char *buf )
 /**********************************************/

--- a/bld/dwarf/dr/c/drgetref.c
+++ b/bld/dwarf/dr/c/drgetref.c
@@ -164,7 +164,7 @@ static void References( ReferWhich which, drmem_hdl entry, void *data1,
             break;
 
         case REF_SET_COLUMN:
-            registers.column = (unsigned_8)DWRVMReadULEB128( &loc );
+            registers.column = DWRVMReadULEB128( &loc );
             break;
 
         case REF_ADD_LINE:
@@ -173,7 +173,7 @@ static void References( ReferWhich which, drmem_hdl entry, void *data1,
             break;
 
         case REF_ADD_COLUMN:
-            registers.column += (signed_8)DWRVMReadSLEB128( &loc );
+            registers.column += DWRVMReadSLEB128( &loc );
             break;
 
         case REF_COPY:

--- a/bld/dwarf/dr/c/drleb128.c
+++ b/bld/dwarf/dr/c/drleb128.c
@@ -25,44 +25,48 @@
 *
 *  ========================================================================
 *
-* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
-*               DESCRIBE IT HERE!
+* Description:  signed/unsigned LEB128 reading procedures
 *
 ****************************************************************************/
 
 
-#ifndef __DRGETREF_H__
-#define __DRGETREF_H__
+#include "drpriv.h"
+#include "drleb128.h"
 
-#include "dr.h"
-#include "drsrchdf.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+int_64 SLEB128( void **h, uint_8 (*ifn)(void **h) )
+/*************************************************/
+{
+    uint_64     value;
+    uint        shift;
+    uint_8      byte;
 
-typedef struct {
-    int         size;   /* available room */
-    int         free;   /* next free entry */
-    drmem_hdl   *stack; /* values */
-} dr_scope_stack;
-
-typedef struct {
-    dr_scope_stack  scope;
-    drmem_hdl       dependent;
-    char            *file;
-    unsigned_32     line;
-    unsigned_16     column;
-} dr_ref_info;
-
-typedef bool (*DRSYMREF)( drmem_hdl, dr_ref_info *, char *, void * );
-
-extern void DRRefersTo( drmem_hdl, void *, DRSYMREF callback );
-extern void DRReferredToBy( drmem_hdl, void *, DRSYMREF callback );
-extern void DRReferencedSymbols( dr_sym_type, void *, DRSYMREF callback );
-
-#ifdef __cplusplus
+    value = 0;
+    shift = 0;
+    do {
+        byte = ifn( h );
+        value |= (uint_64)( byte & 0x7f ) << shift;
+        shift += 7;
+    } while( byte & 0x80 );
+    if( (byte & 0x40) && ( shift < 64 ) ) {
+        value |= ~0ULL << shift;
+    }
+    return( (int_64)value );
 }
-#endif
 
-#endif // __DRGETREF_H__
+uint_64 ULEB128( void **h, uint_8 (*ifn)(void **h) )
+/**************************************************/
+{
+    uint_64     value;
+    uint        shift;
+    uint_8      byte;
+
+    value = 0;
+    shift = 0;
+    do {
+        byte = ifn( h );
+        value |= (uint_64)( byte & 0x7f ) << shift;
+        shift += 7;
+    } while( byte & 0x80 );
+    return( value );
+}

--- a/bld/dwarf/dr/c/drline.c
+++ b/bld/dwarf/dr/c/drline.c
@@ -2,6 +2,7 @@
 *
 *                            Open Watcom Project
 *
+* Copyright (c) 2002-2022 The Open Watcom Contributors. All Rights Reserved.
 *    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
 *
 *  ========================================================================
@@ -66,7 +67,7 @@ static void InitState( line_info *info )
     info->state.offset = 0;
     info->state.file = 1;
     info->state.line = 1;
-    info->state.col = 0;
+    info->state.column = 0;
     info->state.is_stmt = info->rdr.def_is_stmt;
     info->state.basic_blk = false;
     info->state.end_seq = false;
@@ -162,7 +163,7 @@ static bool WlkStateProg( line_info *info, DRCUEWLK cue, void *cue_data,
                     }
                     curr += curr_len;
                     df.name = name_buf;                             // directory path
-                    df.dir = (uint_16)DWRVMReadULEB128( &curr );    // directory index
+                    df.dir = DWRVMReadULEB128( &curr );             // directory index
                     df.time = DWRVMReadULEB128( &curr );            // time
                     df.len = DWRVMReadULEB128( &curr );             // length
                     df.index = (filetab_idx)info->rdr.file_idx;     // index
@@ -193,10 +194,10 @@ static bool WlkStateProg( line_info *info, DRCUEWLK cue, void *cue_data,
                 info->state.line += DWRVMReadSLEB128( &curr );
                 break;
             case DW_LNS_set_file:
-                info->state.file = (uint_16)DWRVMReadULEB128( &curr );
+                info->state.file = DWRVMReadULEB128( &curr );
                 break;
             case DW_LNS_set_column:
-                info->state.col = (uint_16)DWRVMReadULEB128( &curr );
+                info->state.column = DWRVMReadULEB128( &curr );
                 break;
             case DW_LNS_negate_stmt:
                 info->state.is_stmt = !info->state.is_stmt;
@@ -359,7 +360,7 @@ bool DRWalkLFiles( drmem_hdl stmt, DRLFILEWLK file, void *file_data,
         stmt += curr_len;
         info.rdr.file_idx++;
         df.name = name_buf;                             // directory path
-        df.dir = (uint_16)DWRVMReadULEB128( &stmt );    // directory index
+        df.dir = DWRVMReadULEB128( &stmt );             // directory index
         df.time = DWRVMReadULEB128( &stmt );            // time
         df.len = DWRVMReadULEB128( &stmt );             // length
         df.index = (filetab_idx)info.rdr.file_idx;      // index

--- a/bld/dwarf/dr/c/virtstub.c
+++ b/bld/dwarf/dr/c/virtstub.c
@@ -2,6 +2,7 @@
 *
 *                            Open Watcom Project
 *
+* Copyright (c) 2002-2022 The Open Watcom Contributors. All Rights Reserved.
 *    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
 *
 *  ========================================================================
@@ -30,8 +31,9 @@
 
 
 #include <string.h>
-
 #include "drpriv.h"
+#include "drleb128.h"
+
 
 typedef struct alloc_struct {
     struct alloc_struct *next;
@@ -123,30 +125,22 @@ bool DRSwap( void )
     return( false );
 }
 
-
-unsigned_32 ReadLEB128( drmem_hdl *vmptr, bool issigned )
-/*******************************************************/
-// works for signed or unsigned
+static uint_8 readLEB( void **h )
+/*******************************/
 {
-    drmem_hdl       src;
-    unsigned_32     result;
-    unsigned        shift;
-    char            b;
+    return( *(*(drmem_hdl *)h)++ );
+}
 
-    src = *vmptr;
-    result = 0;
-    shift = 0;
-    do {
-        b = *src++;
-        result |= (b & 0x7f) << shift;
-        shift += 7;
-    } while( (b & 0x80) != 0 );
-    *vmptr = src;
-    if( issigned && (b & 0x40) != 0 && shift < 32 ) {
-        // we have to sign extend
-        result |= - ((signed_32)( 1 << shift ));
-    }
-    return( result );
+int_64 DWRVMReadSLEB128( drmem_hdl *vmptr )
+/*****************************************/
+{
+    return( SLEB128( (void **)vmptr, readLEB ) );
+}
+
+uint_64 DWRVMReadULEB128( drmem_hdl *vmptr )
+/******************************************/
+{
+    return( ULEB128( (void **)vmptr, readLEB ) );
 }
 
 #if 0

--- a/bld/dwarf/dr/h/drleb128.h
+++ b/bld/dwarf/dr/h/drleb128.h
@@ -25,44 +25,10 @@
 *
 *  ========================================================================
 *
-* Description:  WHEN YOU FIGURE OUT WHAT THIS FILE DOES, PLEASE
-*               DESCRIBE IT HERE!
+* Description:  signed/unsigned LEB128 reading procedures
 *
 ****************************************************************************/
 
 
-#ifndef __DRGETREF_H__
-#define __DRGETREF_H__
-
-#include "dr.h"
-#include "drsrchdf.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-typedef struct {
-    int         size;   /* available room */
-    int         free;   /* next free entry */
-    drmem_hdl   *stack; /* values */
-} dr_scope_stack;
-
-typedef struct {
-    dr_scope_stack  scope;
-    drmem_hdl       dependent;
-    char            *file;
-    unsigned_32     line;
-    unsigned_16     column;
-} dr_ref_info;
-
-typedef bool (*DRSYMREF)( drmem_hdl, dr_ref_info *, char *, void * );
-
-extern void DRRefersTo( drmem_hdl, void *, DRSYMREF callback );
-extern void DRReferredToBy( drmem_hdl, void *, DRSYMREF callback );
-extern void DRReferencedSymbols( dr_sym_type, void *, DRSYMREF callback );
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif // __DRGETREF_H__
+extern int_64   SLEB128( void **h, uint_8 (*ifn)(void **h) );
+extern uint_64  ULEB128( void **h, uint_8 (*ifn)(void **h) );

--- a/bld/dwarf/dr/h/drline.h
+++ b/bld/dwarf/dr/h/drline.h
@@ -2,6 +2,7 @@
 *
 *                            Open Watcom Project
 *
+* Copyright (c) 2002-2022 The Open Watcom Contributors. All Rights Reserved.
 *    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
 *
 *  ========================================================================
@@ -35,7 +36,7 @@
 typedef struct { /* current state of stmt prog */
     uint_32 offset;
     uint_32 line;
-    uint_16 col;
+    uint_16 column;
     uint_16 file;
     uint_16 seg;
     uint_8  is_stmt   :1;

--- a/bld/dwarf/dr/h/virtmem.h
+++ b/bld/dwarf/dr/h/virtmem.h
@@ -2,6 +2,7 @@
 *
 *                            Open Watcom Project
 *
+* Copyright (c) 2002-2022 The Open Watcom Contributors. All Rights Reserved.
 *    Portions Copyright (c) 1983-2002 Sybase, Inc. All Rights Reserved.
 *
 *  ========================================================================
@@ -29,8 +30,6 @@
 ****************************************************************************/
 
 
-extern unsigned_32      ReadLEB128( drmem_hdl *, bool );
-
 extern void             DWRVMInit( void );
 extern void             DWRVMDestroy( void );
 extern void             DWRVMReset( void );
@@ -42,8 +41,8 @@ extern char             *DWRVMCopyString( drmem_hdl * );
 extern size_t           DWRVMGetStrBuff( drmem_hdl drstr, char *buf, size_t max );
 extern unsigned_16      DWRVMReadWord( drmem_hdl );
 extern unsigned_32      DWRVMReadDWord( drmem_hdl );
-
-#define DWRVMReadSLEB128(__h) (signed_32)ReadLEB128( __h, true )
+extern int_64           DWRVMReadSLEB128( drmem_hdl *vmptr );
+extern uint_64          DWRVMReadULEB128( drmem_hdl *vmptr );
 
 #if defined( USE_VIRTMEM )
 
@@ -53,11 +52,9 @@ extern void             DWRVMSkipLEB128( drmem_hdl * );
 extern void             DWRVMRead( drmem_hdl, void *, size_t );
 extern unsigned_8       DWRVMReadByte( drmem_hdl );
 
-#define DWRVMReadULEB128(__h) ReadLEB128( __h, false )
-
 #else   /* !USE_VIRTMEM */
 
-#define DWRVMStrLen(__h)          strlen((const char *)__h)
+#define DWRVMStrLen(__h)        strlen((const char *)__h)
 #define DWRVMSwap(__ig1,__ig2,__ig3)
 #define DWRVMSkipLEB128(__h)          \
     {                                 \
@@ -97,10 +94,6 @@ extern unsigned_32      ReadULEB128( drmem_hdl * );         /* inline */
     __parm          [__edx] \
     __value         [__eax] \
     __modify __nomemory
-
-#else
-
-#define DWRVMReadULEB128(__h)   ReadLEB128( __h, false )
 
 #endif
 

--- a/bld/dwarf/dr/master.mif
+++ b/bld/dwarf/dr/master.mif
@@ -62,6 +62,7 @@ libtarg_objs = &
     drstack.obj  &
     drtype.obj   &
     drutils.obj  &
+    drleb128.obj &
     $(libtarg_objs_virt)
 !include libtarg.mif
 


### PR DESCRIPTION
correct sign extension for SLEB128 routine
enable to process 64-bit items