### PR TITLE
whelp: Avoid a crash, when the search path has an empty segment

### DIFF
--- a/bld/hlpview/c/filelist.c
+++ b/bld/hlpview/c/filelist.c
@@ -187,7 +187,12 @@ static FileList *doFillFileList( const char *path, FileList *list )
         }
         *path_end = '\0';
         strcpy( buf, p );
-        len = strlen( buf ) - 1;
+
+        if( *buf != '\0' ) {
+            len = strlen( buf ) -1;
+        } else {
+            len = 0;
+        }
 #ifdef __UNIX__
         if( buf[len] == '/' )
             buf[len] = '\0';


### PR DESCRIPTION

The double colon in $PATH let whelp segfault,
when whelp is searching for available help files.

--
Regards ... Detlef