### PR TITLE
linuxppc: Declare a linuxppc target for wlink and owcc

### DIFF
--- a/bld/wl/lnk/specs.sp
+++ b/bld/wl/lnk/specs.sp
@@ -394,6 +394,19 @@ system begin linuxmips
     op norelocs
 :endsegment
 end
+system begin linuxppc
+:segment Pspecs
+    ARCH ppc -bt=linux
+:elsesegment Pwlsystem
+    option osname='Linux PowerPC'
+    libpath '%WATCOM%/libppc'
+    libpath '%WATCOM%/libppc/linux'
+    format elf
+    runtime linux
+    op exportall
+    op norelocs
+:endsegment
+end
 system begin nt
 :segment Pspecs
     ARCH i386 -bt=nt


### PR DESCRIPTION
That's far from working, but a mini step.

No arch specific headers or runtime libraries for ppc-linux are available.

--
Regards ... Detlef