### PR TITLE
endian.h: Make sure, that _ARCH_INCLUDE always works

### DIFF
--- a/bld/hdr/watcom/endian.mh
+++ b/bld/hdr/watcom/endian.mh
@@ -38,6 +38,8 @@
 )
 
 :segment LINUX
+:include incdir.sp
+
 #include _ARCH_INCLUDE(sys/endian.h)
 :elsesegment
 #define BYTE_ORDER      LITTLE_ENDIAN


### PR DESCRIPTION

Without this fix, projects failed to compile, when "endian.h" is included early or alone.

Example: zlib-ng
https://github.com/zlib-ng/zlib-ng/blob/develop/zendian.h

(zlib-ng has portability issues, before it can be build with OpenWatcom)

#####

I checked with `git grep`, that all other header, which use `_ARCH_INCLUDE, already include "incdir.sp".
Either nearby or for "sys/socket.mh" at the start of the file.

-- 
Regards ... Detlef