### PR TITLE
unsigned long long support in switch statements (cstmt.c)

### DIFF
--- a/bld/cc/c/cstmt.c
+++ b/bld/cc/c/cstmt.c
@@ -1002,6 +1002,10 @@ static void SwitchStmt( void )
         sw->case_format = "%lu";
 //        switch_type = TYP_ULONG;
         break;
+    case TYP_ULONG64:
+        sw->case_format = "%llu";
+//        switch_type = TYP_ULONG64;
+        break;
     case TYP_LONG:
 //        switch_type = TYP_LONG;
         break;

--- a/bld/cg/c/bestub.c
+++ b/bld/cg/c/bestub.c
@@ -106,8 +106,8 @@ extern void CGControl(cg_op _1,cg_name _2,label_handle _4) {}
 extern void CGBigLabel(back_handle _4) {}
 extern void CGBigGoto(label_handle _1,int _4) {}
 extern sel_handle CGSelInit(){return(0);}
-extern void CGSelCase(sel_handle _1,label_handle _2,signed_32 _4) {}
-extern void CGSelRange(sel_handle _1,signed_32 _2,signed_32 _3,label_handle _4) {}
+extern void CGSelCase(sel_handle _1,label_handle _2,signed_64 _4) {}
+extern void CGSelRange(sel_handle _1,signed_64 _2,signed_64 _3,label_handle _4) {}
 extern void CGSelOther(sel_handle _1,label_handle _4) {}
 extern void CGSelectRestricted(sel_handle _1,cg_name _4,cg_switch_type _2 );
 extern void CGSelect(sel_handle _1,cg_name _4) {}

--- a/bld/cg/c/cg.c
+++ b/bld/cg/c/cg.c
@@ -483,7 +483,7 @@ extern  sh      *CGSelInit() {
     Action( " -> %d%n", SelId );
     return(s);
 }
-extern  void    CGSelCase( sh *s, l *lb, signed_32 v ) {
+extern  void    CGSelCase( sh *s, l *lb, signed_64 v ) {
 /******************************************************/
 
     Action( "CGSelCase" );
@@ -491,7 +491,7 @@ extern  void    CGSelCase( sh *s, l *lb, signed_32 v ) {
     CRefLabel( lb );
     SelRange(s,v,v,lb);
 }
-extern  void    CGSelRange( sh *s, signed_32 lo, signed_32 hi, l *lb ) {
+extern  void    CGSelRange( sh *s, signed_64 lo, signed_64 hi, l *lb ) {
 /**********************************************************************/
 
     Action( "CGSelRange" );
@@ -500,7 +500,7 @@ extern  void    CGSelRange( sh *s, signed_32 lo, signed_32 hi, l *lb ) {
     SelRange(s,lo,hi,lb);
 }
 
-extern  void    SelRange( sh *s, signed_32 lo, signed_32 hi, l *lb ) {
+extern  void    SelRange( sh *s, signed_64 lo, signed_64 hi, l *lb ) {
 /********************************************************************/
 
     rh  **or;


### PR DESCRIPTION
This commit is designed to fix a C compiler limitation on switch statements. In the cstmt.c file, I added support for unsigned long long to fix issue #66.