### PR TITLE
clib/linux: Fix sysconf(_SC_NPROCESSORS_ONLN) result

### DIFF
--- a/bld/clib/linux/c/sysconf.c
+++ b/bld/clib/linux/c/sysconf.c
@@ -54,13 +54,20 @@
 static int __sysconf_nprocessors( void )
 {
     syscall_res res;
-    unsigned char mask[128];
+    unsigned char mask[128];    /* enough space for 1024 cores */
     int ret;
     int i;
+    int used;
 
     res = sys_call3( SYS_sched_getaffinity, (u_long)0, (u_long)(sizeof(mask)), (u_long)mask );
+    if ( __syscall_iserror( res ) ) {
+        _RWD_errno = __syscall_errno( res );
+        return( -1 );
+    }
+    used = __syscall_val( int, res );
+
     ret = 0;
-    for( i = 0; i < sizeof( mask ); i++ ) {
+    for( i = 0; i < used ; i++ ) {
         while( mask[i] ) {
             mask[i] &= mask[i] - 1;
             ret++;


### PR DESCRIPTION
Needed to fix sysconf(_SC_NPROCESSORS_ONLN)

Small testcase:
```

#include <stdio.h>
#include <unistd.h>

#ifndef _SC_NPROCESSORS_ONLN
#error "_SC_NPROCESSORS_ONLN not found"
#endif

int main(void)
{
    long res = sysconf(_SC_NPROCESSORS_ONLN);
    printf("%ld\n", res);
    return 0;
}
```

The initialization of the 128 byte array increases the 
resulting program by 512 byte,
because OpenWatcom creates 128 mov instructions (even with owcc -Os`),
but that is a different issue.

--
Regards ... Detlef