### PR TITLE
libzip: backport security fixes for CVE-2012-1162, CVE-2012-1163, CVE-2015-2331

### DIFF
--- a/contrib/libzip/lib/zdirent.c
+++ b/contrib/libzip/lib/zdirent.c
@@ -39,7 +39,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <stddef.h>
 #include <sys/types.h>
 
 #include "wio.h"
@@ -78,7 +77,7 @@ _zip_cdir_new(int nentry, struct zip_error *error)
 {
     struct zip_cdir *cd;
 
-    if (nentry < 0 || (nentry > 0 && (size_t)nentry > SIZE_MAX / sizeof(*(cd->entry)))) {
+    if (nentry < 0 || (nentry > 0 && (size_t)nentry > (size_t)-1 / sizeof(struct zip_dirent))) {
         _zip_error_set(error, ZIP_ER_MEMORY, 0);
         return NULL;
     }

--- a/contrib/libzip/lib/zdirent.c
+++ b/contrib/libzip/lib/zdirent.c
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <limits.h>
 #include <sys/types.h>
 
 #include "wio.h"
@@ -77,7 +78,7 @@ _zip_cdir_new(int nentry, struct zip_error *error)
 {
     struct zip_cdir *cd;
 
-    if (nentry < 0 || (nentry > 0 && (size_t)nentry > (size_t)-1 / sizeof(struct zip_dirent))) {
+    if (nentry < 0 || nentry > INT_MAX / (int)sizeof(struct zip_dirent)) {
         _zip_error_set(error, ZIP_ER_MEMORY, 0);
         return NULL;
     }
@@ -90,7 +91,7 @@ _zip_cdir_new(int nentry, struct zip_error *error)
     if (nentry == 0) {
         cd->entry = NULL;
     }
-    else if ((cd->entry=ZIP_ALLOC(sizeof(*(cd->entry))*nentry)) == NULL) {
+    else if ((cd->entry=ZIP_ALLOC(sizeof(*(cd->entry))*(unsigned)nentry)) == NULL) {
         _zip_error_set(error, ZIP_ER_MEMORY, 0);
         ZIP_FREE(cd);
         return NULL;

--- a/contrib/libzip/lib/zdirent.c
+++ b/contrib/libzip/lib/zdirent.c
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <stddef.h>
 #include <sys/types.h>
 
 #include "wio.h"
@@ -77,12 +78,20 @@ _zip_cdir_new(int nentry, struct zip_error *error)
 {
     struct zip_cdir *cd;
 
+    if (nentry < 0 || (nentry > 0 && (size_t)nentry > SIZE_MAX / sizeof(*(cd->entry)))) {
+        _zip_error_set(error, ZIP_ER_MEMORY, 0);
+        return NULL;
+    }
+
     if ((cd=ZIP_ALLOC(sizeof(*cd))) == NULL) {
         _zip_error_set(error, ZIP_ER_MEMORY, 0);
         return NULL;
     }
 
-    if ((cd->entry=ZIP_ALLOC(sizeof(*(cd->entry))*nentry)) == NULL) {
+    if (nentry == 0) {
+        cd->entry = NULL;
+    }
+    else if ((cd->entry=ZIP_ALLOC(sizeof(*(cd->entry))*nentry)) == NULL) {
         _zip_error_set(error, ZIP_ER_MEMORY, 0);
         ZIP_FREE(cd);
         return NULL;
@@ -282,14 +291,18 @@ _zip_dirent_read(struct zip_dirent *zde, FILE *fp,
         if (zde->extrafield_len) {
             zde->extrafield = _zip_readstr(&cur, zde->extrafield_len, 0,
                                            error);
-            if (!zde->extrafield)
+            if (!zde->extrafield) {
+                _zip_dirent_finalize(zde);
                 return -1;
+            }
         }
 
         if (zde->comment_len) {
             zde->comment = _zip_readstr(&cur, zde->comment_len, 0, error);
-            if (!zde->comment)
+            if (!zde->comment) {
+                _zip_dirent_finalize(zde);
                 return -1;
+            }
         }
     }
     else {
@@ -302,14 +315,18 @@ _zip_dirent_read(struct zip_dirent *zde, FILE *fp,
         if (zde->extrafield_len) {
             zde->extrafield = _zip_readfpstr(fp, zde->extrafield_len, 0,
                                              error);
-            if (!zde->extrafield)
+            if (!zde->extrafield) {
+                _zip_dirent_finalize(zde);
                 return -1;
+            }
         }
 
         if (zde->comment_len) {
             zde->comment = _zip_readfpstr(fp, zde->comment_len, 0, error);
-            if (!zde->comment)
+            if (!zde->comment) {
+                _zip_dirent_finalize(zde);
                 return -1;
+            }
         }
     }
 

--- a/contrib/libzip/lib/znameloc.c
+++ b/contrib/libzip/lib/znameloc.c
@@ -65,7 +65,7 @@ _zip_name_locate(struct zip *za, const char *fname, int flags,
 	return -1;
     }
     
-    cmp = (flags & ZIP_FL_NOCASE) ? strcasecmp : strcmp;
+    cmp = (flags & ZIP_FL_NOCASE) ? stricmp : strcmp;
 
     n = (flags & ZIP_FL_UNCHANGED) ? za->cdir->nentry : za->nentry;
     for (i=0; i<n; i++) {

--- a/contrib/libzip/lib/znameloc.c
+++ b/contrib/libzip/lib/znameloc.c
@@ -65,7 +65,7 @@ _zip_name_locate(struct zip *za, const char *fname, int flags,
 	return -1;
     }
     
-    cmp = (flags & ZIP_FL_NOCASE) ? stricmp : strcmp;
+    cmp = (flags & ZIP_FL_NOCASE) ? strcasecmp : strcmp;
 
     n = (flags & ZIP_FL_UNCHANGED) ? za->cdir->nentry : za->nentry;
     for (i=0; i<n; i++) {

--- a/contrib/libzip/lib/zopen.c
+++ b/contrib/libzip/lib/zopen.c
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <limits.h>
 #include <sys/types.h>
 
 #include "wio.h"
@@ -193,8 +194,8 @@ zip_open(const char *fn, int flags, int *zep)
         return NULL;
     }
 
-    if (cdir->nentry > 0
-        && (size_t)cdir->nentry > (size_t)-1 / sizeof(struct zip_entry)) {
+    if (cdir->nentry < 0
+        || cdir->nentry > INT_MAX / (int)sizeof(struct zip_entry)) {
         set_error(zep, NULL, ZIP_ER_MEMORY);
         _zip_free(za);
         return NULL;
@@ -202,7 +203,7 @@ zip_open(const char *fn, int flags, int *zep)
     if (cdir->nentry == 0) {
         za->entry = NULL;
     }
-    else if ((za->entry=ZIP_ALLOC(sizeof(*(za->entry))*cdir->nentry)) == NULL) {
+    else if ((za->entry=ZIP_ALLOC(sizeof(*(za->entry))*(unsigned)cdir->nentry)) == NULL) {
         set_error(zep, NULL, ZIP_ER_MEMORY);
         _zip_free(za);
         return NULL;

--- a/contrib/libzip/lib/zopen.c
+++ b/contrib/libzip/lib/zopen.c
@@ -39,7 +39,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <stddef.h>
 #include <sys/types.h>
 
 #include "wio.h"
@@ -195,7 +194,7 @@ zip_open(const char *fn, int flags, int *zep)
     }
 
     if (cdir->nentry > 0
-        && (size_t)cdir->nentry > SIZE_MAX / sizeof(*(za->entry))) {
+        && (size_t)cdir->nentry > (size_t)-1 / sizeof(struct zip_entry)) {
         set_error(zep, NULL, ZIP_ER_MEMORY);
         _zip_free(za);
         return NULL;

--- a/contrib/libzip/lib/zopen.c
+++ b/contrib/libzip/lib/zopen.c
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <stddef.h>
 #include <sys/types.h>
 
 #include "wio.h"
@@ -193,7 +194,16 @@ zip_open(const char *fn, int flags, int *zep)
         return NULL;
     }
 
-    if ((za->entry=ZIP_ALLOC(sizeof(*(za->entry))*cdir->nentry)) == NULL) {
+    if (cdir->nentry > 0
+        && (size_t)cdir->nentry > SIZE_MAX / sizeof(*(za->entry))) {
+        set_error(zep, NULL, ZIP_ER_MEMORY);
+        _zip_free(za);
+        return NULL;
+    }
+    if (cdir->nentry == 0) {
+        za->entry = NULL;
+    }
+    else if ((za->entry=ZIP_ALLOC(sizeof(*(za->entry))*cdir->nentry)) == NULL) {
         set_error(zep, NULL, ZIP_ER_MEMORY);
         _zip_free(za);
         return NULL;
@@ -269,6 +279,13 @@ _zip_readcdir(FILE *fp, unsigned char *buf, unsigned char *eocd, int buflen,
     cd->comment = NULL;
     cd->comment_len = _zip_read2(&cdp);
 
+    if (cd->size + cd->comment_len + EOCDLEN < cd->size) {
+        /* integer overflow in size calculation */
+        _zip_error_set(error, ZIP_ER_NOZIP, 0);
+        _zip_cdir_free(cd);
+        return NULL;
+    }
+
     /* some zip files are broken; their internal comment length
        says 0, but they have 1 or 2 comment bytes */
     if ((comlen-cd->comment_len < 0) || (comlen-cd->comment_len > 2)
@@ -308,6 +325,9 @@ _zip_readcdir(FILE *fp, unsigned char *buf, unsigned char *eocd, int buflen,
             return NULL;
         }
     }
+
+    for (i=0; i<cd->nentry; i++)
+        _zip_dirent_init(cd->entry+i);
 
     for (i=0; i<cd->nentry; i++) {
         if ((_zip_dirent_read(cd->entry+i, fp, bufp, eocd-cdp, 0,

--- a/contrib/libzip/regress/extractall.c
+++ b/contrib/libzip/regress/extractall.c
@@ -1,0 +1,259 @@
+/*
+  extractall.c -- test full archive enumeration and extraction
+  Copyright (C) 2026 The Open Watcom Contributors.
+
+  Simulates what the OW installer does: open a ZIP archive,
+  enumerate all entries, stat each one, read all data.
+  Uses test.zip (stored files) and broken.zip (mixed methods).
+*/
+
+
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "zip.h"
+#include "mkname.h"
+
+#define BUFSIZE 8192
+
+int extract_all(const char *archive, int expected_nent);
+int enumerate_all(const char *archive, int expected_nent);
+int test_create_add_extract(void);
+
+
+
+int
+main(int argc, char *argv[])
+{
+    int fail;
+
+    fail = 0;
+
+    /* test.zip: 3 entries -- full extract like installer does */
+    fail += extract_all("test.zip", 3);
+
+    /* broken.zip: 5 entries with intentional CRC/zlib errors --
+       verify we can open, enumerate, and stat all entries
+       (reading will fail on corrupt entries by design) */
+    fail += enumerate_all("broken.zip", 5);
+
+    /* create archive, add file, close, reopen, extract, verify */
+    fail += test_create_add_extract();
+
+    if (fail)
+        printf("%d test(s) FAILED\n", fail);
+    else
+        printf("all tests passed\n");
+
+    exit(fail ? 1 : 0);
+}
+
+
+
+/* Open archive, enumerate all entries, stat and read each one.
+   This is the core installer flow. */
+
+int
+extract_all(const char *archive, int expected_nent)
+{
+    struct zip *z;
+    struct zip_file *zf;
+    struct zip_stat st;
+    int ze, nent, i, n;
+    char buf[BUFSIZE];
+    const char *name;
+    unsigned long total;
+
+    if ((z = zip_open(mkname(archive), ZIP_CHECKCONS, &ze)) == NULL) {
+        printf("fail: %s: can't open (%d)\n", archive, ze);
+        return 1;
+    }
+
+    nent = zip_get_num_files(z);
+    if (nent != expected_nent) {
+        printf("fail: %s: expected %d entries, got %d\n",
+               archive, expected_nent, nent);
+        zip_close(z);
+        return 1;
+    }
+
+    for (i = 0; i < nent; i++) {
+        name = zip_get_name(z, i, 0);
+        if (name == NULL) {
+            printf("fail: %s: can't get name for entry %d: %s\n",
+                   archive, i, zip_strerror(z));
+            zip_close(z);
+            return 1;
+        }
+
+        if (zip_stat_index(z, i, 0, &st) < 0) {
+            printf("fail: %s: can't stat '%s': %s\n",
+                   archive, name, zip_strerror(z));
+            zip_close(z);
+            return 1;
+        }
+
+        /* skip directories */
+        if (st.size == 0)
+            continue;
+
+        if ((zf = zip_fopen_index(z, i, 0)) == NULL) {
+            printf("fail: %s: can't fopen '%s': %s\n",
+                   archive, name, zip_strerror(z));
+            zip_close(z);
+            return 1;
+        }
+
+        total = 0;
+        while ((n = zip_fread(zf, buf, sizeof(buf))) > 0)
+            total += n;
+
+        if (n < 0) {
+            printf("fail: %s: read error on '%s'\n", archive, name);
+            zip_fclose(zf);
+            zip_close(z);
+            return 1;
+        }
+
+        if (total != st.size) {
+            printf("fail: %s: '%s' size mismatch: read %lu, expected %lu\n",
+                   archive, name, total, (unsigned long)st.size);
+            zip_fclose(zf);
+            zip_close(z);
+            return 1;
+        }
+
+        zip_fclose(zf);
+    }
+
+    zip_close(z);
+    return 0;
+}
+
+
+
+/* Open archive, enumerate and stat all entries without reading.
+   Used for archives with intentionally corrupt data. */
+
+int
+enumerate_all(const char *archive, int expected_nent)
+{
+    struct zip *z;
+    struct zip_stat st;
+    int ze, nent, i;
+    const char *name;
+
+    if ((z = zip_open(mkname(archive), ZIP_CHECKCONS, &ze)) == NULL) {
+        printf("fail: %s: can't open (%d)\n", archive, ze);
+        return 1;
+    }
+
+    nent = zip_get_num_files(z);
+    if (nent != expected_nent) {
+        printf("fail: %s: expected %d entries, got %d\n",
+               archive, expected_nent, nent);
+        zip_close(z);
+        return 1;
+    }
+
+    for (i = 0; i < nent; i++) {
+        name = zip_get_name(z, i, 0);
+        if (name == NULL) {
+            printf("fail: %s: can't get name for entry %d: %s\n",
+                   archive, i, zip_strerror(z));
+            zip_close(z);
+            return 1;
+        }
+
+        if (zip_stat_index(z, i, 0, &st) < 0) {
+            printf("fail: %s: can't stat '%s': %s\n",
+                   archive, name, zip_strerror(z));
+            zip_close(z);
+            return 1;
+        }
+    }
+
+    zip_close(z);
+    return 0;
+}
+
+
+
+/* Create archive, add a file from buffer, close, reopen,
+   extract and verify contents match. Round-trip test. */
+
+int
+test_create_add_extract(void)
+{
+    struct zip *z;
+    struct zip_file *zf;
+    struct zip_source *zs;
+    int ze, n;
+    char buf[256];
+    const char *testdata = "Open Watcom installer test data.\n";
+    const char *testname = "testfile.txt";
+    const char *archive = "roundtrip_test.zip";
+    int testlen;
+
+    testlen = strlen(testdata);
+
+    /* create and add */
+    if ((z = zip_open(archive, ZIP_CREATE, &ze)) == NULL) {
+        printf("fail: roundtrip: can't create archive (%d)\n", ze);
+        return 1;
+    }
+
+    if ((zs = zip_source_buffer(z, testdata, testlen, 0)) == NULL
+        || zip_add(z, testname, zs) == -1) {
+        zip_source_free(zs);
+        printf("fail: roundtrip: can't add file: %s\n", zip_strerror(z));
+        zip_close(z);
+        remove(archive);
+        return 1;
+    }
+
+    if (zip_close(z) != 0) {
+        printf("fail: roundtrip: can't close after add\n");
+        remove(archive);
+        return 1;
+    }
+
+    /* reopen with consistency check and extract */
+    if ((z = zip_open(archive, ZIP_CHECKCONS, &ze)) == NULL) {
+        printf("fail: roundtrip: can't reopen (%d)\n", ze);
+        remove(archive);
+        return 1;
+    }
+
+    if (zip_get_num_files(z) != 1) {
+        printf("fail: roundtrip: expected 1 entry, got %d\n",
+               zip_get_num_files(z));
+        zip_close(z);
+        remove(archive);
+        return 1;
+    }
+
+    if ((zf = zip_fopen(z, testname, 0)) == NULL) {
+        printf("fail: roundtrip: can't fopen '%s': %s\n",
+               testname, zip_strerror(z));
+        zip_close(z);
+        remove(archive);
+        return 1;
+    }
+
+    n = zip_fread(zf, buf, sizeof(buf));
+    zip_fclose(zf);
+    zip_close(z);
+    remove(archive);
+
+    if (n != testlen || memcmp(buf, testdata, testlen) != 0) {
+        printf("fail: roundtrip: data mismatch (read %d bytes, expected %d)\n",
+               n, testlen);
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Reference: https://github.com/open-watcom/open-watcom-v2/pull/1369

## Description

Backport security fixes to the bundled libzip 0.6.1. A full library upgrade
is not feasible due to breaking API changes in libzip 0.11+ (function renames,
type changes, error handling overhaul in 1.0).

This is the first in a series of PRs splitting the work from #1369 into
separate, reviewable changes -- one library at a time.

## Changes

* **CVE-2012-1162**: Add overflow guard and zero-entry handling in `_zip_cdir_new`
  and `zip_open` to prevent heap buffer overflow when `nentry` is 0 or very large
* **CVE-2012-1163**: Validate `cd->size + cd->comment_len + EOCDLEN` does not
  integer-overflow before use in `fseek` offset calculation in `_zip_readcdir`
* **CVE-2015-2331**: Guard against integer overflow in `sizeof(entry) * nentry`
  allocation in `_zip_cdir_new` (32-bit systems)
* **CVE-2017-12858 (variant)**: Fix memory leaks on error paths in
  `_zip_dirent_read` -- partial allocations (filename, extrafield, comment)
  are now properly freed via `_zip_dirent_finalize` on subsequent failures
* Initialize directory entries before reading in `_zip_readcdir` to prevent
  use of uninitialized memory on cleanup
* Add `extractall.c` regression test simulating the installer workflow

### CVEs assessed but not applicable

* **CVE-2011-0421**: Already patched in the bundled copy (NULL check in `_zip_name_locate`)
* **CVE-2017-14107**: No ZIP64 support in 0.6.1 (`_zip_read_eocd64` does not exist)
* **CVE-2017-12858 / CVE-2019-17582**: The double-free and use-after-free patterns
  from later libzip versions manifest as memory leaks in 0.6.1 due to different
  code structure; addressed by the error-path cleanup above

## Testing

All 5 compilable regression tests from `contrib/libzip/regress/` pass
(compiled with clang on macOS, linked against the patched library and zlib):

* `test_open` -- open/create/error handling for zip archives
* `test_fread` -- reading files (stored, deflated, CRC errors, zlib errors, compressed flag)
* `test_name_locate` -- finding files by name (case-sensitive, case-insensitive, nodir, unchanged flags)
* `test_buffadd` -- add file from buffer, close, reopen with consistency check, read back and verify
* **`test_extractall` (new)** -- simulates installer workflow: open archive, enumerate all entries, stat and extract each one, verify sizes. Also tests round-trip create/add/extract with data integrity check. Uses existing `test.zip` and `broken.zip` test archives.

The remaining 2 test files (`deltest.c`, `ziptest.c`) use a legacy API
(`zip_err_str`, `zip_err`, 2-arg `zip_open`) that predates the bundled
library version and do not compile.

### How to run tests locally

From the repo root:
```sh
# build library and zlib
cc -c -D__UNIX__ -I contrib/libzip/lib -I contrib/zlib -I bld/watcom/h -w contrib/libzip/lib/z*.c
ar rcs /tmp/libzip.a z*.o && rm z*.o
cc -c -D__UNIX__ -I contrib/zlib -w $(ls contrib/zlib/*.c | grep -v -e example -e minigzip)
ar rcs /tmp/libz.a *.o && rm *.o

# build and run a test (e.g. extractall)
cc -D__UNIX__ -I contrib/libzip/lib -I contrib/libzip/regress -I contrib/zlib -I bld/watcom/h \
  -include string.h -include zipint.h \
  contrib/libzip/regress/extractall.c contrib/libzip/regress/mkname.c \
  /tmp/libzip.a /tmp/libz.a -o /tmp/test_extractall
cd contrib/libzip/regress && /tmp/test_extractall
```