### PR TITLE
add OpenBSD support

### DIFF
--- a/bld/watcom/c/clibext.c
+++ b/bld/watcom/c/clibext.c
@@ -888,7 +888,9 @@ char *_cmdname(char *name)
 
     save_errno = errno;
 
-    if ( ( *_argv[0] == '.' || *_argv[0] == '/' ) && !_cmdname_sub( name, NULL, _argv[0] ) ) {
+    if ( ( _argv != NULL && _argv[0] != NULL )
+      && ( *_argv[0] == '.' || *_argv[0] == '/' )
+      && ( !_cmdname_sub( name, NULL, _argv[0] ) ) ) {
         result = name;
         goto fin0;
     }
@@ -898,11 +900,17 @@ char *_cmdname(char *name)
         goto fin0;
     }
     envpath_len = strlen( envpath ) + 1;
-    path = malloc( envpath_len );
+    path = malloc( envpath_len + 1 );
     if ( path == NULL ) {
         goto fin0;
     }
     memcpy( path, envpath, envpath_len );
+
+    /* last ":" treat as ":." */
+    if ( path[envpath_len - 2] == ':' ) {
+        path[envpath_len - 1] = '.';
+        path[envpath_len] = '\0';
+    }
 
     for ( p = _cmdname_tokenize( path, &pp ); p != NULL;
           p = _cmdname_tokenize( pp, &pp ) ) {

--- a/bld/watcom/c/clibext.c
+++ b/bld/watcom/c/clibext.c
@@ -827,6 +827,97 @@ char *_cmdname( char *name )
     return( name );
 }
 
+#elif defined( __OPENBSD__ )
+
+extern const char *__progname;
+#include <sys/stat.h>
+
+static int _cmdname_sub( char *out, const char *path, const char *name )
+{
+    int         path_len, name_len;
+    char        tmp[PATH_MAX];
+    struct stat sb;
+
+    path_len = ( path == NULL ) ? 0 : ( strlen( path ) + 1 );   /* with '/' */
+    name_len = ( name == NULL ) ? 0 : strlen( name );
+
+    if ( ( path_len + name_len ) >= sizeof( tmp ) ) {
+        abort();
+    }
+    if ( path_len ) {
+        memcpy( tmp, path, path_len - 1 );
+        tmp[path_len - 1] = '/';
+    }
+    if ( name_len ) {
+        memcpy( tmp + path_len, name, name_len );
+    }
+    tmp[path_len + name_len] = '\0';
+
+    if ( tmp[0] == '/' ) {
+        memcpy( out, tmp, path_len + name_len + 1 );
+    } else {
+        realpath( tmp, out );
+    }
+    return( stat( out, &sb ) );
+}
+
+static char *_cmdname_tokenize( char *str, char **next )
+{
+    char    *p;
+
+    if ( *str == '\0' ) {
+        return( NULL );
+    }
+
+    p = strchr( str, ':' );
+    if ( p == NULL ) {
+        *next = str + strlen( str );
+    } else {
+        *p = '\0';
+        *next = p + 1;
+    }
+
+    return( str );
+}
+
+char *_cmdname(char *name)
+{
+    int     save_errno, envpath_len;
+    char    *path, *envpath, *result = NULL;
+    char    *p, *pp;
+
+    save_errno = errno;
+
+    if ( ( *_argv[0] == '.' || *_argv[0] == '/' ) && !_cmdname_sub( name, NULL, _argv[0] ) ) {
+        result = name;
+        goto fin0;
+    }
+
+    envpath = getenv( "PATH" );
+    if ( envpath == NULL ) {
+        goto fin0;
+    }
+    envpath_len = strlen( envpath ) + 1;
+    path = malloc( envpath_len );
+    if ( path == NULL ) {
+        goto fin0;
+    }
+    memcpy( path, envpath, envpath_len );
+
+    for ( p = _cmdname_tokenize( path, &pp ); p != NULL;
+          p = _cmdname_tokenize( pp, &pp ) ) {
+        if ( !_cmdname_sub( name, ( *p == '\0' ) ? "." : p, __progname ) ) {
+            result = name;
+            goto fin1;
+        }
+    }
+fin1:
+    free( path );
+fin0:
+    errno = save_errno;
+    return( result );
+}
+
 #else
 
 char *_cmdname( char *name )

--- a/bld/wipfc/icu/common/unicode/platform.h
+++ b/bld/wipfc/icu/common/unicode/platform.h
@@ -749,7 +749,7 @@ namespace std {
      * C++11 and C11 require support for UTF-16 literals
      * TODO: Fix for plain C. Doesn't work on Mac.
      */
-#   if U_CPLUSPLUS_VERSION >= 11 || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+#   if U_CPLUSPLUS_VERSION >= 11 || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) || defined(__OpenBSD__)
 #       define U_HAVE_CHAR16_T 1
 #   else
 #       define U_HAVE_CHAR16_T 0

--- a/build/dosbox.cfg
+++ b/build/dosbox.cfg
@@ -1,5 +1,6 @@
 [cpu]
 core=auto
+cycles=10000000
 [mixer]
 nosound=true
 [midi]


### PR DESCRIPTION
There is three commits.

1. Different from other *BSDs, OpenBSD does not have interface for obtaining filname that is currently running such as NetBSD's /proc/curproc/exe . I wrote a code that uses argv[0], realpath() and PATH environment variable to emulate that interface.
2. Unicode related code at bld/wipfc defines char16_t, but the definition is different from OpenBSD's one. This causes error. It might be avoid with -DU_HAVE_CHAR16_T at configure, but this is disabled by [configure.ac](https://github.com/open-watcom/open-watcom-v2/blob/master/bld/wipfc/configure.ac#L5). So, workaround for [wipfc/icu/common/unicode/platform.h](https://github.com/open-watcom/open-watcom-v2/blob/master/bld/wipfc/icu/common/unicode/platform.h#L752) is required. It is worth replacing with modernized ICU4C code in the future.
3. Some components use DOSBox/DOSBox-X to run docs/gml/dos/wgml.exe but this is too slow on NetBSD/OpenBSD. As DOSBox's CPU speed  default as `cycles=auto` but even if adding `cycles=max` worked slow, I put enough large value that is used [old 86Duino's IDE](https://github.com/roboard/86Duino/blob/Coding-106/build/linux/work/DOSBox-0.74/dosbox-86duino.conf#L29).