### PR TITLE
fix vxd writer to account for DDB not in the start of a segment

### DIFF
--- a/bld/wl/c/loadflat.c
+++ b/bld/wl/c/loadflat.c
@@ -426,7 +426,7 @@ static void SetHeaderVxDInfo(os2_flat_header *exe_head)
 
     exp = FmtData.u.os2fam.exports;
     if( ( exp != NULL ) && ( exp->sym != NULL ) ) {
-        ReadInfo( (exp->sym->p.seg)->u1.vm_ptr, &ddb, sizeof( ddb ) );
+        ReadInfo( exp->sym->addr.off + (exp->sym->p.seg)->u1.vm_ptr, &ddb, sizeof( ddb ) );
         exe_head->r.vxd.device_ID = ddb.req_device_number;
         exe_head->r.vxd.DDK_version = ddb.SDK_version;
     }


### PR DESCRIPTION
Wlink's VxD generator sets some fields of the LE header based on data from the VxD's device descriptor block (DDB). However, the current code assumes that the the DDB is always at offset 0 in some segment. 
If the DDB is not at offset 0 then it just reads random data from the DDB's segment thereby writing a corrupt VxD. 
This patch fixes this. 

(having a DDB at offset 0 is not necessary for the VxD to be loaded by windows, in fact most builtin vxds have the DDB at the end of the segment). 