### PR TITLE
.DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,5 @@ failures.log
 !makefile
 !afile
 !binmake
+
+.DS_Store


### PR DESCRIPTION
This pull request adds .DS_Store to the project's .gitignore file to prevent it from being tracked by Git.

**What is .DS_Store?**
.DS_Store is a hidden file created automatically by macOS in a directory (folder) to store metadata. This metadata includes things like the position of icons, window view options, and other visual settings.

**How it appears on a system**
Whenever a macOS user browses a directory using the Finder application, a .DS_Store file is automatically created. These files are unnecessary for the project's functionality and are a source of clutter.

**Changes in this PR**
By adding .DS_Store to .gitignore, we ensure that this operating-system-specific file will no longer be included in the repository, making collaboration smoother for all contributors, regardless of their operating system.