### PR TITLE
Windows 2x submenu check icon translation wrc 20231225 0142

### DIFF
--- a/bld/rc/rc/c/semsnglw.c
+++ b/bld/rc/rc/c/semsnglw.c
@@ -438,12 +438,6 @@ static bool writeTheWindows2xIcon( FullIconDirEntry *entry, WResID *name, ResMem
 } /* writeTheWindows2xIcon */
 
 static bool IconIsWin2xCompatible( FullIconDirEntry *entry ) {
-    fprintf(stderr,"%ux%u %u-plane %ubpp\n",
-        entry->Entry.Res.Info.Width,
-        entry->Entry.Res.Info.Height,
-        entry->Entry.Res.Info.Planes,
-        entry->Entry.Res.Info.BitCount);
-
     if( entry->Entry.Res.Info.Width == 64 && entry->Entry.Res.Info.Height == 64 &&
         entry->Entry.Res.Info.Planes == 1 && entry->Entry.Res.Info.BitCount == 1 )
         return true;

--- a/bld/rc/rc/c/semsnglw.c
+++ b/bld/rc/rc/c/semsnglw.c
@@ -477,21 +477,19 @@ static void AddIconResource( WResID *name, ResMemFlags flags, ResMemFlags group_
         goto READ_DIR_ERROR;
 
     if ( CmdLineParms.VersionStamp20 ) {
+        FullIconDirEntry *entry;
+
         /* More info needed */
-        {
-            FullIconDirEntry *entry;
+        for( entry = dir.Head; entry != NULL; entry = entry->Next ) {
+            BitmapInfoHeader dibhead;
 
-            for( entry = dir.Head; entry != NULL; entry = entry->Next ) {
-                BitmapInfoHeader dibhead;
+            if( RESSEEK( fp, entry->Entry.Ico.Offset, SEEK_SET ) )
+                goto COPY_ICONS_ERROR;
+            if( ReadBitmapInfoHeader( &dibhead, fp ) != RS_OK )
+                goto COPY_ICONS_ERROR;
 
-                if( RESSEEK( fp, entry->Entry.Ico.Offset, SEEK_SET ) )
-                    goto COPY_ICONS_ERROR;
-                if( ReadBitmapInfoHeader( &dibhead, fp ) != RS_OK )
-                    goto COPY_ICONS_ERROR;
-
-                entry->Entry.Res.Info.Planes = dibhead.Planes;
-                entry->Entry.Res.Info.BitCount = dibhead.BitCount;
-            }
+            entry->Entry.Res.Info.Planes = dibhead.Planes;
+            entry->Entry.Res.Info.BitCount = dibhead.BitCount;
         }
 
         /* Windows 2.0 has a more strict requirement of icon resources:
@@ -501,7 +499,7 @@ static void AddIconResource( WResID *name, ResMemFlags flags, ResMemFlags group_
          *
          * If the icon directory does not offer a 64x64x1bpp icon, then
          * pick the first one and print a warning. */
-        FullIconDirEntry *entry = FindWindows2xCompatibleIcon( &dir );
+        entry = FindWindows2xCompatibleIcon( &dir );
         if( !entry ) {
             RcWarning( WARN_ICON_WIN2X );
             entry = dir.Head;

--- a/bld/rc/rc/h/rc.msg
+++ b/bld/rc/rc/h/rc.msg
@@ -323,3 +323,6 @@ pick(   WARN_DLGFONT_WIN2X,
 pick(   WARN_SUBMEN_WIN2X,
         "MENU resources cannot have submenus in Windows 2.x.",
         "MENU resources cannot have submenus in Windows 2.x." )
+pick(   WARN_ICON_WIN2X,
+        "ICON resource is incompatible with Windows 2.x. Please add a compatible size and depth version to your ICO file.",
+        "ICON resource is incompatible with Windows 2.x. Please add a compatible size and depth version to your ICO file." )

--- a/bld/rc/rc/h/rc.msg
+++ b/bld/rc/rc/h/rc.msg
@@ -320,3 +320,6 @@ pick(   ERR_DELETING_FILE,
 pick(   WARN_DLGFONT_WIN2X,
         "FONT not valid for Windows 2.x DIALOG, ignored.",
         "FONT not valid for Windows 2.x DIALOG, ignored." )
+pick(   WARN_SUBMEN_WIN2X,
+        "MENU resources cannot have submenus in Windows 2.x.",
+        "MENU resources cannot have submenus in Windows 2.x." )

--- a/bld/wres/c/resiccu.c
+++ b/bld/wres/c/resiccu.c
@@ -34,6 +34,7 @@
 #include "resiccu.h"
 #include "reserr.h"
 #include "wresrtns.h"
+#include "write.h"
 
 bool ResWriteIconCurDirHeader( const IconCurDirHeader *head, FILE *fp )
 /*********************************************************************/
@@ -96,3 +97,30 @@ bool ResWriteCurHotspot( const CurHotspot *hotspot, FILE *fp )
         return( WRES_ERROR( WRS_WRITE_FAILED ) );
     return( false );
 }
+
+bool ResWriteWinOldIconHeader( const IconDirEntry *entry, FILE *fp )
+/************************************************************/
+{
+    bool error;
+
+    error = ResWriteUint8( 0x01, fp ); // rnType
+    if( !error )
+        error = ResWriteUint8( 0x01, fp ); // rnFlags. Magic undocumented bit 0 must be set or Windows 2.x shows the icon at full scale and randomly corrupts it.
+    if( !error )
+        error = ResWriteUint16( 0x0000, fp ); // rnZero
+    if( !error )
+        error = ResWriteUint16( 0x0000, fp ); // bmType
+    if( !error )
+        error = ResWriteUint16( entry->Info.Width, fp ); // bmWidth
+    if( !error )
+        error = ResWriteUint16( entry->Info.Height, fp ); // bmHeight
+    if( !error )
+        error = ResWriteUint16( (((entry->Info.Width*entry->Info.BitCount+15u)&(~15u))/8u)/*WORD align*/, fp ); // bmWidthBytes
+    if( !error )
+        error = ResWriteUint8( entry->Info.BitCount != 1 ? 1 : 0, fp ); // bmPlanes
+    if( !error )
+        error = ResWriteUint8( entry->Info.BitCount != 1 ? entry->Info.BitCount : 0, fp ); // bmBitsPixel
+
+    return( error );
+}
+

--- a/bld/wres/h/resiccu.h
+++ b/bld/wres/h/resiccu.h
@@ -78,5 +78,6 @@ extern bool ResWriteCurDirEntry( const CurDirEntry * entry, FILE *fp );
 extern bool ResReadIconCurDirHeader( IconCurDirHeader *, FILE *fp );
 extern bool ResReadIconDirEntry( IconDirEntry * entry, FILE *fp );
 extern bool ResReadCurDirEntry( CurDirEntry * entry, FILE *fp );
+extern bool ResWriteWinOldIconHeader( const IconDirEntry *entry, FILE *fp );
 
 #endif


### PR DESCRIPTION
This change allows existing ICO resources to work with Windows 2.0 provided that one of the formats contained in the ICON directory is a 64x64 monochrome image.

This also adds a warning if submenus are listed in any MENU resource when targeting Windows 2.0.