### PR TITLE
ci: add minimal Linux-only build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+name: CI
+run-name: CI Build & Test (Linux)
+
+on:
+  pull_request:
+    branches: '*'
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!README.md'
+  push:
+    branches:
+      - master
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!README.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+env:
+  OWUSETARARCHIVE: '1'
+
+jobs:
+  boot:
+    name: Bootstrap
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v6
+    - name: Bootstrap
+      uses: ./.github/actions/boot
+      with:
+        args:    gcc
+        suffix:  lnx x64 gcc
+        owtools: GCC
+
+  build:
+    name: Build
+    needs: boot
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+    - name: checkout
+      uses: actions/checkout@v6
+    - name: Install DOSBOX
+      uses: ./.github/actions/dosboxin
+    - name: Build
+      uses: ./.github/actions/build
+      with:
+        args:    gcc
+        gitpath: rel
+        suffix:  lnx x64 gcc
+        owtools: GCC
+
+  tests:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - title:   Wmake tests
+            path:    wmaktest
+            timeout: 10
+          - title:   Wasm tests
+            path:    wasmtest
+            timeout: 10
+          - title:   C tests
+            path:    ctest
+            timeout: 30
+          - title:   C++ tests
+            path:    plustest
+            timeout: 90
+          - title:   Fortran tests
+            path:    f77test
+            timeout: 30
+          - title:   C run-time library tests
+            path:    clibtest
+            timeout: 30
+    timeout-minutes: ${{matrix.timeout}}
+    runs-on: ubuntu-latest
+    name: ${{matrix.title}}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v6
+    - name: Set OW environment
+      uses: ./.github/actions/setowenv
+      with:
+        suffix: lnx x64 gcc
+        bits:   '64'
+    - name: ${{matrix.title}}
+      uses: ./.github/actions/tests
+      with:
+        suffix: lnx x64 gcc
+        path:   ${{matrix.path}}


### PR DESCRIPTION
## Description

Add a minimal CI workflow that builds and tests Open Watcom on Linux only (ubuntu-latest, GCC).
Reuses all existing upstream actions — no modifications to upstream files.

This is a draft PR to test the CI pipeline before merging.

## What runs

1. **Bootstrap** — builds wmake and builder from source using GCC
2. **Build** — full OW toolchain build (~120min timeout)
3. **Tests** — 6 test suites in parallel matrix:
   - Wmake, Wasm, C, C++, Fortran, C runtime library

## What's excluded (vs upstream)

- Windows, macOS, ARM64 builds
- CLANG variant
- Backward-compatibility bootstrap tests (OW 1.9/2.0)
- Doc builds
- Snapshot/release assembly
- `mathtest` (skipped on Linux by upstream)