### PR TITLE
bld/wstuba: add BSD support

### DIFF
--- a/bld/wstuba/builder.ctl
+++ b/bld/wstuba/builder.ctl
@@ -21,6 +21,7 @@ set PROJDIR=<CWD>
     <CCCMD> dos386/*.exe        "<OWRELROOT>/binnt64/"
     <CCCMD> dos386/*.exe        "<OWRELROOT>/binl/"
     <CCCMD> dos386/*.exe        "<OWRELROOT>/binl64/"
+    <CCCMD> dos386/*.exe        "<OWRELROOT>/binb64/"
     <CCCMD> dos386/*.exe        "<OWRELROOT>/arml64/"
     <CCCMD> dos386/*.exe        "<OWRELROOT>/bino64/"
     <CCCMD> dos386/*.exe        "<OWRELROOT>/armo/"


### PR DESCRIPTION
binb64/wstub.exe not exist, fixed.