### PR TITLE
owcc: extend -mcmodel argument handling

### DIFF
--- a/bld/wcl/c/owcc.c
+++ b/bld/wcl/c/owcc.c
@@ -741,7 +741,9 @@ static  int  ParseArgs( int argc, char **argv )
             wcc_option = false;
             break;
         case 'm':
-            if( ( strncmp( "cmodel=", Word, 7 ) == 0 ) && ( Word[8] == '\0' ) ) {
+            /* accept short mcmodel names (ow style) and long names (gcc style) */
+            /* examples: -mcmodel=h and -mcmodel=huge */
+            if( ( strncmp( "cmodel=", Word, 7 ) == 0 ) && ( Word[7] != '\0' ) ) {
                 if( Word[7] == 't' ) {      /* tiny model */
                     Word[0] = 's';          /* change to small */
                     Flags.tiny_model = true;


### PR DESCRIPTION
I updated the patch:

owcc: accept also long names for the -mcmodel option

In addition to the short memory model names (t, s, c, m, l, h),
owcc accepts now also long memory model names as used by gcc
(tiny, small, compact, medium, large, huge)

--
Regards ... Detlef