### PR TITLE
Added mising ANSI macro for PathMatchSpec per Microsoft docs

### DIFF
--- a/bld/w32api/include/shlwapi.mh
+++ b/bld/w32api/include/shlwapi.mh
@@ -1239,6 +1239,7 @@ LWSTDAPI                PathMatchSpecExW( LPCWSTR, LPCWSTR, DWORD );
     #define PathIsURL               PathIsURLA
     #define PathMakePretty          PathMakePrettyA
     #define PathMakeSystemFolder    PathMakeSystemFolderA
+    #define PathMatchSpec           PathMatchSpecA
     #define PathParseIconLocation   PathParseIconLocationA
     #define PathQuoteSpaces         PathQuoteSpacesA
     #define PathRelativePathTo      PathRelativePathToA


### PR DESCRIPTION
We were simply missing the [PathMatchSpec alias for ANSI cases (see Remarks)](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-pathmatchspeca).