### PR TITLE
Add predll.obj to bld/clib/builder.ctl

### DIFF
--- a/bld/clib/builder.ctl
+++ b/bld/clib/builder.ctl
@@ -148,6 +148,7 @@ set PROJDIR=<CWD>
     <CCCMD> library/nw_libcl.386/ms_sd/clib3s.lib           "<OWRELROOT>/lib386/netware/libc3sld.lib"
     <CCCMD> library/nw_clib.386/ms_sd/clib3s.lib            "<OWRELROOT>/lib386/netware/clib3sd.lib"
     <CCCMD> library/nw_clibl.386/ms_sd/clib3s.lib           "<OWRELROOT>/lib386/netware/clib3sld.lib"
+    <CCCMD> startup/library/nw_clibl.386/ms_s/predll.obj    "<OWRELROOT>/lib386/netware/predll.obj"
 #
 # Note binmode applies to both LIBC and CLIB libraries but only needs to be built once from the
 # fat CLIB source code.

--- a/bld/clib/files.dat
+++ b/bld/clib/files.dat
@@ -97,6 +97,7 @@ type="l"    usr="clib3sl.lib"
 type="l"    usr="libc3s.lib"
 type="l"    usr="libc3sl.lib"
 type="s"    usr="binmode.obj"
+type="s"    usr="predll.obj"
 
 [ DEFAULT dir="lib386/os2" cond="os2targ" where="c f77 jc jf77" ]
 type="l"    usr="clib3r.lib"    cond+="3r"


### PR DESCRIPTION
This should make Builder put predll.obj to lib386/netware, checked working on my machine