### PR TITLE
Resource compiler: CURSOR resource translation for Windows 2.x targets

### DIFF
--- a/bld/rc/rc/h/rc.msg
+++ b/bld/rc/rc/h/rc.msg
@@ -326,3 +326,6 @@ pick(   WARN_SUBMEN_WIN2X,
 pick(   WARN_ICON_WIN2X,
         "ICON resource is incompatible with Windows 2.x. Please add a compatible size and depth version to your ICO file.",
         "ICON resource is incompatible with Windows 2.x. Please add a compatible size and depth version to your ICO file." )
+pick(   WARN_CURSOR_WIN2X,
+        "CURSOR resource is incompatible with Windows 2.x. Please add a compatible size and depth version to your CUR file.",
+        "CURSOR resource is incompatible with Windows 2.x. Please add a compatible size and depth version to your CUR file." )

--- a/bld/wres/c/resiccu.c
+++ b/bld/wres/c/resiccu.c
@@ -124,3 +124,27 @@ bool ResWriteWinOldIconHeader( const IconDirEntry *entry, FILE *fp )
     return( error );
 }
 
+bool ResWriteWinOldCursorHeader( const CurDirEntry *entry, const CurHotspot *hotspot, FILE *fp ) {
+    bool error;
+
+    error = ResWriteUint8( 0x03, fp ); // rnType
+    if( !error )
+        error = ResWriteUint8( 0x01, fp ); // rnFlags. Magic undocumented bit 0 must be set or Windows 2.x shows the icon at full scale and randomly corrupts it.
+    if( !error )
+        error = ResWriteUint16( hotspot->X, fp ); // rnZero
+    if( !error )
+        error = ResWriteUint16( hotspot->Y, fp ); // bmType
+    if( !error )
+        error = ResWriteUint16( entry->Width, fp ); // bmWidth
+    if( !error )
+        error = ResWriteUint16( entry->Height, fp ); // bmHeight
+    if( !error )
+        error = ResWriteUint16( (((entry->Width*entry->BitCount+15u)&(~15u))/8u)/*WORD align*/, fp ); // bmWidthBytes
+    if( !error )
+        error = ResWriteUint8( entry->BitCount != 1 ? 1 : 0, fp ); // bmPlanes
+    if( !error )
+        error = ResWriteUint8( entry->BitCount != 1 ? entry->BitCount : 0, fp ); // bmBitsPixel
+
+    return( error );
+}
+

--- a/bld/wres/h/resiccu.h
+++ b/bld/wres/h/resiccu.h
@@ -79,5 +79,6 @@ extern bool ResReadIconCurDirHeader( IconCurDirHeader *, FILE *fp );
 extern bool ResReadIconDirEntry( IconDirEntry * entry, FILE *fp );
 extern bool ResReadCurDirEntry( CurDirEntry * entry, FILE *fp );
 extern bool ResWriteWinOldIconHeader( const IconDirEntry *entry, FILE *fp );
+extern bool ResWriteWinOldCursorHeader( const CurDirEntry *entry, const CurHotspot *hotspot, FILE *fp );
 
 #endif


### PR DESCRIPTION
This code also splits the image+mask code out into a common function for both CURSOR and ICON translation.