### PR TITLE
trmem: Print the allocation counter in the summary

### DIFF
--- a/bld/trmem/trmem.c
+++ b/bld/trmem/trmem.c
@@ -83,7 +83,7 @@ msg(NULL_PTR,           "%W NULL pointer" );
 msg(NO_ROUTINE,         "Tracker was not given a %S routine!" );
 msg(NOT_IN_ALLOCATION,  "%W %D not in any allocation" );
 msg(OVERRUN_2,          "%W %D+%T overruns allocation %D+%T" );
-msg(PRT_USAGE,          "Current usage: %Z bytes; Peak usage: %Z bytes" );
+msg(PRT_USAGE,          "Current usage: %Z bytes; Peak usage: %Z bytes; Allocations: %3" );
 msg(MIN_ALLOC,          "%W allocation of %T less than minimum size" );
 #if defined( _M_I86SM )
     msg(PRT_LIST_1,     "Who  Addr Size   Call   Contents" );
@@ -734,7 +734,7 @@ int _trmem_chk_range( void *start, size_t len, _trmem_who who, _trmem_hdl hdl )
 void _trmem_prt_usage( _trmem_hdl hdl )
 /*************************************/
 {
-    trPrt( hdl, MSG_PRT_USAGE, hdl->mem_used, hdl->max_mem );
+    trPrt( hdl, MSG_PRT_USAGE, hdl->mem_used, hdl->max_mem, hdl->alloc_no);
 }
 
 unsigned _trmem_prt_list( _trmem_hdl hdl )


### PR DESCRIPTION
This can help to find useful areas for optimizations

When compiling OpenWatcom, I see >1 million allocations in a single project
(bld/causeway/cw32/dos386)
***Current usage: 000000000000001c bytes; Peak usage: 0000000000510ebe bytes; Allocations: 000a0091

