### PR TITLE
clib: fix Win16 default windowing teardown

### DIFF
--- a/bld/clib/defwin/c/wingen.c
+++ b/bld/clib/defwin/c/wingen.c
@@ -273,7 +273,11 @@ void _WCNEAR _InitMainWindowData( HANDLE inst )
 void _WCNEAR _FiniMainWindowData( void )
 {
 
-    FARfree( _MainWindowData );
+    if( _MainWindowData != NULL ) {
+        FARfree( _MainWindowData->windows );
+        FARfree( _MainWindowData );
+        _MainWindowData = NULL;
+    }
 
 } /* _FiniMainWindowData */
 

--- a/bld/clib/defwin/c/winmain.c
+++ b/bld/clib/defwin/c/winmain.c
@@ -110,8 +110,8 @@ int PASCAL __export DefaultWinMain( HINSTANCE inst, HINSTANCE previnst,
 
     rc = pmain( ___Argc, ___Argv );
 
-    windowsFini();
     _WindowsExit();
+    windowsFini();
     return( rc );
 
 } /* DefaultWinMain */


### PR DESCRIPTION
The Win16 default-windowing teardown released `_MainWindowData` before
calling `_WindowsExit()`.

`_WindowsExit()` continues dispatching messages while the generated
console window remains open. These messages can call `_GetWindowData()`,
which in turn accessed the released window data. With the pre-fix
C library, this caused a general protection fault in `_GetWindowData()`
and crashed the program during the exit process.

Reproducer:

```
    #include <stdio.h>

    int main(void)
    {
        printf("Press Enter to exit.\n");
        getchar();
        return 0;
    }
```

Compile for Win16:

```
    wcl -bcl=windows -zw -ml test.c
```

Compile and bind for Win386:

```
    wcl386 -l=win386 -zw test.c
    wbind -n test
```

Before the fix, returning from `main()` released the default-windowing
state and then entered the final message-processing loop. This caused 
a GP fault under `_GetWindowData()` due to freed memory dereference 
`_MainWindowData->windows[i]->hwnd`

After the fix, the default-windowing state remains valid until
`_WindowsExit()` finishes processing messages. The window stays
responsive and can be closed normally, then its state is released.

The cleanup now also releases the nested window array, clears
`_MainWindowData`, and safely handles partial initialization.

The change was tested under Windows for Workgroups 3.11 using both the
Win16 and Win386 extender paths.