### PR TITLE
buildx.sh: Update comments in the CI script

### DIFF
--- a/ci/buildx.sh
+++ b/ci/buildx.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Script to build the Open Watcom tools on Azure Pipelines
+# Script to build the Open Watcom tools on Github CI/CD Pipelines
 # using the host platform's native C/C++ compiler.
 #
 # Expects
@@ -11,7 +11,7 @@
 bootutil_proc()
 {
     #
-    # build new verison of wmake for host system
+    # build new version of wmake for host system
     #
     mkdir $OWROOT/build/$OWOBJDIR
     #


### PR DESCRIPTION
Building OpenWatcom on the Azure Pipelines has ended long ago.
Also fixes the Typo nearby. 

There is no other location of "Azure" in the OpenWatcom sources.
 