### PR TITLE
Fixing D3DTEXTUREMAGFILTER member names.

### DIFF
--- a/bld/w32api/include/directx/d3dtypes.mh
+++ b/bld/w32api/include/directx/d3dtypes.mh
@@ -1485,6 +1485,7 @@ typedef enum _D3DTEXTUREOP {
 #endif
 
 /* Direct3D texture magnification filters */
+#if (DIRECT3D_VERSION >= 0x0600)
 typedef enum _D3DTEXTUREMAGFILTER {
     D3DTFG_POINT            = 1,
     D3DTFG_LINEAR           = 2,
@@ -1493,6 +1494,7 @@ typedef enum _D3DTEXTUREMAGFILTER {
     D3DTFG_ANISOTROPIC      = 5,
     D3DTFG_FORCE_DWORD      = 0x7FFFFFFF
 } D3DTEXTUREMAGFILTER;
+#endif
 
 /* Direct3D texture minification filters */
 #if (DIRECT3D_VERSION >= 0x0600)

--- a/bld/w32api/include/directx/d3dtypes.mh
+++ b/bld/w32api/include/directx/d3dtypes.mh
@@ -1485,16 +1485,14 @@ typedef enum _D3DTEXTUREOP {
 #endif
 
 /* Direct3D texture magnification filters */
-#if (DIRECT3D_VERSION >= 0x0600)
 typedef enum _D3DTEXTUREMAGFILTER {
     D3DTFG_POINT            = 1,
     D3DTFG_LINEAR           = 2,
     D3DTFG_FLATCUBIC        = 3,
-    D3DTFG_GUASSIANCUBIC    = 4,
-    D3DTFG_ANSIOTROPIC      = 5,
+    D3DTFG_GAUSSIANCUBIC    = 4,
+    D3DTFG_ANISOTROPIC      = 5,
     D3DTFG_FORCE_DWORD      = 0x7FFFFFFF
 } D3DTEXTUREMAGFILTER;
-#endif
 
 /* Direct3D texture minification filters */
 #if (DIRECT3D_VERSION >= 0x0600)


### PR DESCRIPTION
Fixing D3DTEXTUREMAGFILTER member names:

1. D3DTFG_GUASSIANCUBIC -> D3DTFG_GAUSSIANCUBIC
2. D3DTFG_ANSIOTROPIC -> D3DTFG_ANISOTROPIC

to match original names in DirectX SDKs.

Also removing check for 0x600 version. There is no such version check in DirectX 6.0 SDK, and those values definitely were supported in at least DirectX 5.0.