### PR TITLE
Build mathlib for Windows NT MIPS

### DIFF
--- a/bld/mathlib/builder.ctl
+++ b/bld/mathlib/builder.ctl
@@ -42,6 +42,7 @@ set PROJDIR=<CWD>
     <CCCMD> library/msdos.387/ms_s/math387s.lib     "<OWRELROOT>/lib386/netware/math387s.lib"
 
     <CCCMD> library/winnt.axp/_s/math.lib           "<OWRELROOT>/libaxp/nt/math.lib"
+    <CCCMD> library/winnt.mps/_s/math.lib           "<OWRELROOT>/libmps/nt/math.lib"
 
     <CCCMD> library/msdos.386/mf_r/math3r.lib       "<OWRELROOT>/lib386/math3r.lib"
     <CCCMD> library/msdos.386/mf_rd/math3r.lib      "<OWRELROOT>/lib386/math3rd.lib"

--- a/bld/mathlib/files.dat
+++ b/bld/mathlib/files.dat
@@ -27,7 +27,7 @@ dir="lib386"    usr="math3r.lib"    cond="3r"   wherea="ac"
 dir="lib386"    usr="math3s.lib"    cond="3s"   wherea="ac"
 dir="lib386"    usr="math387r.lib"  cond="3r"   wherea="ac"
 dir="lib386"    usr="math387s.lib"  cond="3s"   wherea="ac"
-
+dir="libmps"    usr="math.lib"                  where="ac"
 dir="libaxp"    usr="math.lib"                  where="ac"
 
 [ DEFAULT where="c jc f77 jf77" desc="Math Library 32-bit DLL Import Libraries" ]

--- a/bld/mathlib/h/ifprag.h
+++ b/bld/mathlib/h/ifprag.h
@@ -39,6 +39,8 @@
 // do nothing
 #elif defined(__PPC__)
 // do nothing
+#elif defined(__MIPS__)
+// do nothing
 #elif defined(__386__)
     #pragma aux if_rtn __parm [__eax __ebx __ecx __edx __8087];
     #if defined(__SW_3S)

--- a/bld/watcom/h/libmain.h
+++ b/bld/watcom/h/libmain.h
@@ -41,7 +41,7 @@ extern int APIENTRY _LibMain( HANDLE hdll, DWORD reason, LPVOID reserved );
 #pragma aux _LibMain "_*"
 extern int APIENTRY LibMain( HANDLE hdll, DWORD reason, LPVOID reserved );
 
-#if defined( _M_ALPHA ) || defined( _M_PPC )
+#if defined( _M_ALPHA ) || defined( _M_PPC ) || defined( _M_MRX000 )
 extern int DllMainCRTStartup( HANDLE hdll, DWORD reason, LPVOID reserved );
 extern int _DllMainCRTStartup( HANDLE hdll, DWORD reason, LPVOID reserved );
 extern int wDllMainCRTStartup( HANDLE hdll, DWORD reason, LPVOID reserved );


### PR DESCRIPTION
Similar style of #1108 , this PR adds the Windows NT for MIPS platform for mathlib, it also adds a missing check for MIPS on watcom project (which fixes crt build)