### PR TITLE
trmem: Adjust non Portable 64bit OS detection

### DIFF
--- a/bld/trmem/trmem.c
+++ b/bld/trmem/trmem.c
@@ -97,7 +97,7 @@ msg(MIN_ALLOC,          "%W allocation of %T less than minimum size" );
 #elif defined( _M_I86LM ) || defined( _M_I86HM )
     msg(PRT_LIST_1,     "   Who      Addr    Size   Call   Contents" );
     msg(PRT_LIST_2,     "========= ========= ==== ======== ===========================================" );
-#elif defined( _M_X64 )
+#elif defined( _M_X64 ) || defined( __x86_64__ ) || defined( __amd64__ ) || defined( __amd64 )
     msg(PRT_LIST_1,     "  Who              Addr             Size     Call     Contents" );
     msg(PRT_LIST_2,     "================ ================ ======== ======== ===========================" );
 #else


### PR DESCRIPTION
The Previous change from _WIN64 to _M_X64 does not work here (gcc 13).

The Macro _M_X64 is non portable and only used on Windows.
Add additional checks, which are already used in other locations in the source.

