### PR TITLE
owcc: Fix handling of equal character with option -b

### DIFF
--- a/bld/wcl/c/owcc.c
+++ b/bld/wcl/c/owcc.c
@@ -918,9 +918,9 @@ static  int  ParseArgs( int argc, char **argv )
         case 'b':
             Flags.link_for_sys = true;
             MemFree( SystemName );
-            SystemName = MemStrDup( Word );
-            /* if Word found in specs.owc, add options from there: */
-            if( ConsultSpecsFile( Word ) ) {
+            SystemName = MemStrDup( Word[0] == '=' ? (Word + 1) : Word );
+            /* if new target found in specs.owc, add options from there: */
+            if( ConsultSpecsFile( SystemName ) ) {
                 /* all set */
                 wcc_option = false;
             } else {


### PR DESCRIPTION
Example:
owcc -b=dos -v -std=c99 hello.c -o hellodos.exe

The patch avoids calling wcc386 with the broken arg "-bt==dos" 
followed by wlink stop the compilation:
Warning! W1107: file __owcc00.lnk: line(2): undefined system name: system
Error! E3033: file __owcc00.lnk: line(2): directive error near 'system'
Error: Linker returned a bad status

--
Regards Detlef