### PR TITLE
clib: fix OS/2 32-bit startup arguments

### DIFF
--- a/bld/clib/startup/c/main2o32.c
+++ b/bld/clib/startup/c/main2o32.c
@@ -52,7 +52,7 @@
 #include "xmain.h"
 
 
-_WCNORETURN void _WCNEAR __F_NAME(__OS2Main,__wOS2Main)( unsigned hmod,
+void _WCNEAR __F_NAME(__OS2Main,__wOS2Main)( unsigned hmod,
                             unsigned reserved, char *env, char *cmd )
 /********************************************************************/
 {

--- a/bld/clib/startup/h/osmain.h
+++ b/bld/clib/startup/h/osmain.h
@@ -39,8 +39,8 @@
     #endif
         #pragma aux _OS2Main "_*" __parm __caller [__dx __ax] [__cx __bx]
   #else
-        extern _WCNORETURN void _WCNEAR __OS2Main( unsigned hmod, unsigned reserved, char *env, char *cmd );
-        extern _WCNORETURN void _WCNEAR __wOS2Main( unsigned hmod, unsigned reserved, char *env, char *cmd );
+        extern void _WCNEAR __OS2Main( unsigned hmod, unsigned reserved, char *env, char *cmd );
+        extern void _WCNEAR __wOS2Main( unsigned hmod, unsigned reserved, char *env, char *cmd );
     #if defined(_M_IX86)
         #pragma aux __wOS2Main "*" __parm __caller []
         #pragma aux __OS2Main "*" __parm __caller []


### PR DESCRIPTION
The 32-bit OS/2 CRT entry point was incorrectly marked `_WCNORETURN`.

For OS/2 executable entry points, the loader-provided stack contains a
return address followed by the module handle, reserved value, environment
pointer, and command-line pointer. The `_WCNORETURN` annotation changed
the compiler parameter offsets so that the return-address slot was not
accounted for, which breaks OS/2 ABI.

Thus, `__OS2Main()` received shifted arguments and environment pointer 
was interpreted as the command-line pointer. `__OS2MainInit()` then 
searched backwards from that address for the program name and 
would read outside accessible memory.

Reproducer:

```
    #include <stdio.h>
    
    int main(void)
    {
        printf("Hello from OS/2\n");
        return 0;
    }
```

Compile with:

```text
    wcl386 -bt=os2 -l=os2v2 test.c
```

Before the fix, launching the executable produced a SYS3175 access
violation during CRT startup, before `main()` was reached.

After the fix, the console application starts, prints its output, and
exits normally.

The fix removes `_WCNORETURN` from the 32-bit OS/2 entry-point
declarations and definition, restoring the loader-compatible parameter
layout. The 16-bit OS/2 startup path is unchanged.

The change was tested under OS/2 Warp 3.0.