### PR TITLE
msgencod, optencod, errdoc, vicomp: fix segv without argument

### DIFF
--- a/bld/f77/utils/c/errdoc.c
+++ b/bld/f77/utils/c/errdoc.c
@@ -112,6 +112,10 @@ int main( int argc, char **argv )
     } else {
         fi = fopen( "error.msg", "rt" );
     }
+    if ( fi == NULL ) {
+        printf( "input file open error\n" );
+	return( 0 );
+    }
     if( argc > 1 ) {
         fo = fopen( argv[2], "wt" );
         argc--;

--- a/bld/fe_misc/c/optencod.c
+++ b/bld/fe_misc/c/optencod.c
@@ -329,13 +329,13 @@ typedef struct codeseq {
 static unsigned     line;
 static unsigned     errcount = 0;
 
-static FILE         *gfp;
-static FILE         *ofp;
-static FILE         *pfp;
-static FILE         *ufp;
-static FILE         *mfp;
-static FILE         *bfp;
-static FILE         *ofpg;
+static FILE         *gfp = NULL;
+static FILE         *ofp = NULL;
+static FILE         *pfp = NULL;
+static FILE         *ufp = NULL;
+static FILE         *mfp = NULL;
+static FILE         *bfp = NULL;
+static FILE         *ofpg = NULL;
 
 static char         ibuff[BUFF_SIZE];
 static char         tagbuff[BUFF_SIZE];
@@ -3127,7 +3127,8 @@ static void dumpInternational( void )
 
 static void closeFiles( void )
 {
-    fclose( gfp );
+    if( gfp != NULL )
+        fclose( gfp );
     if( mfp != NULL )
         fclose( mfp );
     if( ofp != NULL )

--- a/bld/vi/c/vicomp.c
+++ b/bld/vi/c/vicomp.c
@@ -345,7 +345,9 @@ int main( int argc, char **argv )
 {
     vi_rc   rc;
 
-    /* unused parameters */ (void)argc;
+    if ( argc < 3 ) {
+        return( -1 );
+    }
 
     rc = Compile( argv[1], argv[2] );
     return( (rc == ERR_NO_ERR) ? 0 : -1 );


### PR DESCRIPTION
in many cases, adding argv/argc check or NULL by fopen() solve the problem.
maybe default value of FILE * variables are NULL, but I clarified it.
