### PR TITLE
wgml-build: move bsd setup from dosbox.cfg to specific platform setup

### DIFF
--- a/build/dosbox.cfg
+++ b/build/dosbox.cfg
@@ -1,6 +1,5 @@
 [cpu]
 core=auto
-cycles=10000000
 [mixer]
 nosound=true
 [midi]

--- a/build/mif/wgmlcmd.mif
+++ b/build/mif/wgmlcmd.mif
@@ -42,9 +42,11 @@ dosbox_cfg = $(%OWROOT)\build\dosbox.cfg
 !ifdef %OWWGMLDEBUG
 dosbox_options_nt =
 dosbox_options_osx = -c "config -set cpu core=normal"
+dosbox_options_bsd = -c "config -set cpu cycles=10000000"
 !else
 dosbox_options_nt = -noconsole
 dosbox_options_osx = -c "config -set cpu core=normal"
+dosbox_options_bsd = -c "config -set cpu cycles=10000000"
 !endif
 
 !ifeq bld_os dos


### PR DESCRIPTION
now it has no impact to other platforms except bsd clones 
dosbox.cfg hold only setup common for all platforms and specific setup is passed by command line