### PR TITLE
strnicmp and _fstrnicmp return incorrect value when n == 0

### DIFF
--- a/bld/clib/string/c/fstrnicm.c
+++ b/bld/clib/string/c/fstrnicm.c
@@ -49,10 +49,10 @@ _WCRTLINK int _fstrnicmp( const char _WCFAR *s, const char _WCFAR *t, size_t n )
         if( c2 >= 'A' && c2 <= 'Z' )
             c2 += 'a' - 'A';
         if( c1 != c2 )
-            break;      /* less than or greater than */
+            return( c1 - c2 );      /* less than or greater than */
         if( c1 == '\0' ) {
             break;      /* equal */
         }
     }
-    return( c1 - c2 );
+    return( 0 );
 }

--- a/bld/clib/string/c/strnicmp.c
+++ b/bld/clib/string/c/strnicmp.c
@@ -57,10 +57,10 @@
             c2 += STRING( 'a' ) - STRING( 'A' );
         }
         if( c1 != c2 )
-            break;      /* less than or greater than */
+            return( c1 - c2 );      /* less than or greater than */
         if( c1 == '\0' ) {
             break;      /* equal */
         }
     }
-    return( c1 - c2 );
+    return( 0 );
 }


### PR DESCRIPTION
When the comparison length parameter `n` is set to `0`, the functions `strnicmp` and `_fstrnicmp` return an incorrect, arbitrary non-zero value instead of indicating equality.

When `n == 0` the local variables `c1` and `c2` are left unitialized, and the arbitrary value `c2 - c1` is returned.
To correct the bug, return `c2 - c1` only when a mismatch occurs, `0` otherwise.

