### PR TITLE
add DragonFlyBSD/NetBSD support (bootstrap only) (2)

### DIFF
--- a/bld/ncurses/c/lib_baud.c
+++ b/bld/ncurses/c/lib_baud.c
@@ -46,7 +46,7 @@
  * of the indices up to B115200 fit nicely in a 'short', allowing us to retain
  * ospeed's type for compatibility.
  */
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__NetBSD__)
 #undef B0
 #undef B50
 #undef B75

--- a/bld/wtouch/c/touch.c
+++ b/bld/wtouch/c/touch.c
@@ -457,7 +457,7 @@ static void doTouch( void )
         }
         _splitpath2( item, pg.buffer, &pg.drive, &pg.dir, NULL, NULL );
         number_of_successful_touches = 0;
-#if defined(__LINUX__) || defined(__OSX__)
+#if defined(__LINUX__) || defined(__OSX__) || defined(__BSD__)
         strcpy( full_name, item );
         dire = NULL;
         number_of_successful_touches += doTouchFile( full_name, dire, &stamp );


### PR DESCRIPTION
continued from #1390 (my dfly branch is deleted accidentaly).
I found clibext.c has separated with `__BSD__` and `__UNIX__` code, so I did not do nothing.
support for OpenBSD is now pending. For a while we have to do work for FreeBSD, DragonFlyBSD and NetBSD.

bld/wtouch/c/touch.c and bld/ncurses/c/lib_baud.c has error, fixed.

now I am stucking bld/setupgui running sh build.sh (no option). *BSDs says:

```
============ 22:55:06 /home/uaa/open-watcom-v2/bld/setupgui/bsdx64 ============
cl setup.exe
../c/setup.c:312: error: undefined reference to 'FileInit'
../c/setup.c:366: error: undefined reference to 'FileFini'
../c/setupinf.c:1013: error: undefined reference to 'FileOpen'
../c/setupinf.c:1015: error: undefined reference to 'FileStat'
../c/setupinf.c:1018: error: undefined reference to 'FileRead'
../c/setupinf.c:1021: error: undefined reference to 'FileClose'
../c/setupinf.c:2210: error: undefined reference to 'FileRead'
../c/setupinf.c:2352: error: undefined reference to 'FileStat'
../c/setupinf.c:2370: error: undefined reference to 'FileOpen'
../c/setupinf.c:2378: error: undefined reference to 'FileClose'
../c/setupinf.c:2379: error: undefined reference to 'FileOpen'
../c/setupinf.c:2413: error: undefined reference to 'FileClose'
../c/utils.c:1439: error: undefined reference to 'FileOpen'
../c/utils.c:1479: error: undefined reference to 'FileRead'
../c/utils.c:1415: error: undefined reference to 'FileStat'
../c/utils.c:1504: error: undefined reference to 'FileClose'
../c/utils.c:1905: error: undefined reference to 'FileIsPlainFS'
collect2: error: ld returned 1 exit status
Error(E42): Last command making (setup.exe) returned a bad status
Error(E02): Make execution terminated
<pmake -d build          -h> => non-zero return: 512
Build failed
uaa@dragonfly-vm:~/open-watcom-v2 %
```