### PR TITLE
wpp*: Fix handling of the #warning preprocessor directive

### DIFF
--- a/bld/plusplus/c/cmac2.c
+++ b/bld/plusplus/c/cmac2.c
@@ -700,9 +700,9 @@ static void CWarning( void )
 {
     bool save;
 
-    if( !CompFlags.extensions_enabled ) {
+    if( CompFlags.extensions_enabled || ( CHECK_STD( >= , CXX23 ) ) ) {
         get_arg_message();
-        /* Force #error output to be reported, even with preprocessor */
+        /* Force #warning output to be reported, even with preprocessor */
         save = CompFlags.cpp_output;
         CompFlags.cpp_output = false;
         CErr2p( WARN_USER_WARNING_MSG, Buffer );

--- a/bld/plusplus/h/plusplus.h
+++ b/bld/plusplus/h/plusplus.h
@@ -188,7 +188,12 @@ enum {
 typedef enum {
     STD_NONE,
     STD_CXX98,
-    STD_CXX0X,
+    STD_CXX11,
+    STD_CXX0X=STD_CXX11,
+    STD_CXX14,
+    STD_CXX17,
+    STD_CXX20,
+    STD_CXX23,
 } cxxstd_ver;
 
 #define CHECK_STD(o,v)  (CompVars.cxxstd o STD_ ## v)


### PR DESCRIPTION
The previous code enabled the preprocessor directive "#warning",
when extensions are disabled (independent of the selected c++ standard).

This PR fixes this.
