### PR TITLE
build: Add support for BSD on ARM64 as a host platform

### DIFF
--- a/bld/as/axp/bsda64/makefile
+++ b/bld/as/axp/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_axp os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/as/axp/builder.ctl
+++ b/bld/as/axp/builder.ctl
@@ -39,6 +39,7 @@ set PROJDIR=<CWD>
     <CCCMD> ntaxp/wasaxp.sym      "<OWRELROOT>/axpnt/"
 
     <CCCMD> bsdx64/wasaxp.exe     "<OWRELROOT>/binb64/wasaxp"
+    <CCCMD> bsda64/wasaxp.exe     "<OWRELROOT>/armb64/wasaxp"
     <CCCMD> ntx64/wasaxp.exe      "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wasaxp.exe   "<OWRELROOT>/binl64/wasaxp"
     <CCCMD> linuxx64/wasaxp.sym   "<OWRELROOT>/binl64/"

--- a/bld/as/mps/bsda64/makefile
+++ b/bld/as/mps/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_mips os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/as/mps/builder.ctl
+++ b/bld/as/mps/builder.ctl
@@ -39,6 +39,7 @@ set PROJDIR=<CWD>
     <CCCMD> ntaxp/wasmps.sym      "<OWRELROOT>/axpnt/"
 
     <CCCMD> bsdx64/wasmps.exe     "<OWRELROOT>/binb64/wasmps"
+    <CCCMD> bsda64/wasmps.exe     "<OWRELROOT>/armb64/wasmps"
     <CCCMD> ntx64/wasmps.exe      "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wasmps.exe   "<OWRELROOT>/binl64/wasmps"
     <CCCMD> linuxx64/wasmps.sym   "<OWRELROOT>/binl64/"

--- a/bld/as/ppc/bsda64/makefile
+++ b/bld/as/ppc/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_ppc os_bs cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/as/ppc/builder.ctl
+++ b/bld/as/ppc/builder.ctl
@@ -39,6 +39,7 @@ set PROJDIR=<CWD>
     <CCCMD> ntaxp/wasppc.sym      "<OWRELROOT>/axpnt/"
 
     <CCCMD> bsdx64/wasppc.exe     "<OWRELROOT>/binb64/wasppc"
+    <CCCMD> bsda64/wasppc.exe     "<OWRELROOT>/armb64/wasppc"
     <CCCMD> ntx64/wasppc.exe      "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wasppc.exe   "<OWRELROOT>/binl64/wasppc"
     <CCCMD> linuxx64/wasppc.sym   "<OWRELROOT>/binl64/"

--- a/bld/aui/bsda64/makefile
+++ b/bld/aui/bsda64/makefile
@@ -1,0 +1,4 @@
+#pmake: build os_bsd cpu_a64
+host_os  = bsd
+host_cpu = a64
+!include ../master.mif

--- a/bld/builder/bsda64/makefile
+++ b/bld/builder/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/cc/386/bsda64/makefile
+++ b/bld/cc/386/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_386 386 bsd os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/cc/386/builder.ctl
+++ b/bld/cc/386/builder.ctl
@@ -57,7 +57,9 @@ set PROJDIR=<CWD>
     <CCCMD> rdos386/<OWOBJDIR>/wcc386.sym       "<OWRELROOT>/rdos/"
 
     <CCCMD> bsdx64/<OWOBJDIR>/wcc386.exe        "<OWRELROOT>/binb64/wcc386"
+    <CCCMD> bsda64/<OWOBJDIR>/wcc386.exe        "<OWRELROOT>/armb64/wcc386"
     <CCCMD> bsdx64/<OWOBJDIR>/wcc38601.int      "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/<OWOBJDIR>/wcc38601.int      "<OWRELROOT>/armb64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wcc386.exe     "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccd386.dll    "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wcc38601.int   "<OWRELROOT>/binnt64/"

--- a/bld/cc/axp/bsda64/makefile
+++ b/bld/cc/axp/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_axp bsd os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/cc/axp/builder.ctl
+++ b/bld/cc/axp/builder.ctl
@@ -55,7 +55,9 @@ set PROJDIR=<CWD>
     <CCCMD> linux386/<OWOBJDIR>/wccaxp01.int    "<OWRELROOT>/binl/"
 
     <CCCMD> bsdx64/<OWOBJDIR>/wccaxp.exe        "<OWRELROOT>/binb64/wccaxp"
+    <CCCMD> bsda64/<OWOBJDIR>/wccaxp.exe        "<OWRELROOT>/armb64/wccaxp"
     <CCCMD> bsdx64/<OWOBJDIR>/wccaxp01.int      "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/<OWOBJDIR>/wccaxp01.int      "<OWRELROOT>/armb64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccaxp.exe     "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccdaxp.dll    "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccaxp01.int   "<OWRELROOT>/binnt64/"

--- a/bld/cc/i86/bsda64/makefile
+++ b/bld/cc/i86/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_i86 i86 os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/cc/i86/builder.ctl
+++ b/bld/cc/i86/builder.ctl
@@ -55,7 +55,9 @@ set PROJDIR=<CWD>
     <CCCMD> linux386/<OWOBJDIR>/wcci8601.int    "<OWRELROOT>/binl/"
 
     <CCCMD> bsdx64/<OWOBJDIR>/wcc.exe           "<OWRELROOT>/binb64/wcc"
+    <CCCMD> bsda64/<OWOBJDIR>/wcc.exe           "<OWRELROOT>/armb64/wcc"
     <CCCMD> bsdx64/<OWOBJDIR>/wcci8601.int      "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/<OWOBJDIR>/wcci8601.int      "<OWRELROOT>/armb64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wcc.exe        "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccd.dll       "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wcci8601.int   "<OWRELROOT>/binnt64/"

--- a/bld/cc/mps/bsda64/makefile
+++ b/bld/cc/mps/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_mips bsd os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/cc/mps/builder.ctl
+++ b/bld/cc/mps/builder.ctl
@@ -55,7 +55,9 @@ set PROJDIR=<CWD>
     <CCCMD> linux386/<OWOBJDIR>/wccmps01.int    "<OWRELROOT>/binl/"
 
     <CCCMD> bsdx64/<OWOBJDIR>/wccmps.exe        "<OWRELROOT>/binb64/wccmps"
+    <CCCMD> bsda64/<OWOBJDIR>/wccmps.exe        "<OWRELROOT>/armb64/wccmps"
     <CCCMD> bsdx64/<OWOBJDIR>/wccmps01.int      "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/<OWOBJDIR>/wccmps01.int      "<OWRELROOT>/armb64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccmps.exe     "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccdmps.dll    "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccmps01.int   "<OWRELROOT>/binnt64/"

--- a/bld/cc/ppc/bsda64/makefile
+++ b/bld/cc/ppc/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_ppc ppc os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/cc/ppc/builder.ctl
+++ b/bld/cc/ppc/builder.ctl
@@ -55,7 +55,9 @@ set PROJDIR=<CWD>
     <CCCMD> linux386/<OWOBJDIR>/wccppc01.int    "<OWRELROOT>/binl/"
 
     <CCCMD> bsdx64/<OWOBJDIR>/wccppc.exe        "<OWRELROOT>/binb64/wccppc"
+    <CCCMD> bsda64/<OWOBJDIR>/wccppc.exe        "<OWRELROOT>/armb64/wccppc"
     <CCCMD> bsdx64/<OWOBJDIR>/wccppc01.int      "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/<OWOBJDIR>/wccppc01.int      "<OWRELROOT>/armb64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccppc.exe     "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccdppc.dll    "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/<OWOBJDIR>/wccppc01.int   "<OWRELROOT>/binnt64/"

--- a/bld/cfloat/bsda64/makefile
+++ b/bld/cfloat/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/cg/intel/386/bsda64/makefile
+++ b/bld/cg/intel/386/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_386 intel os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/cg/intel/i86/bsda64/makefile
+++ b/bld/cg/intel/i86/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_i86 i86 intel os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/cg/risc/axp/bsda64/makefile
+++ b/bld/cg/risc/axp/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_axp axp alpha os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/cg/risc/mps/bsda64/makefile
+++ b/bld/cg/risc/mps/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_mips mips os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/cg/risc/ppc/bsda64/makefile
+++ b/bld/cg/risc/ppc/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_ppc ppc powerpc os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/cpp/bsda64/makefile
+++ b/bld/cpp/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/dmpobj/bsda64/makefile
+++ b/bld/dmpobj/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/dmpobj/builder.ctl
+++ b/bld/dmpobj/builder.ctl
@@ -34,6 +34,7 @@ set PROJDIR=<CWD>
     <CCCMD> ntaxp/dmpobj.exe     "<OWRELROOT>/axpnt/"
 
     <CCCMD> bsdx64/dmpobj.exe    "<OWRELROOT>/binb64/dmpobj"
+    <CCCMD> bsda64/dmpobj.exe    "<OWRELROOT>/armb64/dmpobj"
     <CCCMD> ntx64/dmpobj.exe     "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/dmpobj.exe  "<OWRELROOT>/binl64/dmpobj"
     <CCCMD> linuxarm/dmpobj.exe  "<OWRELROOT>/arml/dmpobj"

--- a/bld/dwarf/dr/bsda64/makefile
+++ b/bld/dwarf/dr/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/dwarf/dw/bsda64/makefile
+++ b/bld/dwarf/dw/bsda64/makefile
@@ -1,0 +1,7 @@
+#pmake: build os_bsd cpu_a64 dwarf
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif
+

--- a/bld/exedump/bsda64/makefile
+++ b/bld/exedump/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/exedump/builder.ctl
+++ b/bld/exedump/builder.ctl
@@ -24,6 +24,7 @@ set PROJDIR=<CWD>
     <CCCMD> rdos386/wdump.exe   "<OWRELROOT>/rdos/"
 
     <CCCMD> bsdx64/wdump.exe    "<OWRELROOT>/binb64/wdump"
+    <CCCMD> bsda64/wdump.exe    "<OWRELROOT>/armb64/wdump"
     <CCCMD> ntx64/wdump.exe     "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wdump.exe  "<OWRELROOT>/binl64/wdump"
     <CCCMD> linuxarm/wdump.exe  "<OWRELROOT>/arml/wdump"

--- a/bld/gui/ui/bsda64/makefile
+++ b/bld/gui/ui/bsda64/makefile
@@ -1,0 +1,7 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../guiui.mif
+

--- a/bld/ncurses/bsda64/makefile
+++ b/bld/ncurses/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/ndisasm/bsda64/makefile
+++ b/bld/ndisasm/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/ndisasm/builder.ctl
+++ b/bld/ndisasm/builder.ctl
@@ -43,6 +43,7 @@ set PROJDIR=<CWD>
     <CCCMD> rdos386/wdis.sym    "<OWRELROOT>/rdos/"
 
     <CCCMD> bsdx64/wdis.exe     "<OWRELROOT>/binb64/wdis"
+    <CCCMD> bsda64/wdis.exe     "<OWRELROOT>/armb64/wdis"
     <CCCMD> ntx64/wdis.exe      "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wdis.exe   "<OWRELROOT>/binl64/wdis"
     <CCCMD> linuxx64/wdis.sym   "<OWRELROOT>/binl64/"

--- a/bld/nwlib/bsda64/makefile
+++ b/bld/nwlib/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/nwlib/builder.ctl
+++ b/bld/nwlib/builder.ctl
@@ -51,6 +51,7 @@ set PROJDIR=<CWD>
     <CCCMD> rdos386/wlib.sym        "<OWRELROOT>/rdos/"
 
     <CCCMD> bsdx64/wlib.exe         "<OWRELROOT>/binb64/wlib"
+    <CCCMD> bsda64/wlib.exe         "<OWRELROOT>/armb64/wlib"
     <CCCMD> ntx64.dll/wlib.exe      "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wlibd.dll     "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wlib.exe       "<OWRELROOT>/binl64/wlib"

--- a/bld/orl/bsda64/makefile
+++ b/bld/orl/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/owl/bsda64/makefile
+++ b/bld/owl/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/plusplus/386/bsda64/makefile
+++ b/bld/plusplus/386/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_386 os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/plusplus/386/builder.ctl
+++ b/bld/plusplus/386/builder.ctl
@@ -57,7 +57,9 @@ set PROJDIR=<CWD>
     <CCCMD> rdos386/wpp386.sym      "<OWRELROOT>/rdos/"
 
     <CCCMD> bsdx64/wpp386.exe       "<OWRELROOT>/binb64/wpp386"
+    <CCCMD> bsda64/wpp386.exe       "<OWRELROOT>/armb64/wpp386"
     <CCCMD> bsdx64/wpp38601.int     "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/wpp38601.int     "<OWRELROOT>/armb64/"
     <CCCMD> ntx64.dll/wpp386.exe    "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wppd386.dll   "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wpp38601.int  "<OWRELROOT>/binnt64/"

--- a/bld/plusplus/axp/bsda64/makefile
+++ b/bld/plusplus/axp/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_axp flat os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/plusplus/axp/builder.ctl
+++ b/bld/plusplus/axp/builder.ctl
@@ -52,7 +52,9 @@ set PROJDIR=<CWD>
     <CCCMD> linux386/wppaxp01.int   "<OWRELROOT>/binl/"
 
     <CCCMD> bsdx64/wppaxp.exe       "<OWRELROOT>/binb64/wppaxp"
+    <CCCMD> bsda64/wppaxp.exe       "<OWRELROOT>/armb64/wppaxp"
     <CCCMD> bsdx64/wppaxp01.int     "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/wppaxp01.int     "<OWRELROOT>/armb64/"
     <CCCMD> ntx64.dll/wppaxp.exe    "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wppdaxp.dll   "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wppaxp01.int  "<OWRELROOT>/binnt64/"

--- a/bld/plusplus/i86/bsda64/makefile
+++ b/bld/plusplus/i86/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_i86 os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/plusplus/i86/builder.ctl
+++ b/bld/plusplus/i86/builder.ctl
@@ -55,7 +55,9 @@ set PROJDIR=<CWD>
     <CCCMD> linux386/wppi8601.int   "<OWRELROOT>/binl/"
 
     <CCCMD> bsdx64/wpp.exe          "<OWRELROOT>/binb64/wpp"
+    <CCCMD> bsda64/wpp.exe          "<OWRELROOT>/armb64/wpp"
     <CCCMD> bsdx64/wppi8601.int     "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/wppi8601.int     "<OWRELROOT>/armb64/"
     <CCCMD> ntx64.dll/wpp.exe       "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wppdi86.dll   "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wppi8601.int  "<OWRELROOT>/binnt64/"

--- a/bld/plusplus/mps/builder.ctl
+++ b/bld/plusplus/mps/builder.ctl
@@ -52,7 +52,9 @@ set PROJDIR=<CWD>
     <CCCMD> linux386/wppmps01.int   "<OWRELROOT>/binl/"
 
     <CCCMD> bsdx64/wppmps.exe       "<OWRELROOT>/binb64/wppmps"
+    <CCCMD> bsda64/wppmps.exe       "<OWRELROOT>/armb64/wppmps"
     <CCCMD> bsdx64/wppmps01.int     "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/wppmps01.int     "<OWRELROOT>/armb64/"
     <CCCMD> ntx64.dll/wppmps.exe    "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wppdmps.dll   "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wppmps01.int  "<OWRELROOT>/binnt64/"

--- a/bld/plusplus/ppc/builder.ctl
+++ b/bld/plusplus/ppc/builder.ctl
@@ -52,7 +52,9 @@ set PROJDIR=<CWD>
     <CCCMD> linux386/wppppc01.int   "<OWRELROOT>/binl/"
 
     <CCCMD> bsdx64/wppppc.exe       "<OWRELROOT>/binb64/wppppc"
+    <CCCMD> bsda64/wppppc.exe       "<OWRELROOT>/armb64/wppppc"
     <CCCMD> bsdx64/wppppc01.int     "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/wppppc01.int     "<OWRELROOT>/armb64/"
     <CCCMD> ntx64.dll/wppppc.exe    "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wppdppc.dll   "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wppppc01.int  "<OWRELROOT>/binnt64/"

--- a/bld/pmake/bsda64/makefile
+++ b/bld/pmake/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: nobuild os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/rc/rc/bsda64/makefile
+++ b/bld/rc/rc/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/rc/rc/builder.ctl
+++ b/bld/rc/rc/builder.ctl
@@ -69,7 +69,9 @@ set PROJDIR=<CWD>
     <CCCMD> ntx64.dll/*.uni         "<OWRELROOT>/binnt64/"
 
     <CCCMD> bsdx64/wrc.exe          "<OWRELROOT>/binb64/wrc"
+    <CCCMD> bsda64/wrc.exe          "<OWRELROOT>/armb64/wrc"
     <CCCMD> bsdx64/*.uni            "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/*.uni            "<OWRELROOT>/armb64/"
     <CCCMD> linuxarm/wrc.exe        "<OWRELROOT>/arml/wrc"
     <CCCMD> linuxarm/wrc.sym        "<OWRELROOT>/arml/"
     <CCCMD> linuxarm/*.uni          "<OWRELROOT>/arml/"

--- a/bld/rcsdll/bsda64/makefile
+++ b/bld/rcsdll/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build cxx os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/setupgui/bsda64/makefile
+++ b/bld/setupgui/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/setupgui/ziplib/bsda64/makefile
+++ b/bld/setupgui/ziplib/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake/50: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/setupgui/zlib/bsda64/makefile
+++ b/bld/setupgui/zlib/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake/50: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/ui/unix/bsda64/makefile
+++ b/bld/ui/unix/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../../master.mif

--- a/bld/vi/bind/bsda64/makefile
+++ b/bld/vi/bind/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/vi/bsda64/makefile
+++ b/bld/vi/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../mif/master.mif

--- a/bld/vi/builder.ctl
+++ b/bld/vi/builder.ctl
@@ -59,8 +59,11 @@ set PROJDIR=<CWD>
     <CCCMD> qnxi86/<OWOBJDIR>/vi.exe     "<OWRELROOT>/qnx/binq/vi"
 
     <CCCMD> bsdx64/<OWOBJDIR>/vi.exe     "<OWRELROOT>/binb64/vi"
+    <CCCMD> bsda64/<OWOBJDIR>/vi.exe     "<OWRELROOT>/armb64/vi"
     <CCCMD> ctags/bsdx64/ctags.exe       "<OWRELROOT>/binb64/ctags"
+    <CCCMD> ctags/bsda64/ctags.exe       "<OWRELROOT>/armb64/ctags"
     <CCCMD> bind/bsdx64/edbind.exe       "<OWRELROOT>/binb64/edbind"
+    <CCCMD> bind/bsda64/edbind.exe       "<OWRELROOT>/armb64/edbind"
     <CCCMD> ntx64/<OWOBJDIR>/vi.exe      "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.win/<OWOBJDIR>/viw.exe "<OWRELROOT>/binnt64/"
     <CCCMD> ctags/ntx64/ctags.exe        "<OWRELROOT>/binnt64/"

--- a/bld/vi/ctags/bsda64/makefile
+++ b/bld/vi/ctags/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wasm/bsda64/makefile
+++ b/bld/wasm/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wasm/builder.ctl
+++ b/bld/wasm/builder.ctl
@@ -45,6 +45,7 @@ set PROJDIR=<CWD>
     <CCCMD> rdos386/wasm.sym    "<OWRELROOT>/rdos/"
 
     <CCCMD> bsdx64/wasm.exe     "<OWRELROOT>/binb64/wasm"
+    <CCCMD> bsda64/wasm.exe     "<OWRELROOT>/armb64/wasm"
     <CCCMD> ntx64/wasm.exe      "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wasm.exe   "<OWRELROOT>/binl64/wasm"
     <CCCMD> linuxx64/wasm.sym   "<OWRELROOT>/binl64/"

--- a/bld/watcom/bsda64/makefile
+++ b/bld/watcom/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wcl/386/bsda64/makefile
+++ b/bld/wcl/386/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_386 os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/wcl/386/builder.ctl
+++ b/bld/wcl/386/builder.ctl
@@ -39,6 +39,7 @@ set PROJDIR=<CWD>
     <CCCMD> ntaxp/wcl386.sym      "<OWRELROOT>/axpnt/"
 
     <CCCMD> bsdx64/wcl386.exe     "<OWRELROOT>/binb64/wcl386"
+    <CCCMD> bsda64/wcl386.exe     "<OWRELROOT>/armb64/wcl386"
     <CCCMD> ntx64/wcl386.exe      "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wcl386.exe   "<OWRELROOT>/binl64/wcl386"
     <CCCMD> linuxx64/wcl386.sym   "<OWRELROOT>/binl64/"

--- a/bld/wcl/axp/bsda64/makefile
+++ b/bld/wcl/axp/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_axp os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/wcl/axp/builder.ctl
+++ b/bld/wcl/axp/builder.ctl
@@ -39,6 +39,7 @@ set PROJDIR=<CWD>
     <CCCMD> ntaxp/wclaxp.sym      "<OWRELROOT>/axpnt/"
 
     <CCCMD> bsdx64/wclaxp.exe     "<OWRELROOT>/binb64/wclaxp"
+    <CCCMD> bsda64/wclaxp.exe     "<OWRELROOT>/armb64/wclaxp"
     <CCCMD> ntx64/wclaxp.exe      "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wclaxp.exe   "<OWRELROOT>/binl64/wclaxp"
     <CCCMD> linuxx64/wclaxp.sym   "<OWRELROOT>/binl64/"

--- a/bld/wcl/i86/bsda64/makefile
+++ b/bld/wcl/i86/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_i86 os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/wcl/i86/builder.ctl
+++ b/bld/wcl/i86/builder.ctl
@@ -39,6 +39,7 @@ set PROJDIR=<CWD>
     <CCCMD> ntaxp/wcl.sym         "<OWRELROOT>/axpnt/"
 
     <CCCMD> bsdx64/wcl.exe        "<OWRELROOT>/binb64/wcl"
+    <CCCMD> bsda64/wcl.exe        "<OWRELROOT>/armb64/wcl"
     <CCCMD> ntx64/wcl.exe         "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wcl.exe      "<OWRELROOT>/binl64/wcl"
     <CCCMD> linuxx64/wcl.sym      "<OWRELROOT>/binl64/"

--- a/bld/wcl/mps/bsda64/makefile
+++ b/bld/wcl/mps/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_mps os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/wcl/owcc/bsda64/makefile
+++ b/bld/wcl/owcc/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../owcc.mif

--- a/bld/wcl/owcc/builder.ctl
+++ b/bld/wcl/owcc/builder.ctl
@@ -44,7 +44,9 @@ set PROJDIR=<CWD>
     <CCCMD> linux386/owcc.sym    "<OWRELROOT>/binl/"
 
     <CCCMD> bsdx64/specs.owc     "<OWRELROOT>/binb64/"
+    <CCCMD> bsda64/specs.owc     "<OWRELROOT>/armb64/"
     <CCCMD> bsdx64/owcc.exe      "<OWRELROOT>/binb64/owcc"
+    <CCCMD> bsda64/owcc.exe      "<OWRELROOT>/armb64/owcc"
     <CCCMD> ntx64/specs.owc      "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64/owcc.exe       "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/specs.owc   "<OWRELROOT>/binl64/"

--- a/bld/wcl/ppc/bsda64/makefile
+++ b/bld/wcl/ppc/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build target_ppc os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../target.mif

--- a/bld/wcl/ppc/builder.ctl
+++ b/bld/wcl/ppc/builder.ctl
@@ -35,6 +35,7 @@ set PROJDIR=<CWD>
     <CCCMD> os2386/wclppc.sym     "<OWRELROOT>/binp/"
 
     <CCCMD> bsdx64/wclppc.exe     "<OWRELROOT>/binb64/wclppc"
+    <CCCMD> bsda64/wclppc.exe     "<OWRELROOT>/armb64/wclppc"
     <CCCMD> ntx64/wclppc.exe      "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wclppc.exe   "<OWRELROOT>/binl64/wclppc"
     <CCCMD> linuxx64/wclppc.sym   "<OWRELROOT>/binl64/"

--- a/bld/win386/builder.ctl
+++ b/bld/win386/builder.ctl
@@ -27,6 +27,7 @@ set PROJDIR=<CWD>
     <CCCMD> wbind/linux386/wbind.exe    "<OWRELROOT>/binl/wbind"
 
     <CCCMD> wbind/bsdx64/wbind.exe      "<OWRELROOT>/binb64/wbind"
+    <CCCMD> wbind/bsda64/wbind.exe      "<OWRELROOT>/armb64/wbind"
     <CCCMD> wbind/ntx64/wbind.exe       "<OWRELROOT>/binnt64/"
     <CCCMD> wbind/linuxx64/wbind.exe    "<OWRELROOT>/binl64/wbind"
     <CCCMD> wbind/linuxarm/wbind.exe    "<OWRELROOT>/arml/wbind"

--- a/bld/win386/wbind/bsda64/makefile
+++ b/bld/win386/wbind/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wl/bsda64/makefile
+++ b/bld/wl/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wl/builder.ctl
+++ b/bld/wl/builder.ctl
@@ -75,10 +75,15 @@ set PROJDIR=<CWD>
     <CCCMD> lnk/qnx/wlink.lnk               "<OWRELROOT>/qnx/etc/"
 
     <CCCMD> bsdx64/wlink.exe                "<OWRELROOT>/binb64/wlink"
+    <CCCMD> bsda64/wlink.exe                "<OWRELROOT>/armb64/wlink"
     <CCCMD> ms2wlink/bsdx64/ms2wlink.exe    "<OWRELROOT>/binb64/ms2wlink"
+    <CCCMD> ms2wlink/bsda64/ms2wlink.exe    "<OWRELROOT>/armb64/ms2wlink"
 #    <CCCMD> fcenable/bsdx64/fcenable.exe    "<OWRELROOT>/binb64/fcenable"
+#    <CCCMD> fcenable/bsda64/fcenable.exe    "<OWRELROOT>/armb64/fcenable"
     <CCCMD> exe2bin/bsdx64/exe2bin.exe      "<OWRELROOT>/binb64/exe2bin"
+    <CCCMD> exe2bin/bsda64/exe2bin.exe      "<OWRELROOT>/armb64/exe2bin"
     <CCCMD> lnk/bsdx64/wlink.lnk            "<OWRELROOT>/binb64/"
+    <CCCMD> lnk/bsda64/wlink.lnk            "<OWRELROOT>/armb64/"
 
     <CCCMD> ntx64.dll/wlink.exe             "<OWRELROOT>/binnt64/"
     <CCCMD> ntx64.dll/wlinkd.dll            "<OWRELROOT>/binnt64/"

--- a/bld/wl/exe2bin/bsda64/makefile
+++ b/bld/wl/exe2bin/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wl/fcenable/bsda64/makefile
+++ b/bld/wl/fcenable/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wl/lnk/bsda64/makefile
+++ b/bld/wl/lnk/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wl/ms2wlink/bsda64/makefile
+++ b/bld/wl/ms2wlink/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wmake/bsda64/makefile
+++ b/bld/wmake/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wmake/builder.ctl
+++ b/bld/wmake/builder.ctl
@@ -30,6 +30,7 @@ set PROJDIR=<CWD>
     <CCCMD> qnxi86/wmk.exe    "<OWRELROOT>/qnx/binq/wmake"
 
     <CCCMD> bsdx64/wmk.exe    "<OWRELROOT>/binb64/wmake"
+    <CCCMD> bsda64/wmk.exe    "<OWRELROOT>/armb64/wmake"
     <CCCMD> ntx64/wmk.exe     "<OWRELROOT>/binnt64/wmake.exe"
     <CCCMD> linuxx64/wmk.exe  "<OWRELROOT>/binl64/wmake"
     <CCCMD> linuxx64/wmk.sym  "<OWRELROOT>/binl64/wmake.sym"

--- a/bld/wmake/c/mglob.c
+++ b/bld/wmake/c/mglob.c
@@ -194,6 +194,8 @@ const char FAR BuiltIns[] = {
         "__BSD386__=\n"
     #elif defined( __PPC__ ) || defined( __ppc__ ) || defined( __powerpc__ )
         "__BSDPPC__=\n"
+    #elif defined( _M_ARM64 ) || defined( __arm64__ ) || defined( __aarch64__ )
+        "__BSDARM64__=\n"
     #else
         #error Unknown CPU architecture
     #endif

--- a/bld/wres/bsda64/_s/makefile
+++ b/bld/wres/bsda64/_s/makefile
@@ -1,0 +1,5 @@
+#pmake: build os_bsd cpu_a64
+host_os  = bsd
+host_cpu = a64
+
+!include ../../master.mif

--- a/bld/wstrip/bsda64/makefile
+++ b/bld/wstrip/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wstrip/builder.ctl
+++ b/bld/wstrip/builder.ctl
@@ -35,6 +35,7 @@ set PROJDIR=<CWD>
     <CCCMD> qnx386/wstripx.exe    "<OWRELROOT>/qnx/binq/wstrip"
 
     <CCCMD> bsdx64/wstripx.exe    "<OWRELROOT>/binb64/wstrip"
+    <CCCMD> bsda64/wstripx.exe    "<OWRELROOT>/armb64/wstrip"
     <CCCMD> ntx64/wstripx.exe     "<OWRELROOT>/binnt64/wstrip.exe"
     <CCCMD> linuxx64/wstripx.exe  "<OWRELROOT>/binl64/wstrip"
     <CCCMD> linuxarm/wstripx.exe  "<OWRELROOT>/arml/wstrip"

--- a/bld/wstuba/builder.ctl
+++ b/bld/wstuba/builder.ctl
@@ -22,6 +22,7 @@ set PROJDIR=<CWD>
     <CCCMD> dos386/*.exe        "<OWRELROOT>/binl/"
     <CCCMD> dos386/*.exe        "<OWRELROOT>/binl64/"
     <CCCMD> dos386/*.exe        "<OWRELROOT>/binb64/"
+    <CCCMD> dos386/*.exe        "<OWRELROOT>/armb64/"
     <CCCMD> dos386/*.exe        "<OWRELROOT>/arml64/"
     <CCCMD> dos386/*.exe        "<OWRELROOT>/bino64/"
     <CCCMD> dos386/*.exe        "<OWRELROOT>/armo/"

--- a/bld/wtouch/bsda64/makefile
+++ b/bld/wtouch/bsda64/makefile
@@ -1,0 +1,6 @@
+#pmake: build os_bsd cpu_a64
+
+host_os  = bsd
+host_cpu = a64
+
+!include ../master.mif

--- a/bld/wtouch/builder.ctl
+++ b/bld/wtouch/builder.ctl
@@ -22,6 +22,7 @@ set PROJDIR=<CWD>
     <CCCMD> ntaxp/wtouch.exe     "<OWRELROOT>/axpnt/"
 
     <CCCMD> bsdx64/wtouch.exe    "<OWRELROOT>/binb64/wtouch"
+    <CCCMD> bsda64/wtouch.exe    "<OWRELROOT>/armb64/wtouch"
     <CCCMD> ntx64/wtouch.exe     "<OWRELROOT>/binnt64/"
     <CCCMD> linuxx64/wtouch.exe  "<OWRELROOT>/binl64/wtouch"
     <CCCMD> linuxarm/wtouch.exe  "<OWRELROOT>/arml/wtouch"

--- a/build/makeinit
+++ b/build/makeinit
@@ -112,6 +112,9 @@ bld_os = bsd
 !else ifdef __BSDX64__
 bld_cpu = x64
 bld_os = bsd
+!else ifdef __BSDARM64__
+bld_cpu = a64
+bld_os = bsd
 !else ifdef __BSDPPC__
 bld_cpu = ppc
 bld_os = bsd

--- a/build/mif/local.mif
+++ b/build/mif/local.mif
@@ -354,6 +354,7 @@ common_cppflags_linuxa64   = -D__LINUX_ARM64__
 
 common_cppflags_bsd386     = -D__BSD_386__
 common_cppflags_bsdx64     = -D__BSD_X64__
+common_cppflags_bsda64     = -D__BSD_ARM64__
 common_cppflags_bsdppc     =
 
 common_cppflags_haiku386   = -D__HAIKU_386__

--- a/build/mif/wres.mif
+++ b/build/mif/wres.mif
@@ -53,6 +53,7 @@ wres_subdir_nt386      = nt386/$(name_model_386)
 wres_subdir_ntaxp      = ntaxp/$(name_model_axp)
 wres_subdir_ntmps      = ntmps/$(name_model_mps)
 
+wres_subdir_bsda64     = bsda64/$(name_model_a64)
 wres_subdir_bsdx64     = bsdx64/$(name_model_x64)
 wres_subdir_linuxarm   = linuxarm/$(name_model_arm)
 wres_subdir_linuxa64   = linuxa64/$(name_model_a64)


### PR DESCRIPTION
Mostly just a mechanical addition (`bsdx64` -> `bsda64`, `binb64` -> `armb64`)