### PR TITLE
Add missing newline, fix a copy&paste error

### DIFF
--- a/bld/orl/test/c/test.c
+++ b/bld/orl/test/c/test.c
@@ -507,7 +507,7 @@ int main( int argc, char *argv[] )
     }
     o_file_format = ORLFileIdentify( o_handle, fp );
     if( o_file_format == ORL_UNRECOGNIZED_FORMAT ) {
-        printf( "The object file is not in either ELF, COFF or OMF format." );
+        printf( "The object file is not in either ELF, COFF or OMF format.\n" );
         return( 1 );
     }
     switch( o_file_format ) {

--- a/bld/wl/c/cmdelf.c
+++ b/bld/wl/c/cmdelf.c
@@ -278,7 +278,7 @@ static bool ProcELFRSolrs( void )
 /*******************************/
 {
     FmtData.u.elf.abitype = ELFOSABI_SOLARIS;
-    ParseABIVersion( "FREEBSD" );
+    ParseABIVersion( "SOLARIS" );
     return( true );
 }
 
@@ -286,7 +286,7 @@ static bool ProcELFRFBSD( void )
 /******************************/
 {
     FmtData.u.elf.abitype = ELFOSABI_FREEBSD;
-    ParseABIVersion( "SOLARIS" );
+    ParseABIVersion( "FREEBSD" );
     return( true );
 }
 


### PR DESCRIPTION
I started with objread from bld/orl/test,
but that segfaults on ELF64.

A git grep for ELFOSABI made the copy&paste failure visible

wdump looked more advanced on the first sight (because it does not segfaults),
but that assumption was wrong: ELF64 does not work there either.
Elf64_Ehdr is present in bld/watcom/h, but unused in all projects other that bld/orl.

-- 
Regards ... Detlef