### PR TITLE
Fixed a problem that made OW's standard library not compliant with the c++ standard.

### DIFF
--- a/ci/ow/h/fstream
+++ b/ci/ow/h/fstream
@@ -169,7 +169,7 @@ namespace std {
 #pragma pack( __pop )
 
   inline void ifstream::open( char const *__n, ios::openmode __m, int __p ) {
-    fstreambase::open( __n, __m, __p );
+    fstreambase::open( __n, __m | ios::in, __p );
   }
 
   // **************************** OFSTREAM ***********************************
@@ -196,7 +196,7 @@ namespace std {
 #pragma pack( __pop )
 
   inline void ofstream::open( char const *__n, ios::openmode __m, int __p ) {
-    fstreambase::open( __n, __m, __p );
+    fstreambase::open( __n, __m | ios::out, __p );
   }
 
   // **************************** FSTREAM ************************************

--- a/ci/ow/lh/fstream
+++ b/ci/ow/lh/fstream
@@ -157,7 +157,7 @@ namespace std {
 #pragma pack( __pop )
 
   inline void ifstream::open( char const *__n, ios::openmode __m, int __p ) {
-    fstreambase::open( __n, __m, __p );
+    fstreambase::open( __n, __m | ios::in, __p );
   }
 
   // **************************** OFSTREAM ***********************************
@@ -180,7 +180,7 @@ namespace std {
 #pragma pack( __pop )
 
   inline void ofstream::open( char const *__n, ios::openmode __m, int __p ) {
-    fstreambase::open( __n, __m, __p );
+    fstreambase::open( __n, __m | ios::out, __p );
   }
 
   // **************************** FSTREAM ************************************


### PR DESCRIPTION
`ios::in` and `ios::out` should always be set (even if not explicitly set in arguments) for `ifstream` and `ofstream`.
Constructors handled that correctly, but `open` function didn't.