### PR TITLE
WGML doc: fix the year 2000 bug in the old binary DOS wgml tools

### DIFF
--- a/bld/cg/doc/cgref.gml
+++ b/bld/cg/doc/cgref.gml
@@ -61,7 +61,7 @@
 :FRONTM.
 :TITLEP.
 :TITLE.&company Code Generator Interface
-:CMT. :DATE.
+:DATE.&cpyyear.
 :eTITLEP.
 :TOC.
 .do end

--- a/bld/dwarf/dw/doc/dwref.gml
+++ b/bld/dwarf/dw/doc/dwref.gml
@@ -20,7 +20,7 @@
 :TITLE.Draft #6
 :AUTHOR.Originally written by WATCOM International Corp.
 :AUTHOR.Revised by Open Watcom contributors
-:CMT. :DATE.
+:DATE.&cpyyear.
 :eTITLEP.
 :TOC.
 .pa odd

--- a/bld/dwarf/dw/doc/dwref.gml
+++ b/bld/dwarf/dw/doc/dwref.gml
@@ -20,7 +20,7 @@
 :TITLE.Draft #6
 :AUTHOR.Originally written by WATCOM International Corp.
 :AUTHOR.Revised by Open Watcom contributors
-:DATE.
+:CMT. :DATE.
 :eTITLEP.
 :TOC.
 .pa odd


### PR DESCRIPTION

Welcome in the year 19123.

That's the current year on the title page of the pdf documentation of the dwarf writer library (dwdoc.pdf).

https://github.com/open-watcom/open-watcom-v2-wikidocs/blob/master/docs/dwdoc.pdf

We can`t change the binary DOS tools, but we can avoid using the buggy
":DATE. " command and hide the bug.

--
Regards ... Detlef
