### PR TITLE
Update contact info for internal error message

### DIFF
--- a/bld/lib_misc/c/aliasgen.c
+++ b/bld/lib_misc/c/aliasgen.c
@@ -94,8 +94,10 @@ void FatalError( char *format, ... )
 void InternalError( int line, char *file )
 /****************************************/
 {
-    fprintf( stderr, "Internal error on line %d of %s; please contact Watcom\n",
-             line, file );
+    fprintf( stderr, "Internal error on line %d of %s.\n"
+                     "Please contact the Open Watcom project at "
+                     "https://github.com/open-watcom/open-watcom-v2\n",
+                     line, file );
     exit( EXIT_FAILURE );
 }
 

--- a/bld/mstools/c/error.c
+++ b/bld/mstools/c/error.c
@@ -76,8 +76,11 @@ void InternalError( int line, const char *file )
 /**********************************************/
 {
     (*bannerFunc)();
-    fprintf( stderr, "Internal error on line %d of %s. Please contact the Open Watcom maintainers at http://www.openwatcom.com\n",
-             line, file );
+
+    fprintf( stderr, "Internal error on line %d of %s.\n"
+                     "Please contact the Open Watcom project at "
+                     "https://github.com/open-watcom/open-watcom-v2\n",
+                     line, file );
     exit( EXIT_FAILURE );
 }
 


### PR DESCRIPTION
"Watcom" no longer exist as a help target
and grep found a similar error message location in the mstools
