### PR TITLE
Empty stubs for IsDBCSLeadByte and GetKBCodePage in Windows 1.0 startup code.

### DIFF
--- a/bld/clib/builder.ctl
+++ b/bld/clib/builder.ctl
@@ -106,6 +106,7 @@ set PROJDIR=<CWD>
     <CCCMD> startup/library/windows.086/ml/libentry.obj     "<OWRELROOT>/lib286/win/"
     <CCCMD> startup/library/windows.086/ms/commode.obj      "<OWRELROOT>/lib286/win/"
     <CCCMD> win10/library/windows.086/ml/libent10.obj       "<OWRELROOT>/lib286/win/"
+    <CCCMD> win10/library/windows.086/ml/cstrtw10.obj       "<OWRELROOT>/lib286/win/"
 
     <CCCMD> library/windows.386/mf_r/clib3r.lib             "<OWRELROOT>/lib386/win/"
     <CCCMD> library/windows.386/mf_s/clib3s.lib             "<OWRELROOT>/lib386/win/"

--- a/bld/clib/startup/a/cstrtw16.asm
+++ b/bld/clib/startup/a/cstrtw16.asm
@@ -328,6 +328,24 @@ endif
 _cstart_ endp
 _wstart_ endp
 
+ifdef WINDOWS10
+
+; Empty stub for IsDBCSLeadByte, which does not exist in Windows 1.x.
+public ISDBCSLEADBYTE
+ISDBCSLEADBYTE proc far
+	xor	ax,ax
+	retf
+ISDBCSLEADBYTE endp
+
+; Empty stub for GetKBCodePage, which does not exist in any KEYBOARD driver in Windows 1.x.
+public GETKBCODEPAGE
+GETKBCODEPAGE proc far
+	xor	ax,ax
+	retf
+GETKBCODEPAGE endp
+
+endif
+
 ;
 ; copyright message
 ;

--- a/bld/clib/startup/a/cstrtw16.asm
+++ b/bld/clib/startup/a/cstrtw16.asm
@@ -331,18 +331,18 @@ _wstart_ endp
 ifdef WINDOWS10
 
 ; Empty stub for IsDBCSLeadByte, which does not exist in Windows 1.x.
-public ISDBCSLEADBYTE
-ISDBCSLEADBYTE proc far
+public WIN10ISDBCSLEADBYTE
+WIN10ISDBCSLEADBYTE proc far
 	xor	ax,ax
 	retf
-ISDBCSLEADBYTE endp
+WIN10ISDBCSLEADBYTE endp
 
 ; Empty stub for GetKBCodePage, which does not exist in any KEYBOARD driver in Windows 1.x.
-public GETKBCODEPAGE
-GETKBCODEPAGE proc far
+public WIN10GETKBCODEPAGE
+WIN10GETKBCODEPAGE proc far
 	xor	ax,ax
 	retf
-GETKBCODEPAGE endp
+WIN10GETKBCODEPAGE endp
 
 endif
 

--- a/bld/wl/lnk/specs.sp
+++ b/bld/wl/lnk/specs.sp
@@ -182,6 +182,8 @@ system begin windows1
     library windows
     option nocaseexact
     option stack=8k, heapsize=1k
+    alias ISDBCSLEADBYTE=WIN10ISDBCSLEADBYTE
+    alias GETKBCODEPAGE=WIN10GETKBCODEPAGE
     libfile cstrtw10.obj
     format windows ^
 :endsegment

--- a/bld/wl/lnk/specs.sp
+++ b/bld/wl/lnk/specs.sp
@@ -182,6 +182,7 @@ system begin windows1
     library windows
     option nocaseexact
     option stack=8k, heapsize=1k
+    libfile cstrtw10.obj
     format windows ^
 :endsegment
 end


### PR DESCRIPTION
Properly install, and reference Windows 1.0 startup. Add empty stubs for Windows 1.0 because those symbols do not exist in Windows 1.0: IsDBCSLeadByte and GetKBCodePage.