### PR TITLE
deps(ci): use Node 20 based actions

### DIFF
--- a/.github/actions/artfload/action.yml
+++ b/.github/actions/artfload/action.yml
@@ -51,7 +51,7 @@ runs:
       }
     shell: pwsh
   - name: Restore Artifact ${{ steps.artifact_name.outputs.id }}
-    uses: actions/download-artifact@v3
+    uses: actions/download-artifact@v4
     with:
       name: ${{ steps.artifact_name.outputs.id }}
       path: ${{ steps.dstpath.outputs.path }}

--- a/.github/actions/artfsave/action.yml
+++ b/.github/actions/artfsave/action.yml
@@ -70,7 +70,7 @@ runs:
       }
     shell: pwsh
   - name: Upload Artifact ${{ steps.artifact_name.outputs.id }}
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name:             ${{ steps.artifact_name.outputs.id }}
       path:             ${{ steps.srcpath.outputs.path }}

--- a/.github/workflows/artfdel.yml
+++ b/.github/workflows/artfdel.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Delete Artifacts
       uses: "./.github/actions/artfdel"
       with:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -139,7 +139,7 @@ jobs:
         gitpath:    'rel'
         owdebug:    ${{ vars.OWDEBUG }}
     - name: Upload Artifact owsnapshot
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name:           'owsnapshot'
         path:           ${{ steps.owsnapshot.outputs.fullname }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
   bootow-lnx:
     needs: start-start
     name: Bootstrap Linux OW
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Bootstrap Linux OW
       uses: "./.github/actions/testboot"
       with:
@@ -51,7 +51,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Bootstrap Windows OW
       uses: "./.github/actions/testboot"
       with:
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Load all release files
       uses: "./.github/actions/relload"
       with:
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Load all release files
       uses: "./.github/actions/relload"
       with:

--- a/.github/workflows/cibldlnx.yml
+++ b/.github/workflows/cibldlnx.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Bootstrap
       uses: "./.github/actions/boot"
       with:
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Build
       uses: "./.github/actions/build"
       with:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Tests
       uses: "./.github/actions/tests"
       with:
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Load Artifact
       uses: "./.github/actions/artfload"
       with:

--- a/.github/workflows/cibldnt.yml
+++ b/.github/workflows/cibldnt.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Bootstrap
       uses: "./.github/actions/boot"
       with:
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Build
       uses: "./.github/actions/build"
       with:
@@ -74,7 +74,7 @@ jobs:
           doctype: docwin
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Docs Build
       uses: "./.github/actions/docbuild"
       with:
@@ -89,7 +89,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Tests
       uses: "./.github/actions/tests"
       with:
@@ -102,7 +102,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Load Artifact
       uses: "./.github/actions/artfload"
       with:

--- a/.github/workflows/cibldosx.yml
+++ b/.github/workflows/cibldosx.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Bootstrap
       uses: "./.github/actions/boot"
       with:
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Build
       uses: "./.github/actions/build"
       with:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,7 +21,7 @@ jobs:
       runit: ${{ steps.check_tag.outputs.old }}
     steps:
     - name: Checkout Actions
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Check tag reference
       id: check_tag
       uses: "./.github/actions/ghtagchk"
@@ -39,7 +39,7 @@ jobs:
       OWCOV_RESULTS_ARCHIVE: 'open-watcom-v2.tgz'
     steps:
     - name: Checkout Actions
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Install DOSBOX
       uses: "./.github/actions/dosboxin"
       with:
@@ -154,7 +154,7 @@ jobs:
 #      OWCOV_RESULTS_ARCHIVE: 'open-watcom-v2.zip'
 #    steps:
 #    - name: Checkout Actions
-#      uses: actions/checkout@v3.5.0
+#      uses: actions/checkout@v4.1.1
 #    - name: Install DOSBOX
 #      uses: "./.github/actions/dosboxin"
 #      with:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -100,7 +100,7 @@ jobs:
       shell: bash
     - if: vars.OWDEBUG == 1
       name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name:             'coverity'
         path:             ${{ steps.tarname.outputs.fullname }}

--- a/.github/workflows/rel-lnx.yml
+++ b/.github/workflows/rel-lnx.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Bootstrap Linux
       uses: "./.github/actions/boot"
       with:
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Build
       uses: "./.github/actions/build"
       with:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Tests
       uses: "./.github/actions/tests"
       with:

--- a/.github/workflows/rel-nt.yml
+++ b/.github/workflows/rel-nt.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Bootstrap
       uses: "./.github/actions/boot"
       with:
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Build
       uses: "./.github/actions/build"
       with:
@@ -74,7 +74,7 @@ jobs:
           doctype: docwin
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Documentation
       uses: "./.github/actions/docbuild"
       with:
@@ -89,7 +89,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Tests
       uses: "./.github/actions/tests"
       with:

--- a/.github/workflows/rel-osx.yml
+++ b/.github/workflows/rel-osx.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ inputs.image }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Bootstrap
       uses: "./.github/actions/boot"
       with:
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Build
       uses: "./.github/actions/build"
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       runit: ${{ steps.check_tag.outputs.old }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Check tag reference
       id: check_tag
       uses: "./.github/actions/ghtagchk"
@@ -106,7 +106,7 @@ jobs:
           insttype: snapshot
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Installer
       uses: "./.github/actions/install"
       with:
@@ -126,7 +126,7 @@ jobs:
       mrelid: ${{ steps.rel_rel.outputs.mrelid }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: GitHub Release
       id: rel_rel
       uses: "./.github/actions/release"
@@ -161,7 +161,7 @@ jobs:
           asset: snapshot
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - run: echo "drelid=${{ needs.release.outputs.drelid }};mrelid=${{ needs.release.outputs.mrelid }}"
       shell: bash
     - name: Upload ${{ matrix.display }} Asset
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Call to delete Artifacs
       uses: "./.github/actions/artfdelc"
       with:

--- a/.github/workflows/wikidocs.yml
+++ b/.github/workflows/wikidocs.yml
@@ -104,12 +104,12 @@ jobs:
         OWGHTOKEN: ${{ secrets.OWGHTOKEN }}
         OWWIKIPROJ: open-watcom/open-watcom-v2-wikidocs
     - name: Download Artifact html
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: 'rel-wikihtml-vs2019'
         path: docs
     - name: Download Artifact pdf
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: 'rel-wikipdf-vs2019'
         path: docs

--- a/.github/workflows/wikidocs.yml
+++ b/.github/workflows/wikidocs.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: windows-2019
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Bootstrap
       uses: "./.github/actions/boot"
       with:
@@ -74,7 +74,7 @@ jobs:
           owtarget: '.and wikipdf .or -- -- docset=wikipdf -i'
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Docs Build
       uses: "./.github/actions/docbuild"
       with:
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.1.1
     - name: Call to delete Artifacts
       uses: "./.github/actions/artfdelc"
       with:


### PR DESCRIPTION
Node 16 is deprecated: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

This PR contains a simple `actions/checkout` bump

~~There are breaking changes in the `@actions/download-artifacts`, which I need to read up on before updating the PR:
Basically when migrating from `actions/download-artifacts@v3` to `v4` the artifacts created by `v3` cannot be downloaded by `v4` version of the action.~~
All artifacts are build and downloaded in the same action, it's a simple ad bumping all publish/download artifact actions together

- https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
- https://github.com/actions/download-artifact/blob/main/README.md#breaking-changes
- https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md