### PR TITLE
* fix define _diskinfo_t in bios.h to _ibm_diskinfo_t

### DIFF
--- a/bld/hdr/watcom/bios.mh
+++ b/bld/hdr/watcom/bios.mh
@@ -24,7 +24,7 @@ struct  _ibm_diskinfo_t {       /* disk parameters */
         unsigned nsectors;      /* number of sectors to read/write/compare  */
         void _WCFAR *buffer;    /* buffer to read to,write from, or compare */
 };
-#define _diskinfo_t     _ibm_diskinfo
+#define _diskinfo_t     _ibm_diskinfo_t
 
 :include ext.sp
 #define diskinfo_t      _ibm_diskinfo_t

--- a/ci/ow/h/bios.h
+++ b/ci/ow/h/bios.h
@@ -41,7 +41,7 @@ struct  _ibm_diskinfo_t {       /* disk parameters */
         unsigned nsectors;      /* number of sectors to read/write/compare  */
         void _WCFAR *buffer;    /* buffer to read to,write from, or compare */
 };
-#define _diskinfo_t     _ibm_diskinfo
+#define _diskinfo_t     _ibm_diskinfo_t
 
 #if !defined(NO_EXT_KEYS) /* extensions enabled */
 #define diskinfo_t      _ibm_diskinfo_t


### PR DESCRIPTION
`bios.h` did define `_diskinfo_t` as `_ibm_diskinfo`, which does not exist and I found its usage in an old codebase.
I think it should point to `_ibm_diskinfo_t`, so same as for `diskinfo_t`