### PR TITLE
as: Implement "-fr" for error report files

### DIFF
--- a/bld/as/c/main.c
+++ b/bld/as/c/main.c
@@ -74,6 +74,9 @@ int main( int argc, char **argv )
         Usage();
     } else {
         PP_Init( '#', PPSPEC_AS );
+        /* Default for backwards compatibility: Use an error file. */
+        _SetOption( USE_ERROR_FILE );
+        ObjSetErrorTemplate( "" );
         OPT_INIT( &data );
         files = NULL;
         if( OptionsInit( --argc, ++argv, &data, &files ) ) {

--- a/bld/as/c/options.c
+++ b/bld/as/c/options.c
@@ -326,7 +326,13 @@ bool OptionsInit( int argc, char **argv, OPT_STORAGE *data, OPT_STRING **files )
         ObjSetObjFile( data->fo_value->data );
     }
     if( data->fr ) {
-        // data->fr_value;
+        if( data->fr_value != NULL ) {
+            _SetOption( USE_ERROR_FILE );
+            ObjSetErrorTemplate( data->fr_value->data );
+        } else {
+            /* "-fr" without argument: disable the error report file */
+            _UnsetOption( USE_ERROR_FILE );
+        }
     }
 #ifdef AS_DEBUG_DUMP
     switch( data->dump

--- a/bld/as/h/obj.h
+++ b/bld/as/h/obj.h
@@ -42,6 +42,7 @@ typedef enum {
 
 extern owl_section_handle       CurrentSection;
 
+extern void ObjSetErrorTemplate( char *template_name );
 extern void ObjSetObjFile( char *obj_name );
 extern void ObjSwitchSection( reserved_section );
 extern bool ObjInit( char *file_name );

--- a/bld/as/h/options.gml
+++ b/bld/as/h/options.gml
@@ -165,7 +165,6 @@
 :option. fr
 :file.
 :optional.
-:internal.
 :usage. set error file name
 
 :option. i

--- a/bld/as/h/options.h
+++ b/bld/as/h/options.h
@@ -48,7 +48,8 @@ typedef enum {
     DUMP_SYMBOL_TABLE   = 0x0400,
     DUMP_INSTRUCTIONS   = 0x0800,
     DUMP_LEXER_BUFFER   = 0x1000,
-    DUMP_DEBUG_MSGS     = 0x2000
+    DUMP_DEBUG_MSGS     = 0x2000,
+    USE_ERROR_FILE      = 0x4000
 } as_flags;
 
 #define _SetOption( x )         ( AsOptions |= (x) )


### PR DESCRIPTION
The "-fr" argument breaks all risc assembler with owcc (see bug [#1265](https://github.com/open-watcom/open-watcom-v2/issues/1265#issuecomment-2037699564))

The "-fr" argument breaks dependency creation for some autotools projects with owcc
(LTP: Linux Test Project as example)

owcc detects the argument "-fr", but that's incomplete and undocumented
https://github.com/open-watcom/open-watcom-v2/blob/1400d891465a25d8e25cdee657aff51352149138/bld/wcl/c/owcc.c#L727

Supporting "-fr[=\<file\>]" in the RISC assembler or in owcc is an area for future enhancements.

--
Regards ... Detlef