### PR TITLE
owcc: Overwrite the default program name only for unix targets

### DIFF
--- a/bld/wcl/c/owcc.c
+++ b/bld/wcl/c/owcc.c
@@ -1514,12 +1514,28 @@ static  int  CompLink( void )
                 rc = tool_exec( TYPE_DIS, ofname, dis_args );
             }
             if( Exe_Name == NULL ) {
+                /* overwrite the default program name only on unix targets */
+                if( Flags.link_for_sys ) {
+                    /* check, if the target system is a unix system */
+                    if( strncmp( SystemName, "linux", 5 ) == 0 ) {
+                        Flags.keep_exename = 1;
+                    } else {
+                        Flags.keep_exename = 0;
+                    }
+                } else {
+                    /* called without "-bsystem" argument. use the host to decide */
 #ifdef __UNIX__
-                Exe_Name = MemStrDup( OUTPUTFILE );
-                Flags.keep_exename = 1;
+                    Flags.keep_exename = 1;
 #else
-                Exe_Name = MemStrDup( RemoveExt( Word ) );
+                    Flags.keep_exename = 0;
 #endif
+                }
+                if( Flags.keep_exename ) {
+                    /* use the well known default program name on unix targets */
+                    Exe_Name = MemStrDup( OUTPUTFILE );
+                } else {
+                    Exe_Name = MemStrDup( RemoveExt( Word ) );
+                }
             }
             file = GetName( NULL, NULL );   /* get next filename */
         }


### PR DESCRIPTION
When cross-compiling on linux for any Windows (or DOS, or OS/2) target,
OpenWatcom now creates a program with an ".exe" extension by default.

Any autotools project now detects the ".exe" extension 
when cross-compiling with OpenWatcom
and uses the ".exe" extension for creating the project executables.

#####

This is a usability enhancement, which makes OpenWatcom more usable
for cross-compiling any autotools project.
In addition, now `owcc -bnt helloworld.c` and `wcl386 -bcl=nt helloworld.c`
produce both a `helloworld.exe` on linux.
