### PR TITLE
hdr: fix bugs in header files

### DIFF
--- a/bld/hdr/null.sp
+++ b/bld/hdr/null.sp
@@ -28,11 +28,15 @@
 :endsegment
 :endsegment
 :segment !CNAME
+: segment RDOS
  #ifdef __RDOSDEV__
   #define NULL 0
  #else
   #define NULL ((void *)0)
  #endif
+: elsesegment
+ #define NULL ((void *)0)
+: endsegment
 :segment !CONLY
 #endif
 :endsegment

--- a/bld/hdr/watcom/_preincl.mh
+++ b/bld/hdr/watcom/_preincl.mh
@@ -35,10 +35,10 @@
 
 #pragma include_alias( <stdnoreturn.h>,      <stdnoret.h> )
 
-#ifdef __LINUX__
+:segment LINUX
 #pragma include_alias( <sysmacros.h>,        <sysmacro.h> )
-#endif
 
+:endsegment
 #define __STDC_LIB_EXT1__     200509L
 
 #endif /* __PREINCL_H_INCLUDED */

--- a/bld/hdr/watcom/crtdbg.mh
+++ b/bld/hdr/watcom/crtdbg.mh
@@ -24,14 +24,14 @@
  * Some data types and #defines.
  */
 
-:segment DOS | RDOS
+:segment DOS
 #ifdef __NT__
  typedef void   *_HFILE;
 #else
-:endsegment
  typedef int    _HFILE;
-:segment DOS | RDOS
 #endif
+:elsesegment
+typedef int     _HFILE;
 :endsegment
 typedef int     (*_CRT_REPORT_HOOK)( int, char *, int * );
 

--- a/bld/hdr/watcom/excpt.mh
+++ b/bld/hdr/watcom/excpt.mh
@@ -11,7 +11,7 @@
 
 :include cpluspro.sp
 
-:segment DOS | RDOS
+:segment DOS
 #ifdef __OS2__
 #ifndef __BSEXCPT_H__
  #include <os2def.h>
@@ -44,7 +44,7 @@ EXCEPTION_DISPOSITION __cdecl _except_handler (
         void * DispatcherContext
         );
 
-:segment DOS | RDOS
+:segment DOS
 #ifdef __OS2__
  typedef struct _EXCEPTION_POINTERS {
      PEXCEPTIONREPORTRECORD ExceptionRecord;

--- a/bld/hdr/watcom/mbstring.mh
+++ b/bld/hdr/watcom/mbstring.mh
@@ -83,7 +83,7 @@ _WCRTLINK extern unsigned int _mbsnextc( const unsigned char *__s );
 ::
 _WCRTLINK extern unsigned char *_mbstok_r( unsigned char *__s, const unsigned char *__delim, unsigned char **__p );
 
-:segment BITS16
+:segment BITS16 & DOS
 :include far2.sp
 
 /* Far versions */
@@ -253,7 +253,7 @@ _WCRTLINK extern unsigned char *_mbgetcode( unsigned char *, unsigned int *);
 _WCRTLINK extern unsigned char *_mbputchar( unsigned char *, unsigned int );
 _WCRTLINK extern int           _mbsbtype( const unsigned char *, int );
 _WCRTLINK extern int           _mbbtype( unsigned char, int );
-:segment BITS16
+:segment BITS16 & DOS
 :include far2.sp
 _WCRTLINK extern unsigned char _WCFAR *_fmbgetcode( unsigned char _WCFAR *, unsigned int _WCFAR *);
 _WCRTLINK extern unsigned char _WCFAR *_fmbputchar( unsigned char _WCFAR *, unsigned int );

--- a/bld/hdr/watcom/stdlib.mh
+++ b/bld/hdr/watcom/stdlib.mh
@@ -332,7 +332,7 @@ _WCRTLINK extern unsigned __int64 _strtoui64( const char *__nptr, char **__endpt
 :endsegment
 #endif
 
-:segment BITS16
+:segment BITS16 & DOS
 :include far2.sp
  _WCRTLINK extern int       _fwctomb( char _WCFAR * __s, wchar_t __wchar );
  _WCRTLINK extern size_t    _fmbstowcs( wchar_t _WCFAR * __pwcs, const char _WCFAR * __s, size_t __n );
@@ -591,7 +591,7 @@ _WCRTLINK extern errno_t    mbstowcs_s( size_t * __restrict __retval, wchar_t * 
 _WCRTLINK extern errno_t    wcstombs_s( size_t * __restrict __retval, char * __restrict __dst, rsize_t __dstmax, const wchar_t * __restrict __src, rsize_t __len );
 
 :include ext.sp
-:segment BITS16
+:segment BITS16 & DOS
 :include far2.sp
  _WCRTLINK extern errno_t   _fwctomb_s( int _WCFAR * __restrict __status, char _WCFAR * __restrict __s, rsize_t __smax, wchar_t __wc );
  _WCRTLINK extern errno_t   _fmbstowcs_s( size_t _WCFAR * __restrict __retval, wchar_t _WCFAR * __restrict __dst, rsize_t __dstmax, const char _WCFAR * __restrict __src, rsize_t __len );

--- a/bld/hdr/watcom/wchar.mh
+++ b/bld/hdr/watcom/wchar.mh
@@ -306,7 +306,7 @@ _WCRTLINK extern int        wscanf( const wchar_t *__format, ... );
 :: C99 says this function is named mbsinit.
 _WCRTLINK extern int        sisinit( const __w_mbstate_t *__ps );
 
-:segment BITS16
+:segment BITS16 & DOS
 :include far2.sp
 _WCRTLINK extern __w_size_t _fmbrlen( const char _WCFAR *__s, __w_size_t __n, __w_mbstate_t _WCFAR *__ps );
 _WCRTLINK extern __w_size_t _fmbrtowc( wchar_t _WCFAR *__pwc, const char _WCFAR *__s, __w_size_t __n, __w_mbstate_t _WCFAR *__ps );
@@ -373,7 +373,7 @@ _WCRTLINK extern errno_t    _wctime_s( wchar_t * __restrict s, rsize_t __maxsize
 _WCRTLINK extern errno_t    mbsrtowcs_s( size_t * __restrict __retval, wchar_t * __restrict __dst, rsize_t __dstmax, const char * * __restrict __src, rsize_t __len, mbstate_t * __restrict __ps );
 _WCRTLINK extern errno_t    wcrtomb_s( size_t * __restrict __retval, char * __restrict __s,  rsize_t __smax, wchar_t __wc, mbstate_t * __restrict __ps );
 _WCRTLINK extern errno_t    wcsrtombs_s( size_t * __restrict __retval, char * __restrict __dst, rsize_t __dstmax, const wchar_t ** __restrict __src, rsize_t __len, mbstate_t * __restrict __ps );
-:segment BITS16
+:segment BITS16 & DOS
 :include far2.sp
 _WCRTLINK extern errno_t    _fmbsrtowcs_s( size_t _WCFAR * __restrict __retval, wchar_t _WCFAR * __restrict __dst, rsize_t __dstmax, const char _WCFAR * _WCFAR * __restrict __src, rsize_t __len, mbstate_t _WCFAR * __restrict __ps );
 _WCRTLINK extern errno_t    _fwcrtomb_s( size_t _WCFAR * __restrict __retval, char _WCFAR * __restrict __s, rsize_t __smax, wchar_t __wc, mbstate_t _WCFAR * __restrict __ps );


### PR DESCRIPTION
- remove __RDOSDEV__ macro guard from non-RDOS headers
- remove DOS far functions prototype from non-DOS headers
- remove unused contents for each platform header files