### PR TITLE
aui_sample: Remove wrong Prototype

### DIFF
--- a/bld/aui/sample/c/menus.c
+++ b/bld/aui/sample/c/menus.c
@@ -35,8 +35,6 @@
 #include "dlgoptn.h"
 
 
-extern void Password( const char *, char *, unsigned );
-
 void *SrchHistory;
 
 static gui_menu_struct FirstMenu[] = {


### PR DESCRIPTION
This fixes a compile error on x86_64-linux

(More is needed for building on linux)

-- 
Regards ... Detlef