### PR TITLE
clib: fix OS/2 16-bit startup arguments

### DIFF
--- a/bld/clib/startup/c/maino16.c
+++ b/bld/clib/startup/c/maino16.c
@@ -111,7 +111,7 @@ FPEhandler  *__FPE_handler = __null_FPE_handler;
 #if defined(__SW_BD)
 int
 #else
-_WCNORETURN void
+void
 #endif
 _WCNEAR _OS2Main( char __far *stklow, char __far *stktop, unsigned envseg, unsigned cmdoff )
 /******************************************************************************************/

--- a/bld/clib/startup/h/osmain.h
+++ b/bld/clib/startup/h/osmain.h
@@ -35,7 +35,7 @@
     #if defined(__SW_BD)
         extern int _WCNEAR _OS2Main( char _WCI86FAR *stklow, char _WCI86FAR *stktop, unsigned envseg, unsigned cmdoff );
     #else
-        extern _WCNORETURN void _WCNEAR _OS2Main( char _WCI86FAR *stklow, char _WCI86FAR *stktop, unsigned envseg, unsigned cmdoff );
+        extern void _WCNEAR _OS2Main( char _WCI86FAR *stklow, char _WCI86FAR *stktop, unsigned envseg, unsigned cmdoff );
     #endif
         #pragma aux _OS2Main "_*" __parm __caller [__dx __ax] [__cx __bx]
   #else


### PR DESCRIPTION
The 16-bit OS/2 CRT entry point was incorrectly marked `_WCNORETURN`.

This issue is the same class of bug fixed in PR #1649. The patch addresses 
OS/2 16-bit executable failure during startup mentioned in issue #1582.

The assembly startup code calls `_OS2Main()` normally, leaving a return
address on the stack. The `_WCNORETURN` annotation caused the compiler
to generate parameter offsets as though no return address were present.

Then, `_OS2Main()` read its stack arguments from the wrong
locations. The return address gets interpreted as the environment 
segment selector. Loading that value into a segment register  caused 
a protection violation during CRT startup, before `main()` was reached.

Reproducer:

```
    #include <stdio.h>
    
    int main(void)
    {
        printf("Hello from OS/2\n");
        return 0;
    }
```

Compile with:

```text
    wcl -bcl=os2 test.c
```

Before the fix, launching the executable under OS/2 1.30 produced a
SYS1943 protection violation during startup.

After the fix, the console application starts, prints its output, and
exits normally.

The fix removes `_WCNORETURN` from the 16-bit OS/2 `_OS2Main()`
declaration and definition. This restores the expected stack layout and
allows the environment segment and command-line offset to be read
correctly.

The fix was tested under OS/2 1.30.