### PR TITLE
ras.mh: Fix typo in RAS_PROJECTION_INFO

### DIFF
--- a/bld/w32api/include/ras.mh
+++ b/bld/w32api/include/ras.mh
@@ -959,7 +959,7 @@ typedef enum _RASPROJECTION_INFO_TYPE {
 /* RAS projection information */
 #if (WINVER >= 0x0601)
 typedef struct _RAS_PROJECTION_INFO {
-    RASAPIVERSION           verison;
+    RASAPIVERSION           version;
     RASPROJECTION_INFO_TYPE type;
     union {
         RASPPP_PROJECTION_INFO      ppp;


### PR DESCRIPTION
Found this typo when fixing the typo in ci/buildx.sh

Verified this change with:
https://learn.microsoft.com/en-us/windows/win32/api/ras/ns-ras-ras_projection_info
