### PR TITLE
Fix some crashes during MIPS 32-bit code generation

### DIFF
--- a/bld/cc/c/cpragmps.c
+++ b/bld/cc/c/cpragmps.c
@@ -164,15 +164,14 @@ static bool GetByteSeq( aux_info *info )
 void PragmaInit( void )
 /*********************/
 {
-    AsmInit();
+
 }
 
 
 void PragmaFini( void )
 /*********************/
 {
-    AsmFiniRelocs();
-    AsmFini();
+
 }
 
 static void InitAuxInfo( void )

--- a/bld/cg/risc/mps/c/mpsdfsup.c
+++ b/bld/cg/risc/mps/c/mpsdfsup.c
@@ -77,10 +77,25 @@ static dw_regs  DFRegMapN( name *reg )
 void    DFOutReg( dw_loc_id locid, name *reg )
 /********************************************/
 {
-    dw_regs     regnum;
+    hw_reg_set  hw_reg;
+    hw_reg_set  hw_low;
+    dw_regs     dw_reg;
 
-    regnum = DFRegMapN( reg );
-    DWLocReg( Client, locid, regnum );
+    hw_reg = reg->r.reg;
+
+    hw_low = Low64Reg( hw_reg );
+    if( HW_CEqual( hw_low, HW_EMPTY ) ) {
+        dw_reg = DFRegMap( hw_reg );
+        DWLocReg( Client, locid, dw_reg );
+   } else {
+        dw_reg =  DFRegMap( hw_low );
+        DWLocReg( Client, locid, dw_reg );
+        DWLocPiece( Client, locid, WD );
+        HW_TurnOff( hw_reg, hw_low );
+        dw_reg = DFRegMap( hw_reg );
+        DWLocReg( Client, locid, dw_reg );
+        DWLocPiece( Client, locid, WD );
+    }
 }
 
 

--- a/bld/cg/risc/mps/c/mpsenc.c
+++ b/bld/cg/risc/mps/c/mpsenc.c
@@ -558,18 +558,19 @@ static  void doCall( instruction *ins )
 
     op = ins->operands[CALL_OP_ADDR];
     sym = op->v.symbol;
-    cclass = (call_class)(pointer_uint)FindAuxInfoSym( sym, FEINF_CALL_CLASS );
     lbl = symLabel( op );
     code = NULL;
     if( !AskIfRTLabel( lbl ) ) {
         code = FindAuxInfoSym( sym, FEINF_CALL_BYTES );
     }
     if( code != NULL ) {
+        cclass = (call_class)(pointer_uint)FindAuxInfoSym( sym, FEINF_CALL_CLASS );
         ObjEmitSeq( code );
         if( cclass & FECALL_GEN_ABORTS ) {
             GenNoReturn();
         }
     } else {
+        cclass = FECALL_GEN_NONE; //!
         GenCallLabel( lbl );
     }
     if( cclass & FECALL_GEN_NORETURN ) {


### PR DESCRIPTION
This PR fixes some CG/CC bugs for MIPS platform (32-bit/R3000) found during building of clib for Windows NT MIPS.
CG is currently still broken for ulonglong due to a "invalid opcode" error that I have yet to investigate (future PR or in this PR in case). Linking of w32api also fails probably due to wrong calling convention or similar. (which will be fixed in another PR once I figure that out)

Explanation of the changes, in case something I did was not correct or I haven't properly understood something:
## Commit 1
Fixes the following bug: https://cdn.discordapp.com/attachments/922945502683758622/1116168969339011082/image.png

According to my research, owcc tries to search for a reduction symbol (RT_MEMCPY) symbol in the function SymAccess (csym.c:303), looking at the original Open Watcom code (https://cdn.discordapp.com/attachments/922945502683758622/1121571378534027334/image.png), the code operation seems to check for a symbol (FEAuxInfo) only when the specified label is not part of any reduction (that is being replaced/generated according to the table defined in mipsrtrtn.c or any custom label in the asm code)
The commit https://github.com/open-watcom/open-watcom-v2/commit/61f1423d981e4372ab2fb911426697bc74f2c915#diff-23dfd5acc856f75a9f70693e82a06c162573c00a6092a7345e2cfbab498ad4ff seems to change how it works, futher modifications were added with the support of reduction symbols that has no return.
My proposal is to only check for the return type (cclass) if it's not searching for a reduction symbol, this will actually force reductions to always return (as FECALL_GEN_NORETURN will never be specified), but I don't think it's an issue as the reudctions are all already made. Looking for comparison on the X86 CG code (FindAuxInfo), it seems to match the behavour.

## Commit 2
I got another crash when using pragma, it was trying to initialzie and destroy the inline assembly code, Alpha CG (if I remember correctly or X86 CG) doesn't seem to handle this case, I don't know specifically why the init and destructions of inline asm relocations was placed there, but it's already handled somewhere else in watcom cg (where an inline asm is used). Any input for this is welcome.

## Commit 3
During the generation of a register operation that involves 64-bit data types, the MIPS platform that targets watcom (R3000/32-bit MIPS) uses a fake qword registers which is a combination of two dword registers, as shown in mpsrgtbl.c. The same mechanism of the fake qword register is used for 32-bit to handle 64-bit data types. The function that was setting up which registers to turn on/off didn't take in account the case of a 64-bit register as it only worked with normal ones and not the fake ones. This commit fixes this by applying the same machism that is currently being done for x86.
