### PR TITLE
resolve: reduce DNS buffer size

### DIFF
--- a/bld/clib/posix/c/_resolve.c
+++ b/bld/clib/posix/c/_resolve.c
@@ -49,7 +49,7 @@
 
 
 /* Our send/receive buffer size */
-#define DNS_BUFFER_SIZE     0xFFFF
+#define DNS_BUFFER_SIZE     0x1000
 
 struct __dns_header
 {


### PR DESCRIPTION
This patch is needed for a real-mode
port of that code.
Not tested in OW tree, as it doesn't
build this for real-mode.