### PR TITLE
trmem: Fix header width on 64bit Linux builds

### DIFF
--- a/bld/trmem/trmem.c
+++ b/bld/trmem/trmem.c
@@ -92,10 +92,16 @@ msg(MIN_ALLOC,          "%W allocation of %T less than minimum size" );
 #elif defined( _M_I86LM ) || defined( _M_I86HM )
     msg(PRT_LIST_1,     "   Who      Addr    Size   Call   Contents" );
     msg(PRT_LIST_2,     "========= ========= ==== ======== ===========================================" );
+#elif defined( __SIZEOF_POINTER__ ) && ( __SIZEOF_POINTER__ == 8) && (__SIZEOF_LONG__ == 8 )
+/* Building OW on a 64bit Host with gcc/clang and similar compiler: a long is 64bit width */
+    msg(PRT_LIST_1,     "  Who              Addr             Size     Call             Contents" );
+    msg(PRT_LIST_2,     "================ ================ ======== ================ ===========================" );
 #elif defined( _WIN64 )
+/* Building OW on Win64: a long is only 32bit width */
     msg(PRT_LIST_1,     "  Who              Addr             Size     Call     Contents" );
     msg(PRT_LIST_2,     "================ ================ ======== ======== ===========================" );
 #else
+/* Default: Building OW on a 32bit Host */
     msg(PRT_LIST_1,     "  Who      Addr     Size     Call     Contents" );
     msg(PRT_LIST_2,     "======== ======== ======== ======== ===========================================" );
 #endif


### PR DESCRIPTION
The header for a memory leak report from bld/trmem 
is better to read  with the correct wide.

Example from building hcwin/nt386:
```
bwcc386 -zq -D_BLDVER=1300 -D_CYEAR=2023  -j-we -od -d2 -x-wpx -xx -zam -fo=trmem.obj -fpi -mf -zc -bt=nt -DWINVER=0x400 -D_WIN32_IE=0x300       -wx-wce=C310-zastd=c99 -D_ENABLE_AUTODEPEND         -I"../h"  -I"../../../bld/hdr/dos/h" -I"../../../bld/w32api/nt/h" -I"../../../bld/trmem" -I"../../../bld/watcom/h" ../../../bld/trmem/trmem.c
%write whc.lnk debug dwarf all op nored op symfile op map sys nt
bwlink op q name whc.exe @whc.lnk
Current usage: 0000000000000314 bytes; Peak usage: 0000000000226140 bytes
  Who              Addr             Size     Call             Contents
================ ================ ======== ================ ===========================
0000000000000000 00005625daccecc0 00000019 0000000000001eec 5f5f776370705f34 5f756e646566__wcpp_4_undef
0000000000000000 00005625dad5be80 00000019 0000000000001eeb 5f5f776370705f34 5f756e646566__wcpp_4_undef

```


--
Regards ... Detlef