### PR TITLE
clib: fix NULL pointer dereferences

### DIFF
--- a/bld/clib/posix/c/gthstent.c
+++ b/bld/clib/posix/c/gthstent.c
@@ -71,6 +71,9 @@ _WCRTLINK struct hostent *gethostent( void )
 
     if( __hostFile == NULL )
         sethostent( 0 );
+    /* If no /etc/hosts, it remains NULL */
+    if( __hostFile == NULL )
+        return NULL;
 
     /* First pass */
     if( buf == NULL ) {

--- a/bld/clib/posix/c/gtsrvent.c
+++ b/bld/clib/posix/c/gtsrvent.c
@@ -72,6 +72,9 @@ _WCRTLINK struct servent *getservent( void )
 
     if( __servFile == NULL )
         setservent( 0 );
+    /* If no /etc/services, it remains NULL */
+    if( __servFile == NULL )
+        return NULL;
 
     /* First pass */
     if( buf == NULL ) {


### PR DESCRIPTION
If /etc/hosts or /etc/services is missing, the corresponding functions gethostent() and getservent() crash.
This patch avoids the problem by ading the missed NULL checks.

Note: the patch is trivial, but it was untested on the main OW source tree. The testing was only done on a local rip-off.