### PR TITLE
causeway: cleanup code

### DIFF
--- a/bld/causeway/asm/api.asm
+++ b/bld/causeway/asm/api.asm
@@ -822,7 +822,7 @@ api15_0:
         assume ds:nothing
         mov     ds,cs:apiDSeg
         assume ds:_cwMain
-        cmp     ProtectedType,2
+        cmp     ProtectedType,PT_DPMI
         assume ds:_apiCode
         jnz     api15_NoStack0
         assume ds:nothing
@@ -866,7 +866,7 @@ api15_DoneStack0:
         assume ds:nothing
         mov     ds,cs:apiDSeg
         assume ds:_cwMain
-        cmp     ProtectedType,2
+        cmp     ProtectedType,PT_DPMI
         assume ds:_apiCode
         jnz     api15_DoneStack1
         assume ds:nothing
@@ -915,7 +915,7 @@ api16_0:
         assume ds:nothing
         mov     ds,cs:apiDSeg
         assume ds:_cwMain
-        cmp     ProtectedType,2
+        cmp     ProtectedType,PT_DPMI
         assume ds:_apiCode
         jnz     api16_NoStack1
         assume ds:nothing
@@ -941,7 +941,7 @@ api16_DoneStack2:
         assume ds:nothing
         mov     ds,cs:apiDSeg
         assume ds:_cwMain
-        cmp     ProtectedType,2
+        cmp     ProtectedType,PT_DPMI
         assume ds:_apiCode
         jnz     api16_DoneStack3
         assume ds:nothing
@@ -4201,7 +4201,7 @@ COMMENT ! MED 02/15/96
         push    ds
         mov     ds,apiDSeg
         assume ds:_cwMain
-        cmp     ProtectedType,2
+        cmp     ProtectedType,PT_DPMI
         assume ds:_apiCode
         pop     ds
         jz      api74_normal

--- a/bld/causeway/asm/raw_vcpi.asm
+++ b/bld/causeway/asm/raw_vcpi.asm
@@ -406,7 +406,7 @@ rv1_pl0:
         mov     ax,MainDS
         mov     ds,ax
         assume ds:_cwMain
-        cmp     ProtectedType,1 ;VCPI?
+        cmp     ProtectedType,PT_VCPI
         mov     ax,KernalDS
         mov     ds,ax
         assume ds:_cwRaw
@@ -778,7 +778,7 @@ VCPIRelExtended proc far
         mov     ax,MainCS
         mov     ds,ax
         assume ds:_cwMain
-        cmp     ProtectedType,1
+        cmp     ProtectedType,PT_VCPI
         assume ds:_cwRaw
         pop     ds
         jnz     rv12_9
@@ -1037,7 +1037,7 @@ Int15Rel        proc    far
         mov     ax,MainDS
         mov     ds,ax
         assume ds:_cwMain
-        cmp     ProtectedType,1 ;VCPI?
+        cmp     ProtectedType,PT_VCPI
         assume ds:_cwRaw
         pop     ds
         jnc     rv15_9
@@ -2477,7 +2477,7 @@ A20Handler      proc    far
         mov     ax,MainDS
         mov     ds,ax
         assume ds:_cwMain
-        cmp     ProtectedType,0
+        cmp     ProtectedType,PT_RAW
         assume ds:_cwRaw
         pop     ax
         pop     ds
@@ -4512,7 +4512,7 @@ GetVCPIPage     proc    near
         mov     ax,MainDS
         mov     ds,ax
         assume ds:_cwMain
-        cmp     ProtectedType,1 ;VCPI?
+        cmp     ProtectedType,PT_VCPI
         assume ds:_cwDPMIEMU
         jnz     rv52_9
 
@@ -4578,7 +4578,7 @@ GetVCPIPages    proc    near
         mov     ax,MainDS
         mov     ds,ax
         assume ds:_cwMain
-        cmp     ProtectedType,1 ;VCPI?
+        cmp     ProtectedType,PT_VCPI
         assume ds:_cwDPMIEMU
         jnz     rv53_9
         ;
@@ -4827,7 +4827,7 @@ GetXMSPages     proc    near
         assume ds:_cwMain
 
 ; MED, 11/11/99
-;       cmp     ProtectedType,1 ;VCPI?
+;       cmp     ProtectedType,PT_VCPI
         cmp     VCPIHasNoMem,0  ; see if VCPI provided no memory, bail if it did
 
         assume ds:_cwRaw
@@ -5319,7 +5319,7 @@ GetInt15Pages   proc    near
         mov     ax,MainDS
         mov     ds,ax
         assume ds:_cwMain
-        cmp     ProtectedType,1 ;VCPI?
+        cmp     ProtectedType,PT_VCPI
         assume ds:_cwRaw
         pop     ds
         jnc     rv57_9


### PR DESCRIPTION
use symbolic constants to do code more transparent