### PR TITLE
owcc: Accept more filename extensions as fortran source:.f77, .f90, .f95

### DIFF
--- a/bld/wcl/c/owcc.c
+++ b/bld/wcl/c/owcc.c
@@ -115,7 +115,9 @@
 #define MAX_CC_OPTS 256
 
 #define IS_ASM(x)   (x[0] == '.' && (fname_cmp(x + 1, ASM_EXT) == 0 || stricmp(x + 1, ASMS_EXT) == 0))
-#define IS_FOR(x)   (x[0] == '.' && (fname_cmp(x + 1, "f") == 0 || stricmp(x + 1, "for") == 0 || fname_cmp(x + 1, "ftn") == 0))
+#define IS_FOR(x)   (x[0] == '.' && (fname_cmp(x + 1, "f") == 0 || stricmp(x + 1, "for") == 0 || \
+                    fname_cmp(x + 1, "ftn") == 0 || stricmp(x + 1, "f77") == 0 || \
+                    stricmp(x + 1, "f90") == 0 || stricmp(x + 1, "f95") == 0))
 #define IS_LIB(x)   (HasFileExtension( x, LIB_EXT ) || HasFileExtension( x, LIB_EXT_SECONDARY ))
 
 typedef enum {


### PR DESCRIPTION
This is enough to build 3 of the 17 test from
The "Polyhedron Fortran Benchmarks" Suite
which is available from fortran.uk ( www.fortran.uk/pb11.zip )

These files compile with OpenWatcom:
air.f90, doduc.f90, linpk.f90



--
Regards ... Detlef