### PR TITLE
cg: fix RISC subregister mapping

### DIFF
--- a/bld/cg/risc/axp/c/axprgtbl.c
+++ b/bld/cg/risc/axp/c/axprgtbl.c
@@ -856,48 +856,41 @@ void            InitRegTbl( void )
 {
 }
 
+static int findArchRegInfo( hw_reg_set regs )
+/********************************************/
+{
+    int         i;
+
+    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
+        if( HW_Ovlap( regs, RegsTab[i].hw_reg ) ) {
+            return( i );
+        }
+    }
+    _Zoiks( ZOIKS_031 );
+    return( ARCH_IDX_START );
+}
+
+
 reg_idx RegTrans( hw_reg_set regs )
 /**********************************
  * Translate reg to register index
  */
 {
-    int         i;
-
-    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
-        if( HW_Equal( regs, RegsTab[i].hw_reg ) ) {
-            return( RegsTab[i].idx );
-        }
-    }
-    return( 0 );
+    return( RegsTab[findArchRegInfo( regs )].idx );
 }
 
 int GetArchIndex( hw_reg_set regs )
 /*********************************/
 {
-    int         i;
-
-    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
-        if( HW_Equal( regs, RegsTab[i].hw_reg ) ) {
-            return( RegsTab[i].idx );
-        }
-    }
-    return( 0 );
+    return( RegsTab[findArchRegInfo( regs )].idx );
 }
 
-dw_regs   RegTransDW( hw_reg_set reg )
+dw_regs   RegTransDW( hw_reg_set regs )
 /*************************************
  * Translate reg to Dwarf enum name
  */
 {
-    int         i;
-
-    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
-        if( HW_Equal( reg, RegsTab[i].hw_reg ) ) {
-            return( RegsTab[i].dw_idx );
-        }
-    }
-    _Zoiks( ZOIKS_031 );
-    return( DW_REG_END );
+    return( RegsTab[findArchRegInfo( regs )].dw_idx );
 }
 
 hw_reg_set      FirstReg( reg_set_index regs_idx )

--- a/bld/cg/risc/mps/c/mpsrgtbl.c
+++ b/bld/cg/risc/mps/c/mpsrgtbl.c
@@ -915,49 +915,42 @@ void InitRegTbl( void )
 }
 
 
+static int findArchRegInfo( hw_reg_set regs )
+/********************************************/
+{
+    int         i;
+
+    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
+        if( HW_Ovlap( regs, RegsTab[i].hw_reg ) ) {
+            return( i );
+        }
+    }
+    _Zoiks( ZOIKS_031 );
+    return( ARCH_IDX_START );
+}
+
+
 reg_idx RegTrans( hw_reg_set regs )
 /**********************************
  * Translate reg to register index
  */
 {
-    int         i;
-
-    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
-        if( HW_Equal( regs, RegsTab[i].hw_reg ) ) {
-            return( RegsTab[i].idx );
-        }
-    }
-    return( 0 );
+    return( RegsTab[findArchRegInfo( regs )].idx );
 }
 
 int GetArchIndex( hw_reg_set regs )
 /*********************************/
 {
-    int         i;
-
-    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
-        if( HW_Equal( regs, RegsTab[i].hw_reg ) ) {
-            return( RegsTab[i].idx );
-        }
-    }
-    return( 0 );
+    return( RegsTab[findArchRegInfo( regs )].idx );
 }
 
 
-dw_regs RegTransDW( hw_reg_set reg )
+dw_regs RegTransDW( hw_reg_set regs )
 /***********************************
  * Translate reg to Dwarf enum name
  */
 {
-    int         i;
-
-    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
-        if( HW_Equal( reg, RegsTab[i].hw_reg ) ) {
-            return( RegsTab[i].dw_idx );
-        }
-    }
-    _Zoiks( ZOIKS_031 );
-    return( DW_REG_END );
+    return( RegsTab[findArchRegInfo( regs )].dw_idx );
 }
 
 hw_reg_set      FirstReg( reg_set_index regs_idx )

--- a/bld/cg/risc/ppc/c/ppcrgtbl.c
+++ b/bld/cg/risc/ppc/c/ppcrgtbl.c
@@ -847,48 +847,41 @@ void        InitRegTbl( void )
 {
 }
 
+static int findArchRegInfo( hw_reg_set regs )
+/********************************************/
+{
+    int         i;
+
+    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
+        if( HW_Ovlap( regs, RegsTab[i].hw_reg ) ) {
+            return( i );
+        }
+    }
+    _Zoiks( ZOIKS_031 );
+    return( ARCH_IDX_START );
+}
+
+
 reg_idx     RegTrans( hw_reg_set regs )
 /**************************************
  * Translate reg to register index
  */
 {
-    int         i;
-
-    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
-        if( HW_Equal( regs, RegsTab[i].hw_reg ) ) {
-            return( RegsTab[i].idx );
-        }
-    }
-    return( 0 );
+    return( RegsTab[findArchRegInfo( regs )].idx );
 }
 
 int GetArchIndex( hw_reg_set regs )
 /*********************************/
 {
-    int         i;
-
-    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
-        if( HW_Equal( regs, RegsTab[i].hw_reg ) ) {
-            return( RegsTab[i].idx );
-        }
-    }
-    return( 0 );
+    return( RegsTab[findArchRegInfo( regs )].idx );
 }
 
-dw_regs   RegTransDW( hw_reg_set reg )
+dw_regs   RegTransDW( hw_reg_set regs )
 /*************************************
  * Translate reg to Dwarf enum name
  */
 {
-    int         i;
-
-    for( i = ARCH_IDX_START; i < ARCH_IDX_END; i++ ) {
-        if( HW_Equal( reg, RegsTab[i].hw_reg ) ) {
-            return( RegsTab[i].dw_idx );
-        }
-    }
-    _Zoiks( ZOIKS_031 );
-    return( DW_REG_END );
+    return( RegsTab[findArchRegInfo( regs )].dw_idx );
 }
 
 hw_reg_set ParmRegConflicts( hw_reg_set r )


### PR DESCRIPTION
The RISC register-table lookup used HW_Equal() to match register sets
against canonical entries in RegsTab.

Narrow integer registers use byte and word register sets that overlap
their canonical physical register but are not exactly equal to it.
MIPS 64-bit values may similarly use paired register sets. Lookup
therefore failed for these register forms and GetArchIndex() returned
register 0.

On MIPS, narrow loads could consequently target the read-only $zero
register and silently discard their result.

Reproducer:
```
    unsigned short narrow_word(unsigned long value)
    {
        return value;
    }
```

Compile with:
```
    wccmps -od test.c
```

Before:
```
    narrow_word:
        sw      $a0,($sp)
        lhu     $zero,($sp)
        andi    $v0,$zero,0xffff
        jr      $ra
        nop
```

After:
```
    narrow_word:
        sw      $a0,($sp)
        lhu     $v0,($sp)
        andi    $v0,$v0,0xffff
        jr      $ra
        nop
```

The fix uses overlap-aware lookup for the MIPS, Alpha, and PowerPC
register tables. This maps byte, word, full-width, and paired register
sets to their physical architectural register. An unrecognized register
now reports an internal compiler error instead of silently selecting
register 0.