### PR TITLE
Define NT_TIB[32/64] types in winnt.h

### DIFF
--- a/bld/w32api/include/ddk/ntddk.mh
+++ b/bld/w32api/include/ddk/ntddk.mh
@@ -1067,50 +1067,7 @@ typedef struct _KEY_VIRTUALIZATION_INFORMATION {
 } KEY_VIRTUALIZATION_INFORMATION;
 typedef KEY_VIRTUALIZATION_INFORMATION  *PKEY_VIRTUALIZATION_INFORMATION;
 
-/* NT thread information block */
-typedef struct _NT_TIB {
-    struct _EXCEPTION_REGISTRATION_RECORD   *ExceptionList;
-    PVOID           StackBase;
-    PVOID           StackLimit;
-    PVOID           SubSystemTib;
-    union {
-        PVOID   FiberData;
-        ULONG   Version;
-    };
-    PVOID           ArbitraryUserPointer;
-    struct _NT_TIB  *Self;
-} NT_TIB;
-typedef NT_TIB  *PNT_TIB;
-
-/* NT thread information block (32-bit version) */
-typedef struct _NT_TIB32 {
-    ULONG   ExceptionList;
-    ULONG   StackBase;
-    ULONG   StackLimit;
-    ULONG   SubSystemTib;
-    union {
-        ULONG   FiberData;
-        ULONG   Version;
-    };
-    ULONG   ArbitraryUserPointer;
-    ULONG   Self;
-} NT_TIB32;
-typedef NT_TIB32    *PNT_TIB32;
-
-/* NT thread information block (64-bit version) */
-typedef struct _NT_TIB64 {
-    ULONG64 ExceptionList;
-    ULONG64 StackBase;
-    ULONG64 StackLimit;
-    ULONG64 SubSystemTib;
-    union {
-        ULONG64 FiberData;
-        ULONG   Version;
-    };
-    ULONG64 ArbitraryUserPointer;
-    ULONG64 Self;
-} NT_TIB64;
-typedef NT_TIB64    *PNT_TIB64;
+:include nttib.sp
 
 /* Process information classes */
 typedef enum _PROCESSINFOCLASS {

--- a/bld/w32api/include/nttib.sp
+++ b/bld/w32api/include/nttib.sp
@@ -1,0 +1,44 @@
+/* NT thread information block */
+typedef struct _NT_TIB {
+    struct _EXCEPTION_REGISTRATION_RECORD   *ExceptionList;
+    PVOID           StackBase;
+    PVOID           StackLimit;
+    PVOID           SubSystemTib;
+    union {
+        PVOID   FiberData;
+        ULONG   Version;
+    };
+    PVOID           ArbitraryUserPointer;
+    struct _NT_TIB  *Self;
+} NT_TIB;
+typedef NT_TIB  *PNT_TIB;
+
+/* NT thread information block (32-bit version) */
+typedef struct _NT_TIB32 {
+    ULONG   ExceptionList;
+    ULONG   StackBase;
+    ULONG   StackLimit;
+    ULONG   SubSystemTib;
+    union {
+        ULONG   FiberData;
+        ULONG   Version;
+    };
+    ULONG   ArbitraryUserPointer;
+    ULONG   Self;
+} NT_TIB32;
+typedef NT_TIB32    *PNT_TIB32;
+
+/* NT thread information block (64-bit version) */
+typedef struct _NT_TIB64 {
+    ULONG64 ExceptionList;
+    ULONG64 StackBase;
+    ULONG64 StackLimit;
+    ULONG64 SubSystemTib;
+    union {
+        ULONG64 FiberData;
+        ULONG   Version;
+    };
+    ULONG64 ArbitraryUserPointer;
+    ULONG64 Self;
+} NT_TIB64;
+typedef NT_TIB64    *PNT_TIB64;

--- a/bld/w32api/include/winnt.mh
+++ b/bld/w32api/include/winnt.mh
@@ -4115,6 +4115,8 @@ typedef struct _JOB_SET_ARRAY {
 } JOB_SET_ARRAY;
 typedef JOB_SET_ARRAY   *PJOB_SET_ARRAY;
 
+:include nttib.sp
+
 /* Quota limits */
 typedef struct _QUOTA_LIMITS {
     SIZE_T          PagedPoolLimit;


### PR DESCRIPTION
NT_TIB, NT_TIB32, NT_TIB64 types should be defined in h/nt/winnt.h, duplicating the definitions in h/nt/ddk/ntddk.h.