### PR TITLE
Make sure graphics state is inited before returning cursor shape

### DIFF
--- a/bld/graphlib/c/outtext.c
+++ b/bld/graphlib/c/outtext.c
@@ -228,6 +228,7 @@ _WCRTLINK short _WCI86FAR _CGRAPH _settextcursor( short shape )
         _ErrorStatus = _GRNOTINPROPERMODE;
         return( -1 );
     }
+    _InitState();
     previous = _CursorShape;
     _CursorShape = shape;
 


### PR DESCRIPTION
`_settextcursor` is documented to return the previous cursor shape before setting the new one - however if `_InitState` has not been called the previous cursor shape is undefined.