### PR TITLE
owcc: Fix typo in commandline help

### DIFF
--- a/bld/wcl/h/owccopts.gml
+++ b/bld/wcl/h/owccopts.gml
@@ -401,7 +401,7 @@
 :option. std
 :usage. disable/enable extensions
 :group. 3
-:id. . {c89,c99,wc}
+:id. . {c89,c99,ow}
 :target. any
 
 :option. Wall


### PR DESCRIPTION
The code and the documentation use "-std=ow" to enable OpenWatcom extensions.

--
Regards ... Detlef