### PR TITLE
wccmps: build the c compiler also for an i386-linux host

### DIFF
--- a/bld/cc/mps/linux386/makefile
+++ b/bld/cc/mps/linux386/makefile
@@ -1,4 +1,4 @@
-#pmake: nobuild target_mips 386 linux os_linux cpu_386
+#pmake: build target_mips 386 linux os_linux cpu_386
 
 host_os  = linux
 host_cpu = 386


### PR DESCRIPTION
since wccmps builds already for a x86_64-linux host, 
enable the build also for an i386-linux host feels better.

--
Regards
Detlef