### PR TITLE
tcpserv: fixed not working 'q' for exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,5 @@ failures.log
 !makefile
 !afile
 !binmake
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -239,5 +239,3 @@ failures.log
 !makefile
 !afile
 !binmake
-
-.DS_Store

--- a/bld/trap/common/dos/dostrio.c
+++ b/bld/trap/common/dos/dostrio.c
@@ -66,7 +66,10 @@ int KeyPress( void )
 
 int KeyGet( void )
 {
-    return( _BIOSKeyboardGet( KEYB_STD ) );
+    unsigned short value;
+
+    value = _BIOSKeyboardGet( KEYB_STD );
+    return( value & 0x00ff );
 }
 
 int WantUsage( const char *ptr )


### PR DESCRIPTION
This pull request updates the `KeyGet` function to ensure that only the lower 8 bits of the keyboard input value are returned. This change improves compatibility with code that expects a single byte character code from keyboard input.

- Input handling improvement:
  * Modified the `KeyGet` function in `dostrio.c` to mask the return value from `_BIOSKeyboardGet` with `0x00ff`, ensuring only the lower 8 bits are returned.