### PR TITLE
unistd.h: Support also _SC_PAGE_SIZE for sysconf()

### DIFF
--- a/bld/clib/linux/c/sysconf.c
+++ b/bld/clib/linux/c/sysconf.c
@@ -159,6 +159,7 @@ _WCRTLINK long sysconf( int name )
         ret = TZNAME_MAX;
         break;
     case _SC_PAGESIZE:
+        /* Also used for _SC_PAGE_SIZE */
 #ifdef PAGE_SIZE
         ret = PAGE_SIZE;
 #else

--- a/bld/hdr/watcom/unistd.mh
+++ b/bld/hdr/watcom/unistd.mh
@@ -62,7 +62,7 @@
 #endif
 
 /* Symbolic constants for sysconf */
-/* caution: the module sysconf.c bound checks _SC_ARG_MAX ... _SC_PAGESIZE */
+/* caution: the module sysconf.c bound checks _SC_ARG_MAX ... _SC_THREAD_STACK_MIN */
 #define _SC_ARG_MAX                         1
 #define _SC_CHILD_MAX                       2
 #define _SC_CLK_TCK                         3
@@ -73,6 +73,7 @@
 #define _SC_VERSION                         8
 #define _SC_STREAM_MAX                      9
 #define _SC_TZNAME_MAX                      10
+#define _SC_PAGE_SIZE                       11
 #define _SC_PAGESIZE                        11
 #define _SC_NPROCESSORS_CONF                12
 #define _SC_NPROCESSORS_ONLN                13


### PR DESCRIPTION
The value is the same as _SC_PAGESIZE (as allowed by POSIX)
to reduce the implementation codesize to 0 Byte.

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html

_SC_PAGE_SIZE is required by POSIX and needed to compile zycore-c

--
Regards ... Detlef