### PR TITLE
ide: Fix the Dialog type, when saving the build logfile

### DIFF
--- a/bld/ide/ide/cpp/vmsglog.cpp
+++ b/bld/ide/ide/cpp/vmsglog.cpp
@@ -295,7 +295,7 @@ bool VMsgLog::saveLogAs()
     }
     fn.setExt( "txt" );
     WFileDialog fd( this, sFilter );
-    fn = fd.getOpenFileName( fn, "Save Log as", WFSaveDefault );
+    fn = fd.getSaveFileName( fn, "Save Log as", WFSaveDefault );
     if( fn.legal() ) {
 //        fn.toLower();
         WFile f;


### PR DESCRIPTION
I was surprised, that the action Button had the label "Öffnen" (Open), after selecting "Save As.." to save the Build Logfile.

Tested on Linux with Wine

(The WFileDialog class is implemented in bld/wclass/cpp/wfiledlg.cpp)

--
Regards ... Detlef