### PR TITLE
minimal fix for DragonFlyBSD/NetBSD

### DIFF
--- a/bld/ui/unix/c/ctkeyb.c
+++ b/bld/ui/unix/c/ctkeyb.c
@@ -568,7 +568,7 @@ static int ck_shift_state( void )
 /*******************************/
 {
 // FIXME: This is nonsense - the two should not be defined at the same time
-#if defined( __LINUX__ ) && !defined( __FreeBSD__ )
+#if defined( __LINUX__ )
     /* read the shift state on the Linux console. Works only locally. */
     /* and WARNING: see console_ioctl(4)                              */
     char ioctl_shift_state = 6;

--- a/bld/watcom/c/clibext.c
+++ b/bld/watcom/c/clibext.c
@@ -807,7 +807,7 @@ char *_cmdname( char *name )
     return( name );
 }
 
-#elif defined( __BSD__ )
+#elif defined( __FREEBSD__ )
 
 #include <sys/sysctl.h>
 
@@ -852,7 +852,11 @@ char *_cmdname( char *name )
     result = readlink( "/proc/self/exe", name, PATH_MAX );
     if( result == -1 ) {
         /* try another way for BSD */
+#if defined( __NETBSD__ )
+        result = readlink( "/proc/curproc/exe", name, PATH_MAX );
+#else
         result = readlink( "/proc/curproc/file", name, PATH_MAX );
+#endif
     }
     errno = save_errno;
 


### PR DESCRIPTION
bld/ui/unix/c/ctkeyb.c and bld/watcom/c/clibext.c is modified for initial BSD support of #1390 .

Especially, clibext.c's _cmdname() implementation is different among *BSDs.

FreeBSD:
only /proc/curproc/file supported but proc filesystem is not mounted as default.
use sysctl() to obtain information.

DragonFlyBSD:
/proc/self/exe, /proc/curproc/file, /proc/curproc/exe and FreeBSD's sysctl() interface available.
but sysctl() needs both <sys/types.h> and <sys/sysctl.h>.
due to -D_POSIX_C_SOURCE=200112L of bld/wmake/posmake, __BSD_VISIBLE and u_int is not defined and this disables sysctl(). treat as `__UNIX__`.

NetBSD:
/proc/self/exe and /proc/curproc/exe is available. treat as `__UNIX__` but  /proc/curproc/file points execute file itself (not symbolic link).

OpenBSD:
no interface for obtaining currently executing file itself path. maybe libc's [execvpe()](https://github.com/openbsd/src/blob/master/lib/libc/gen/exec.c#L182) alike path-finding code needed.


bld/ui/unix/c/ctkeyb.c's TIOCLINUX is Linux dependent. so only support for `__LINUX__`.