### PR TITLE
Portability fixes for bootstrap OW on ppc-linux

### DIFF
--- a/bld/plusplus/h/pcheader.h
+++ b/bld/plusplus/h/pcheader.h
@@ -90,6 +90,8 @@ enum {
 #define PHH_TARG_ARCHITECTURE   PHH_ARCHITECTURE_286
 #elif _CPU == _AXP
 #define PHH_TARG_ARCHITECTURE   PHH_ARCHITECTURE_AXP
+#elif _CPU == _PPC
+#define PHH_TARG_ARCHITECTURE   PHH_ARCHITECTURE_PPC
 #else
 #error missing _CPU check
 #endif
@@ -115,6 +117,8 @@ enum {
 #define PHH_HOST_ARCHITECTURE   PHH_ARCHITECTURE_ARM
 #elif defined( _M_ARM64 )
 #define PHH_HOST_ARCHITECTURE   PHH_ARCHITECTURE_ARM64
+#elif defined( __PPC__ )
+#define PHH_HOST_ARCHITECTURE   PHH_ARCHITECTURE_PPC
 #else
 #error missing host architecture check
 #endif


### PR DESCRIPTION
This patch allows starting to bootstrap OW on ppc-linux

(bootstrap halts in "bld/causeway/cwc/dosi86", 
when OW try to use "wclpcc" (release version)) 

-- 
Regards ... Detlef
