### PR TITLE
owcc: Accept pthread and pedantic as alias for mthreads and Wextra

### DIFF
--- a/bld/wcl/c/owcc.c
+++ b/bld/wcl/c/owcc.c
@@ -235,6 +235,7 @@ static option_mapping mappings[] = {
     { "mwindows",                       "bg" },
     { "mconsole",                       "bc" },
     { "mthreads",                       "bm" },
+    { "pthread",                        "bm" },
     { "mrtdll",                         "br" },
     { "mdefault-windowing",             "bw" },
     { "mhard-emu-float",                "fpi" },
@@ -242,6 +243,7 @@ static option_mapping mappings[] = {
     { "w",                              "w0" },
     { "Wlevel:",                        "w" },
     { "Wall",                           "w4" },
+    { "pedantic",                       "wx" },
     { "Wextra",                         "wx" },
     { "Werror",                         "we" },
     { "Wno-n:",                         "wcd=" }, /* NOTE: this needs to be listed before -Wn to work */
@@ -659,7 +661,7 @@ static  int  ParseArgs( int argc, char **argv )
 #else
                         "b:CcD:Ef:g::"
                         "HI:i::L:l:M::m:"
-                        "O::o:P::QSs::U:vW::wx::yz::",
+                        "O::o:P::p:QSs::U:vW::wx::yz::",
 #endif
                         UsageText )) != -1 ) {
 

--- a/bld/wcl/h/owccopts.gml
+++ b/bld/wcl/h/owccopts.gml
@@ -774,7 +774,14 @@
 :number. . . =<stack_size>
 :target. any
 
+:cmt. used on windows
 :option. mthreads
+:usage. build Multi-thread application
+:group. 7
+:target. any
+
+:cmt. used on unix
+:option. pthread
 :usage. build Multi-thread application
 :group. 7
 :target. any


### PR DESCRIPTION

Most unix based Open Source Projects expect gcc or clang as compiler.
(or the gcc port mingw on windows)

OpenWatcom is old and the userbase is so small compared to gcc or clang,
that porting the affected projects to support OpenWatcom is nearly impossible.

Sometimes the only Problem when using owcc instead of gcc/clang
is a commandline option, which is not handled by owcc.

By making owcc commandline handling less strict,
OpenWatcom can be used more often as a dropin for gcc or clang.

This patch allows owcc to accept "-pthread" and "-pedantic":

-pthread option in gcc / clang:
* defines _REENTRANT (obsolete, was selecting multithread aware implementations)
* links with libpthread

With this patch, "-pthread" is an alias for the windows based option "-mthreads"
For linking, no adjustment is needed, as the
OpenWatcom runtime library already includes the pthread code.

-pedantic option in gcc / clang
* Use more checks as with "-Wall" and "-Wextra"

With this patch, "-pedantic" is an alias for "-Wextra".

--
Regards ... Detlef