### PR TITLE
__declspec(fld) to enable 80-bit long double (same as if -fld were given) but on a symbol by symbol basis

### DIFF
--- a/bld/cc/c/ctype.c
+++ b/bld/cc/c/ctype.c
@@ -311,7 +311,7 @@ static TYPEPTR GetScalarType( bool *plain_int, type_mask bmask, type_modifiers f
         data_type = TYP_FLOAT;
         break;
     case M_LONG | M_DOUBLE:
-        if( CompFlags.use_long_double ) {
+        if( CompFlags.use_long_double || (flags & FLAG_FLD) ) {
             data_type = TYP_LONG_DOUBLE;
             break;
         }
@@ -323,7 +323,7 @@ static TYPEPTR GetScalarType( bool *plain_int, type_mask bmask, type_modifiers f
         data_type = TYP_FCOMPLEX;
         break;
     case M_COMPLEX | M_LONG | M_DOUBLE:
-        if( CompFlags.use_long_double ) {
+        if( CompFlags.use_long_double || (flags & FLAG_FLD) ) {
             data_type = TYP_LDCOMPLEX;
             break;
         }
@@ -335,7 +335,7 @@ static TYPEPTR GetScalarType( bool *plain_int, type_mask bmask, type_modifiers f
         data_type = TYP_FIMAGINARY;
         break;
     case M_IMAGINARY | M_LONG | M_DOUBLE:
-        if( CompFlags.use_long_double ) {
+        if( CompFlags.use_long_double || (flags & FLAG_FLD) ) {
             data_type = TYP_LDIMAGINARY;
             break;
         }
@@ -555,6 +555,8 @@ static void DeclSpecifiers( bool *plain_int, decl_info *info )
                         modifier = FLAG_NORETURN;
                     } else if( strcmp( Buffer, "farss" ) == 0 ) {
                         modifier = FLAG_FARSS;
+                    } else if( strcmp( Buffer, "fld" ) == 0 ) {
+                        modifier = FLAG_FLD;
                     } else {
                         CErr1( ERR_INVALID_DECLSPEC );
                     }
@@ -596,6 +598,14 @@ static void DeclSpecifiers( bool *plain_int, decl_info *info )
                         CErr1( ERR_INVALID_DECLSPEC );
                     } else {
                         info->decl_mod |= modifier;
+                    }
+                }
+                if( modifier & FLAG_FLD ) {
+                    if( info->decl_mod & FLAG_FLD ) {
+                        CErr1( ERR_INVALID_DECLSPEC );
+                    } else {
+                        info->decl_mod |= modifier;
+                        flags |= FLAG_FLD;
                     }
                 }
                 NextToken();
@@ -652,6 +662,7 @@ static void DeclSpecifiers( bool *plain_int, decl_info *info )
                     info->naked = true;
                 }
             }
+            flags |= info->decl_mod & FLAG_FLD;
             AdvanceToken();
             continue;
         default:

--- a/bld/cc/h/ctypes.h
+++ b/bld/cc/h/ctypes.h
@@ -112,6 +112,7 @@ typedef enum    type_modifiers {    /* type   leaf   sym   */
     FLAG_ABORTS     = 0x40000,      /* Y40000              __declspec(aborts) */
     FLAG_NORETURN   = 0x80000,      /* Y80000              __declspec(noreturn) */
     FLAG_FARSS      = 0x100000,     /* Y100000             use far ss for auto variables (-zu) */
+    FLAG_FLD        = 0x200000,     /* Y200000             force enable long double */
 } type_modifiers;
 
 #define MASK_CV_QUALIFIERS  (FLAG_CONST|FLAG_VOLATILE)


### PR DESCRIPTION
Allow compiled C/C++ code to enable 80-bit long double on a symbol by symbol basis by adding __declspec(fld) to the data type. Allow the __declspec(fld) to function the same as if -fld were enabled at that very point.

This can help enable support for 80-bit long double gradually through the codebase without breaking anything.

Related to https://github.com/open-watcom/open-watcom-v2/issues/1200