### PR TITLE
URL: Replace dead url to help users to find the recent landing Page.

### DIFF
--- a/bld/watcom/h/banner.h
+++ b/bld/watcom/h/banner.h
@@ -65,7 +65,7 @@
 #define banner2a(year)      banner21a(year) " All Rights Reserved."
 
 #define banner3             "Source code is available under the Sybase Open Watcom Public License."
-#define banner3a            "See http://www.openwatcom.org/ for details."
+#define banner3a            "See https://open-watcom.github.io/ for details."
 
 #define banner1ps(p,v)      "Powersoft " p " " banner1v(v)
 #define banner2ps           banner21a( 1984 )


### PR DESCRIPTION
(Use https://open-watcom.github.io/ instead of the dead URL)

The old Website looks dead since several Years.

A landing page was restored in Jan.2023 with a download links for the old release of OW 1.9, but nothing more happens since then.

There are more locations in the git sources to the dead URL, (windows resource files, example sources, documentation and more), but that might need discussion first.

--
Regards ... Detlef
