### PR TITLE
clib: enable OS/2 32-bit default windowing

### DIFF
--- a/bld/clib/defwin/c/pmmain.c
+++ b/bld/clib/defwin/c/pmmain.c
@@ -37,6 +37,8 @@
 #define INCL_WIN
 #include <wos2.h>
 #include "win.h"
+#include "defwin.h"
+#include "initwin.h"
 #include "pmmenu.rh"
 
 
@@ -189,10 +191,10 @@ _WCRTLINK void  __InitDefaultWin( void )
 _WCRTLINK void  __FiniDefaultWin( void )
 //======================================
 {
-    _FiniMainWindowData();
     if( _MainWindow != 0 ) {
         WinDestroyWindow( _MainWindow );
     }
+    _FiniMainWindowData();
     if( hMessageQueue != 0 ) {
         WinDestroyMsgQueue( hMessageQueue );
     }

--- a/bld/clib/defwin/h/win.h
+++ b/bld/clib/defwin/h/win.h
@@ -53,7 +53,7 @@
 #ifdef __OS2__
 typedef int         HANDLE;
 extern  unsigned    __WinSetWindowPos(unsigned);
-#pragma aux __WinSetWindowPos __parm [__eax] __modify [__ebx]
+#pragma aux __WinSetWindowPos = __parm [__eax] __modify [__ebx]
 #define WinSetWindowPos(a1,a2,a3,a4,a5,a6,a7)           \
         __WinSetWindowPos(WinSetWindowPos(a1,a2,a3,a4,a5,a6,a7))
 #endif

--- a/build/mif/defwind.mif
+++ b/build/mif/defwind.mif
@@ -1,3 +1,8 @@
 !ifeq system windows
 default_windowing = 1
 !endif
+!ifeq system os2
+!ifeq host_cpu 386
+default_windowing = 1
+!endif
+!endif


### PR DESCRIPTION
Open Watcom contains an OS/2 Presentation Manager implementation of
default windowing, but the feature was not enabled by the OS/2 32-bit
clib build.

This enables default windowing for the i386 OS/2 target and fixes the
remaining compilation and teardown issues in that path.

During shutdown, `_MainWindowData` was freed before the PM windows were
destroyed. Window destruction dispatches messages through
`_MainDriver()`, which still requires that data. The cleanup order is
changed to destroy the window first and release its bookkeeping
afterwards.

Reproducer:

```
    #include <stdio.h>
    
    int main(void)
    {
        printf("Hello from OS/2!\n");
    
        printf("\nPress Enter to exit...");
        getchar();

        return 0;
    }
```

Build as a normal window-compatible VIO application:

```
    wcl386 -bt=os2 -l=os2v2 main.c -fe=main-vio.exe
```

Build using Open Watcom default windowing:

```
    wcl386 -bt=os2 -bw -l=os2v2_pm main.c -fe=main-bw.exe
```

The normal build runs in an OS/2 VIO window. The `-bw` build creates the
Open Watcom PM frame and its `Standard IO` child window, with
`printf()` and `getchar()` redirected through the existing default
windowing infrastructure.

VIO:
<img width="480" height="360" alt="image" src="https://github.com/user-attachments/assets/09e2f839-96cc-49eb-b32d-7dccdff2d254" />

OW DW:
<img width="480" height="360" alt="image" src="https://github.com/user-attachments/assets/11e46ac0-09bd-4330-99c9-4624a6a0b02d" />


Both modes were tested on OS/2 Warp 3.0, including input and clean
program termination.

This change enables default windowing only for 32-bit i386 OS/2. The
16-bit OS/2 path remains unchanged.