### PR TITLE
exedump: fix incorrect 'high bound' value for arrays with >256 elements (watcom debug format)

### DIFF
--- a/bld/exedump/c/typewv.c
+++ b/bld/exedump/c/typewv.c
@@ -178,8 +178,8 @@ static void array_index( unsigned_8 *ptr, unsigned_8 size )
     switch (size)
     {
     case 1: Puthex( *ptr, 2 ); break;
-    case 2: Puthex( *(unsigned_16*)ptr, 4 ); break;
-    default: Puthex( *(unsigned_32*)ptr, 8 ); break;
+    case 2: Puthex( *(unsigned_16 *)ptr, 4 ); break;
+    default: Puthex( *(unsigned_32 *)ptr, 8 ); break;
     }
 
     base_type_index( ptr+size );


### PR DESCRIPTION
Noticed some incorrect values when investigating Watcom debug data. Pretty simple bug, the array_index function was only ever looking at the first byte of the value, resulting in incorrect results for any arrays with more than 256 elements.