### PR TITLE
wl: fix MIPS PE jump base relocations

### DIFF
--- a/bld/wl/c/obj2supp.c
+++ b/bld/wl/c/obj2supp.c
@@ -1358,6 +1358,9 @@ static bool formatBaseReloc( fix_relo_data *fix, target_spec *tthread, segdata *
             reltype = PE_FIX_HIGHADJ;   // NYI: can be high when objalign == 0x10000
             breloc->rel_size = sizeof( high_pe_reloc_item );
             breloc->item.hpe.low_off = (unsigned_16)target.off;
+        } else if( (LinkState & LS_HAVE_MACHTYPE_MASK) == LS_HAVE_MIPS_CODE
+          && ftype == FIX_OFFSET_26 ) {
+            reltype = PE_FIX_MIPSJMP;
         } else if( ftype == FIX_OFFSET_16 ) {
             if( (FmtData.objalign & 0xFFFF) == 0 ) {
                 save = false;


### PR DESCRIPTION
Wlink emitted `HIGHLOW` PE base relocations for MIPS 26-bit jump
relocations.

When an image was loaded away from its preferred base, the loader added
the complete byte delta to the instruction word. This corrupted `j` and
`jal` targets and could cause an immediate crash. Whether a program
worked therefore depended on whether its preferred image base was
available.

Reproducer:

```
    int main(void)
    {
        return 0;
    }
```

Compile and inspect the relocation table:

```
    wclmps test.c
    wdump -f test.exe
```

The entry point is at RVA `0x10020`, with a `jal` relocation at
`0x10028`.

Before:

```
    3:028     3:058     4:060      0650     3:080     3:098
```

After:

```
    5:028     5:058     4:060      0650     5:080     5:098
```

Type 3 is `HIGHLOW`; type 5 is `MIPSJMPADDR`.

The fix maps MIPS `FIX_OFFSET_26` relocations to the existing
`PE_FIX_MIPSJMP` relocation type. Other architectures and relocation
kinds are unchanged.