### PR TITLE
plusplus: Fix dependency file creation (multiple target patterns)

### DIFF
--- a/bld/plusplus/c/autodep.c
+++ b/bld/plusplus/c/autodep.c
@@ -77,6 +77,7 @@ void AdDump( void )
                fprintf( AutoDepFile, " %s%s", DependHeaderPath, DoForceSlash( name, ForceSlash ) );
             }
         }
+        fprintf( AutoDepFile, "\n" );
     }
 }
 


### PR DESCRIPTION
Without the fix, OpenWatcom creates broken dependency files.
(everything is in one line)

GNU Make can build the c++ autotools project once (target files are missing),
but any following make to update the targets fails with a message similar to:

*** multiple target patterns.  Stop


An example autotools project is attached:
```
./bootstrap
CC=owcc  CXX=owcc  CFLAGS="-v"  CXXFLAGS="-v"  ./configure
# first make works:
make

# a touch is optional:
# touch foo2.cpp
 
# a following make fails:
make
```
[tst_foo.tar.gz](https://github.com/open-watcom/open-watcom-v2/files/11336623/tst_foo.tar.gz)


--
Regards Detlef