### PR TITLE
trap: fixes 'Incorrect version of module file' for dos tcpserv and std.trp

### DIFF
--- a/bld/trap/common/dos/dosstrt.asm
+++ b/bld/trap/common/dos/dosstrt.asm
@@ -37,8 +37,6 @@
 public  _small_code_
 _small_code_    equ 0
 
-DGROUP  group   BEGTEXT,_TEXT,_DATA,_BSS,CONST,STACK
-
 BEGTEXT         segment byte public 'CODE'
         assume  CS:BEGTEXT
 

--- a/bld/trap/common/dos/dosstrt.asm
+++ b/bld/trap/common/dos/dosstrt.asm
@@ -37,6 +37,8 @@
 public  _small_code_
 _small_code_    equ 0
 
+DGROUP  group   _DATA,_BSS,CONST,STACK
+
 BEGTEXT         segment byte public 'CODE'
         assume  CS:BEGTEXT
 

--- a/bld/trap/common/dos/dosstrt.asm
+++ b/bld/trap/common/dos/dosstrt.asm
@@ -30,6 +30,10 @@
 ;*
 ;*****************************************************************************
 
+;
+; this module must be linked as first that code in _TEXT segment
+; is at offset 0 in final executable
+;
 
                 name    TRAPSTRT
 
@@ -37,10 +41,10 @@
 public  _small_code_
 _small_code_    equ 0
 
-DGROUP  group   _DATA,_BSS,CONST,STACK
+DGROUP  group   _TEXT,_DATA,_BSS,CONST,STACK
 
-BEGTEXT         segment byte public 'CODE'
-        assume  CS:BEGTEXT
+_TEXT   segment byte public 'CODE'
+        assume  CS:_TEXT
 
         extrn   TrapInit_               :near
         extrn   TrapRequest_            :near
@@ -66,9 +70,6 @@ dos_start label far
         mov     ax, 4cffH
         int     21H
 
-BEGTEXT ends
-
-_TEXT   segment byte public 'CODE'
 _TEXT   ends
 
 _BSS    segment byte public 'BSS'

--- a/bld/trap/common/dos/dosstrt.asm
+++ b/bld/trap/common/dos/dosstrt.asm
@@ -41,7 +41,7 @@
 public  _small_code_
 _small_code_    equ 0
 
-DGROUP  group   _TEXT,_DATA,_BSS,CONST,STACK
+DGROUP  group   STACK
 
 _TEXT   segment byte public 'CODE'
         assume  CS:_TEXT
@@ -71,15 +71,6 @@ dos_start label far
         int     21H
 
 _TEXT   ends
-
-_BSS    segment byte public 'BSS'
-_BSS    ends
-
-_DATA   segment byte public 'DATA'
-_DATA   ends
-
-CONST   segment byte public 'DATA'
-CONST   ends
 
 STACK   segment byte stack 'STACK'
     db  1   ; this causes the _BSS segment to be allocated


### PR DESCRIPTION
Per AI (still could be a wrong assumption):

**What was broken:**
- Commit 8fea6a1519 (July 3, 2022) added `DGROUP group BEGTEXT,_TEXT,_DATA,_BSS,CONST,STACK` to dosstrt.asm
- This caused the BEGTEXT code segment to be treated as part of the data group (DGROUP)
- Function pointers in the trap header were resolved as group-relative addresses instead of simple code segment offsets
- The trap loader couldn't properly call TrapInit_, causing version check failures

**The fix:**
- Remove the `BEGTEXT,_TEXT` from DGROUP in dosstrt.asm

**Result:**
- tcpserv.exe now successfully loads std.trp without "Incorrect version of module file" errors
- The trap file signature is correctly positioned and accessible