### PR TITLE
cg: fix RISC physical register encoding

### DIFF
--- a/bld/cg/c/namelist.c
+++ b/bld/cg/c/namelist.c
@@ -567,10 +567,9 @@ name    *AllocRegName( hw_reg_set regs )
     }
     new_r = AllocName( N_REGISTER, RegClass( regs ), 0 );
     new_r->r.reg = regs;
-#if _TARGET_RISC
-    new_r->r.reg_index = GetArchIndex( regs );
-#else
     new_r->r.reg_index = -1;
+#if _TARGET_RISC
+    new_r->r.arch_index = GetArchIndex( regs );
 #endif
     return( new_r );
 }


### PR DESCRIPTION
AllocRegName() stored the architecture-specific register number in
reg_index instead of arch_index.

The RISC instruction encoders read arch_index to determine the physical
register to encode. Because that field remained zero, ordinary register
operands were emitted as register 0. On MIPS, this caused generated code
to use the read-only $zero register and silently discard results.

Reproducer:
```
    #include <stdio.h>

    int main(void)
    {
        int a = 1;
        int b = 2;
        return a + b;
    }
```
Compile with:
```
    wccmps -od test.c
```

Before:
```
    0000  24000001    li      zero,0x00000001
    0004  24000002    li      zero,0x00000002
    0008  00000021    move    zero,zero
    000C  03E00008    jr      ra
    0010  00000000    nop
```
After:
```
    0000  24030001    li      v1,0x00000001
    0004  24020002    li      v0,0x00000002
    0008  00621021    addu    v0,v1,v0
    000C  03E00008    jr      ra
    0010  00000000    nop
```

The fix keeps reg_index initialized for scoreboarding and stores
GetArchIndex() in arch_index, where the RISC encoders expect it.