### PR TITLE
rc/exedmp: Build the exedmp tool also on i386-linux

### DIFF
--- a/bld/rc/exedmp/builder.ctl
+++ b/bld/rc/exedmp/builder.ctl
@@ -15,10 +15,11 @@ set PROJDIR=<CWD>
 
 [ BLOCK <BLDRULE> rel cprel ]
 #============================
-    <CCCMD> os2386/exedmp.exe  "<OWRELROOT>/binp/"
-    <CCCMD> nt386/exedmp.exe   "<OWRELROOT>/binnt/"
-
-    <CCCMD> ntx64/exedmp.exe   "<OWRELROOT>/binnt64/"
+    <CCCMD> os2386/exedmp.exe   "<OWRELROOT>/binp/"
+    <CCCMD> nt386/exedmp.exe    "<OWRELROOT>/binnt/"
+    <CCCMD> ntx64/exedmp.exe    "<OWRELROOT>/binnt64/"
+    <CCCMD> linux386/exedmp.exe "<OWRELROOT>/binl/exedmp"
+    <CCCMD> linuxx64/exedmp.exe "<OWRELROOT>/binl64/exedmp"
 
 [ BLOCK . . ]
 

--- a/bld/rc/exedmp/c/main.c
+++ b/bld/rc/exedmp/c/main.c
@@ -35,7 +35,7 @@
 #include "format.h"
 
 
-void main( int argc, char *argv[] ) {
+int main( int argc, char *argv[] ) {
     Parameters          param;
     ExeFile             exeFile;
     bool                ret;
@@ -68,5 +68,7 @@ void main( int argc, char *argv[] ) {
                                     0 );
     }
     freeAllResources( &exeFile );
+
+    return 0;
 }
 

--- a/bld/rc/exedmp/linux386/makefile
+++ b/bld/rc/exedmp/linux386/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_linux  cpu_386
+
+host_os  = linux
+host_cpu = 386
+
+!include ../master.mif

--- a/bld/rc/exedmp/linuxx64/makefile
+++ b/bld/rc/exedmp/linuxx64/makefile
@@ -1,0 +1,6 @@
+#pmake:  nobuild os_linux  cpu_x64
+
+host_os  = linux
+host_cpu = x64
+
+!include ../master.mif


### PR DESCRIPTION

This tool uses Microsoft specific runtime functions
and needs more fixes for 64bit.

--
Regards ... Detlef
